### PR TITLE
[READY] Print diagnostic code field

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -2263,12 +2263,19 @@ def _BuildDiagnostic( contents, uri, diag ):
     filename = ''
 
   r = _BuildRange( contents, filename, diag[ 'range' ] )
+  diag_text = diag[ 'message' ]
+  try:
+    code = diag[ 'code' ]
+    diag_text += " [" + str( code ) + "]"
+  except KeyError:
+    # code field doesn't exist.
+    pass
 
   return responses.Diagnostic(
     ranges = [ r ],
     location = r.start_,
     location_extent = r,
-    text = diag[ 'message' ],
+    text = diag_text,
     kind = lsp.SEVERITY[ diag[ 'severity' ] ].upper() )
 
 

--- a/ycmd/tests/java/diagnostics_test.py
+++ b/ycmd/tests/java/diagnostics_test.py
@@ -82,7 +82,8 @@ DIAG_MATCHERS_PER_FILE = {
   TestFactory: contains_inanyorder(
     has_entries( {
       'kind': 'WARNING',
-      'text': 'The value of the field TestFactory.Bar.testString is not used',
+      'text': 'The value of the field TestFactory.Bar.testString is not used '
+              '[570425421]',
       'location': LocationMatcher( TestFactory, 15, 19 ),
       'location_extent': RangeMatcher( TestFactory, ( 15, 19 ), ( 15, 29 ) ),
       'ranges': contains( RangeMatcher( TestFactory, ( 15, 19 ), ( 15, 29 ) ) ),
@@ -90,7 +91,7 @@ DIAG_MATCHERS_PER_FILE = {
     } ),
     has_entries( {
       'kind': 'ERROR',
-      'text': 'Wibble cannot be resolved to a type',
+      'text': 'Wibble cannot be resolved to a type [16777218]',
       'location': LocationMatcher( TestFactory, 18, 24 ),
       'location_extent': RangeMatcher( TestFactory, ( 18, 24 ), ( 18, 30 ) ),
       'ranges': contains( RangeMatcher( TestFactory, ( 18, 24 ), ( 18, 30 ) ) ),
@@ -98,7 +99,7 @@ DIAG_MATCHERS_PER_FILE = {
     } ),
     has_entries( {
       'kind': 'ERROR',
-      'text': 'Wibble cannot be resolved to a variable',
+      'text': 'Wibble cannot be resolved to a variable [33554515]',
       'location': LocationMatcher( TestFactory, 19, 15 ),
       'location_extent': RangeMatcher( TestFactory, ( 19, 15 ), ( 19, 21 ) ),
       'ranges': contains( RangeMatcher( TestFactory, ( 19, 15 ), ( 19, 21 ) ) ),
@@ -106,7 +107,7 @@ DIAG_MATCHERS_PER_FILE = {
     } ),
     has_entries( {
       'kind': 'ERROR',
-      'text': 'Type mismatch: cannot convert from int to boolean',
+      'text': 'Type mismatch: cannot convert from int to boolean [16777233]',
       'location': LocationMatcher( TestFactory, 27, 10 ),
       'location_extent': RangeMatcher( TestFactory, ( 27, 10 ), ( 27, 16 ) ),
       'ranges': contains( RangeMatcher( TestFactory, ( 27, 10 ), ( 27, 16 ) ) ),
@@ -114,7 +115,7 @@ DIAG_MATCHERS_PER_FILE = {
     } ),
     has_entries( {
       'kind': 'ERROR',
-      'text': 'Type mismatch: cannot convert from int to boolean',
+      'text': 'Type mismatch: cannot convert from int to boolean [16777233]',
       'location': LocationMatcher( TestFactory, 30, 10 ),
       'location_extent': RangeMatcher( TestFactory, ( 30, 10 ), ( 30, 16 ) ),
       'ranges': contains( RangeMatcher( TestFactory, ( 30, 10 ), ( 30, 16 ) ) ),
@@ -124,7 +125,7 @@ DIAG_MATCHERS_PER_FILE = {
       'kind': 'ERROR',
       'text': 'The method doSomethingVaguelyUseful() in the type '
               'AbstractTestWidget is not applicable for the arguments '
-              '(TestFactory.Bar)',
+              '(TestFactory.Bar) [67108979]',
       'location': LocationMatcher( TestFactory, 30, 23 ),
       'location_extent': RangeMatcher( TestFactory, ( 30, 23 ), ( 30, 47 ) ),
       'ranges': contains( RangeMatcher( TestFactory, ( 30, 23 ), ( 30, 47 ) ) ),
@@ -134,7 +135,7 @@ DIAG_MATCHERS_PER_FILE = {
   TestWidgetImpl: contains_inanyorder(
     has_entries( {
       'kind': 'WARNING',
-      'text': 'The value of the local variable a is not used',
+      'text': 'The value of the local variable a is not used [536870973]',
       'location': LocationMatcher( TestWidgetImpl, 15, 9 ),
       'location_extent': RangeMatcher( TestWidgetImpl, ( 15, 9 ), ( 15, 10 ) ),
       'ranges': contains( RangeMatcher( TestWidgetImpl,
@@ -144,7 +145,7 @@ DIAG_MATCHERS_PER_FILE = {
     } ),
     has_entries( {
       'kind': 'ERROR',
-      'text': 'ISR cannot be resolved to a variable',
+      'text': 'ISR cannot be resolved to a variable [33554515]',
       'location': LocationMatcher( TestWidgetImpl, 34, 12 ),
       'location_extent': RangeMatcher( TestWidgetImpl, ( 34, 12 ), ( 34, 15 ) ),
       'ranges': contains( RangeMatcher( TestWidgetImpl,
@@ -154,7 +155,8 @@ DIAG_MATCHERS_PER_FILE = {
     } ),
     has_entries( {
       'kind': 'ERROR',
-      'text': 'Syntax error, insert ";" to complete BlockStatements',
+      'text': 'Syntax error, insert ";" to complete BlockStatements '
+              '[1610612976]',
       'location': LocationMatcher( TestWidgetImpl, 34, 12 ),
       'location_extent': RangeMatcher( TestWidgetImpl, ( 34, 12 ), ( 34, 15 ) ),
       'ranges': contains( RangeMatcher( TestWidgetImpl,
@@ -168,7 +170,7 @@ DIAG_MATCHERS_PER_FILE = {
       'kind': 'ERROR',
       'text': 'The type new TestLauncher.Launchable(){} must implement the '
               'inherited abstract method TestLauncher.Launchable.launch('
-              'TestFactory)',
+              'TestFactory) [67109264]',
       'location': LocationMatcher( TestLauncher, 28, 16 ),
       'location_extent': RangeMatcher( TestLauncher, ( 28, 16 ), ( 28, 28 ) ),
       'ranges': contains( RangeMatcher( TestLauncher,
@@ -179,7 +181,7 @@ DIAG_MATCHERS_PER_FILE = {
     has_entries( {
       'kind': 'ERROR',
       'text': 'The method launch() of type new TestLauncher.Launchable(){} '
-              'must override or implement a supertype method',
+              'must override or implement a supertype method [67109498]',
       'location': LocationMatcher( TestLauncher, 30, 19 ),
       'location_extent': RangeMatcher( TestLauncher, ( 30, 19 ), ( 30, 27 ) ),
       'ranges': contains( RangeMatcher( TestLauncher,
@@ -189,7 +191,8 @@ DIAG_MATCHERS_PER_FILE = {
     } ),
     has_entries( {
       'kind': 'ERROR',
-      'text': 'Cannot make a static reference to the non-static field factory',
+      'text': 'Cannot make a static reference to the non-static field factory '
+              '[33554506]',
       'location': LocationMatcher( TestLauncher, 31, 32 ),
       'location_extent': RangeMatcher( TestLauncher, ( 31, 32 ), ( 31, 39 ) ),
       'ranges': contains( RangeMatcher( TestLauncher,
@@ -202,7 +205,7 @@ DIAG_MATCHERS_PER_FILE = {
     has_entries( {
       'kind': 'ERROR',
       'text': 'The method doUnicødeTes() in the type Test is not applicable '
-              'for the arguments (String)',
+              'for the arguments (String) [67108979]',
       'location': LocationMatcher( youcompleteme_Test, 13, 10 ),
       'location_extent': RangeMatcher( youcompleteme_Test,
                                        ( 13, 10 ),
@@ -287,7 +290,8 @@ def FileReadyToParse_Diagnostics_FileNotOnDisk_test( app ):
 
   diag_matcher = contains( has_entries( {
     'kind': 'ERROR',
-    'text': 'Syntax error, insert ";" to complete ClassBodyDeclarations',
+    'text': 'Syntax error, insert ";" to complete ClassBodyDeclarations '
+            '[1610612976]',
     'location': LocationMatcher( filepath, 4, 21 ),
     'location_extent': RangeMatcher( filepath, ( 4, 21 ), ( 4, 25 ) ),
     'ranges': contains( RangeMatcher( filepath, ( 4, 21 ), ( 4, 25 ) ) ),
@@ -442,7 +446,7 @@ public class Test {
             'diagnostics': contains(
               has_entries( {
                 'kind': 'ERROR',
-                'text': 'Duplicate field Test.test',
+                'text': 'Duplicate field Test.test [33554772]',
                 'location': LocationMatcher( youcompleteme_Test, 4, 17 ),
                 'location_extent': RangeMatcher( youcompleteme_Test,
                                                  ( 4, 17 ),
@@ -454,7 +458,7 @@ public class Test {
               } ),
               has_entries( {
                 'kind': 'ERROR',
-                'text': 'Duplicate field Test.test',
+                'text': 'Duplicate field Test.test [33554772]',
                 'location': LocationMatcher( youcompleteme_Test, 5, 17 ),
                 'location_extent': RangeMatcher( youcompleteme_Test,
                                                  ( 5, 17 ),
@@ -471,6 +475,7 @@ public class Test {
       except AssertionError:
         if time.time() > expiration:
           raise
+
         time.sleep( 0.25 )
 
 

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -997,7 +997,7 @@ def LanguageServerCompleter_Diagnostics_MaxDiagnosticsNumberExceeded_test():
           'end': { 'line': 4, 'character': 13 }
         },
         'severity': 1,
-        'message': 'Second error'
+        'message': 'Second error [8]'
       } ]
     }
   }
@@ -1137,6 +1137,100 @@ def LanguageServerCompleter_GetHoverResponse_test():
                        'GetResponse',
                        side_effect = [ { 'result': { 'contents': 'test' } } ] ):
       eq_( completer.GetHoverResponse( request_data ), 'test' )
+
+
+def LanguageServerCompleter_Diagnostics_Code_test():
+  completer = MockCompleter()
+  filepath = os.path.realpath( '/foo.cpp' )
+  uri = lsp.FilePathToUri( filepath )
+  request_data = RequestWrap( BuildRequest( line_num = 1,
+                                            column_num = 1,
+                                            filepath = filepath,
+                                            contents = '' ) )
+  notification = {
+    'jsonrpc': '2.0',
+    'method': 'textDocument/publishDiagnostics',
+    'params': {
+      'uri': uri,
+      'diagnostics': [ {
+        'range': {
+          'start': { 'line': 3, 'character': 10 },
+          'end': { 'line': 3, 'character': 11 }
+        },
+        'severity': 1,
+        'message': 'First error',
+        'code': 'random_error'
+      }, {
+        'range': {
+          'start': { 'line': 3, 'character': 10 },
+          'end': { 'line': 3, 'character': 11 }
+        },
+        'severity': 1,
+        'message': 'Second error',
+        'code': 8
+      }, {
+        'range': {
+          'start': { 'line': 3, 'character': 10 },
+          'end': { 'line': 3, 'character': 11 }
+        },
+        'severity': 1,
+        'message': 'Third error',
+        'code': '8'
+      } ]
+    }
+  }
+  completer.GetConnection()._notifications.put( notification )
+  completer.HandleNotificationInPollThread( notification )
+
+  with patch.object( completer, 'ServerIsReady', return_value = True ):
+    completer.OnFileReadyToParse( request_data )
+    # Simulate receipt of response and initialization complete
+    initialize_response = {
+      'result': {
+        'capabilities': {}
+      }
+    }
+    completer._HandleInitializeInPollThread( initialize_response )
+
+    diagnostics = contains(
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 4, 11 ),
+        'location_extent': RangeMatcher( filepath, ( 4, 11 ), ( 4, 12 ) ),
+        'ranges': contains(
+           RangeMatcher( filepath, ( 4, 11 ), ( 4, 12 ) ) ),
+        'text': equal_to( 'First error [random_error]' ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 4, 11 ),
+        'location_extent': RangeMatcher( filepath, ( 4, 11 ), ( 4, 12 ) ),
+        'ranges': contains(
+           RangeMatcher( filepath, ( 4, 11 ), ( 4, 12 ) ) ),
+        'text': equal_to( 'Second error [8]' ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 4, 11 ),
+        'location_extent': RangeMatcher( filepath, ( 4, 11 ), ( 4, 12 ) ),
+        'ranges': contains(
+           RangeMatcher( filepath, ( 4, 11 ), ( 4, 12 ) ) ),
+        'text': equal_to( 'Third error [8]' ),
+        'fixit_available': False
+      } )
+    )
+
+    assert_that( completer.OnFileReadyToParse( request_data ), diagnostics )
+
+    assert_that(
+      completer.PollForMessages( request_data ),
+      contains( has_entries( {
+        'diagnostics': diagnostics,
+        'filepath': filepath
+      } ) )
+    )
 
 
 def LanguageServerCompleter_Diagnostics_PercentEncodeCannonical_test():

--- a/ycmd/tests/rust/diagnostics_test.py
+++ b/ycmd/tests/rust/diagnostics_test.py
@@ -41,7 +41,8 @@ DIAG_MATCHERS_PER_FILE = {
   MAIN_FILEPATH: contains_inanyorder(
     has_entries( {
       'kind': 'ERROR',
-      'text': 'no field `build_` on type `test::Builder`\n\nunknown field',
+      'text':
+          'no field `build_` on type `test::Builder`\n\nunknown field [E0609]',
       'location': LocationMatcher( MAIN_FILEPATH, 14, 13 ),
       'location_extent': RangeMatcher( MAIN_FILEPATH, ( 14, 13 ), ( 14, 19 ) ),
       'ranges': contains( RangeMatcher( MAIN_FILEPATH,


### PR DESCRIPTION
Clangd started populating diagnostic's code field with relevant information with https://reviews.llvm.org/D60822 and https://reviews.llvm.org/D58291. 

This patch aims to surface that information to ycmd users, as vscode does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/ycmd/1239)
<!-- Reviewable:end -->
