### PR TITLE
[READY] Use column_codepoint when forcing completion for GenericLSPCompleter

### DIFF
--- a/ycmd/completers/language_server/generic_lsp_completer.py
+++ b/ycmd/completers/language_server/generic_lsp_completer.py
@@ -59,5 +59,12 @@ class GenericLSPCompleter( SimpleLSPCompleter ):
         self.GetHoverResponse( request_data ) ) }
 
 
+  def GetCodepointForCompletionRequest( self, request_data ):
+    if request_data[ 'force_semantic' ]:
+      return request_data[ 'column_codepoint' ]
+    return super( GenericLSPCompleter, self ).GetCodepointForCompletionRequest(
+      request_data )
+
+
   def SupportedFiletypes( self ):
     return self._supported_filetypes

--- a/ycmd/tests/language_server/generic_completer_test.py
+++ b/ycmd/tests/language_server/generic_completer_test.py
@@ -62,6 +62,32 @@ TEST_FILE = PathToTestFile( 'generic_server', 'test_file' )
 TEST_FILE_CONTENT = ReadFile( TEST_FILE )
 
 
+@IsolatedYcmd( { 'semantic_triggers': { 'foo': [ 're!.' ] },
+  'language_server':
+  [ { 'name': 'foo',
+      'filetypes': [ 'foo' ],
+      'cmdline': [ 'node', PATH_TO_GENERIC_COMPLETER, '--stdio' ] } ] } )
+def GenericLSPCompleter_GetCompletions_FilteredNoForce_test( app ):
+  request = BuildRequest( filepath = TEST_FILE,
+                          filetype = 'foo',
+                          line_num = 1,
+                          column_num = 3,
+                          contents = 'Java',
+                          event_name = 'FileReadyToParse' )
+  app.post_json( '/event_notification', request )
+  WaitUntilCompleterServerReady( app, 'foo' )
+  request.pop( 'event_name' )
+  response = app.post_json( '/completions', BuildRequest( **request ) )
+  eq_( response.status_code, 200 )
+  print( 'Completer response: {}'.format( json.dumps(
+    response.json, indent = 2 ) ) )
+  assert_that( response.json, has_entries( {
+    'completions': contains(
+      CompletionEntryMatcher( 'JavaScript', 'JavaScript details' ),
+    )
+  } ) )
+
+
 @IsolatedYcmd( { 'language_server':
   [ { 'name': 'foo',
       'filetypes': [ 'foo' ],


### PR DESCRIPTION
This makes D language server return top level completions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1283)
<!-- Reviewable:end -->
