### PR TITLE
[READY] Use numbers for LSP request IDs

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -365,7 +365,7 @@ class LanguageServerConnection( threading.Thread ):
   def NextRequestId( self ):
     with self._response_mutex:
       self._last_id += 1
-      return str( self._last_id )
+      return self._last_id
 
 
   def GetResponseAsync( self, request_id, message, response_callback=None ):
@@ -544,7 +544,7 @@ class LanguageServerConnection( threading.Thread ):
       else:
         # This is a response to the message with id message[ 'id' ]
         with self._response_mutex:
-          message_id = str( message[ 'id' ] )
+          message_id = message[ 'id' ]
           assert message_id in self._responses
           self._responses[ message_id ].ResponseReceived( message )
           del self._responses[ message_id ]


### PR DESCRIPTION
Right now ycmd is using strings as LSP IDs. What's worse is that those strings are actually just `int()` instances passed through `str()`, making ycmd just work harder for no reason.

Let me justify the "no reason" part:

- Notifications don't have IDs and are therefore unaffected.
- Server-to-client requests just forward whatever the server set as the ID to `lsp.Reject()` and are therefore unaffected.
- Client-to-server requests allow the client to set a request ID and the server needs to reply with the exact same ID, so if ycmd sends a number, server can't respond with a string.
  - So instead of doing `str( self._last_id )` to send the request and `str( message[ 'id' ] )`, we can just drop `str()` from these two.

Sending request IDs as strings, while conforming to JSON-RPC specification, is the reason why rust-analyzer doesn't currently work with ycmd. https://github.com/rust-analyzer/rust-analyzer/issues/1530

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1287)
<!-- Reviewable:end -->
