### PR TITLE
[READY] Vimspector: Remove duplication of python path

### DIFF
--- a/.vimspector.json
+++ b/.vimspector.json
@@ -2,6 +2,25 @@
   "configurations": {
     "python - launch nosetests": {
       "adapter": "vscode-python",
+      "variables": [
+        {
+          "python": {
+            "shell": "/bin/bash -c 'if [ -z \"${dollar}VIRTUAL_ENV\" ]; then echo $$(which python); else echo \"${dollar}VIRTUAL_ENV/bin/python\"; fi'"
+          },
+          "nosetests": {
+            "shell": "/bin/bash -c 'if [ -z \"${dollar}VIRTUAL_ENV\" ]; then echo $$(which nosetests); else echo \"${dollar}VIRTUAL_ENV/bin/nosetests\"; fi'"
+          }
+        },
+        {
+          "python_path": {
+            "shell": [
+              "${python}",
+              "${workspaceRoot}/run_tests.py",
+              "--dump-path"
+            ]
+          }
+        }
+      ],
       "configuration": {
         "name": "Python nosetests",
         "type": "vscode-python",
@@ -14,8 +33,8 @@
 
         "debugOptions": [],
 
-        "program": "$VIRTUAL_ENV/bin/nosetests",
-        "pythonPath": "${VIRTUAL_ENV}/bin/python",
+        "program": "${nosetests}",
+        "pythonPath": "${python}",
         "args": [
           "-v",
           "--with-id",
@@ -23,7 +42,7 @@
           "${Test}"
         ],
         "env": {
-          "PYTHONPATH": "${workspaceRoot}/third_party/bottle:${workspaceRoot}/third_party/cregex/regex_${python_version}:${workspaceRoot}/third_party/frozendict:${workspaceRoot}/third_party/jedi_deps/jedi:${workspaceRoot}/third_party/jedi_deps/numpydoc:${workspaceRoot}/third_party/jedi_deps/parso:${workspaceRoot}/third_party/requests_deps/certifi:${workspaceRoot}/third_party/requests_deps/chardet:${workspaceRoot}/third_party/requests_deps/idna:${workspaceRoot}/third_party/requests_deps/requests:${workspaceRoot}/third_party/requests_deps/urllib3/src:${workspaceRoot}/third_party/waitress",
+          "PYTHONPATH": "${python_path}",
           "LD_LIBRARY_PATH": "${workspaceRoot}/third_party/clang/lib",
           "YCM_TEST_NO_RETRY": "1"
         }

--- a/run_tests.py
+++ b/run_tests.py
@@ -323,12 +323,13 @@ def SetUpGenericLSPCompleter():
 
 
 def Main():
-  SetUpGenericLSPCompleter()
   parsed_args, nosetests_args = ParseArguments()
   if parsed_args.dump_path:
     print( os.environ[ 'PYTHONPATH' ] )
     sys.exit()
+
   print( 'Running tests on Python', platform.python_version() )
+  SetUpGenericLSPCompleter()
   if not parsed_args.no_flake8:
     RunFlake8()
   BuildYcmdLibs( parsed_args )

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -14,3 +14,4 @@ psutil                >= 3.3.0, != 5.0.1
 future                == 0.15.2
 coverage              >= 4.2
 codecov               >= 2.0.5
+ptvsd


### PR DESCRIPTION
The `--dump-path` option was there for this precise purpose, but until [now](https://github.com/puremourning/vimspector/pull/44) we couldn't use it in Vimspector. Now we can, so let's use it.

Had to move the building of the test completer, because npm spam broke the --dump-path output .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1294)
<!-- Reviewable:end -->
