### PR TITLE
[READY] Send compact JSON to language servers and clients

### DIFF
--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -498,7 +498,9 @@ def _BuildMessageData( message ):
   # NOTE: sort_keys=True is needed to workaround a 'limitation' of clangd where
   # it requires keys to be in a specific order, due to a somewhat naive
   # JSON/YAML parser.
-  data = ToBytes( json.dumps( message, sort_keys=True ) )
+  data = ToBytes( json.dumps( message,
+                              separators = ( ',', ':' ),
+                              sort_keys=True ) )
   packet = ToBytes( 'Content-Length: {0}\r\n'
                     '\r\n'.format( len( data ) ) ) + data
   return packet

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -295,7 +295,8 @@ class TypeScriptCompleter( Completer ):
   def _WriteRequest( self, request ):
     """Write a request to TSServer stdin."""
 
-    serialized_request = utils.ToBytes( json.dumps( request ) + '\n' )
+    serialized_request = utils.ToBytes(
+        json.dumps( request, separators = ( ',', ':' ) ) + '\n' )
     with self._write_lock:
       try:
         self._tsserver_handle.stdin.write( serialized_request )

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -277,7 +277,9 @@ app.default_error_handler = ErrorHandler
 
 def _JsonResponse( data ):
   SetResponseHeader( 'Content-Type', 'application/json' )
-  return json.dumps( data, default = _UniversalSerialize )
+  return json.dumps( data,
+                     separators = ( ',', ':' ),
+                     default = _UniversalSerialize )
 
 
 def _UniversalSerialize( obj ):

--- a/ycmd/tests/language_server/language_server_connection_test.py
+++ b/ycmd/tests/language_server/language_server_connection_test.py
@@ -169,13 +169,13 @@ def LanguageServerConnection_RejectUnsupportedRequest_test():
     lsc.LanguageServerConnectionStopped
   ]
 
-  expected_response = bytes( b'Content-Length: 87\r\n\r\n'
-                             b'{"error": {'
-                               b'"code": -32601, '
-                               b'"message": "Method not found"'
-                             b'}, '
-                             b'"id": "1", '
-                             b'"jsonrpc": "2.0"}' )
+  expected_response = bytes( b'Content-Length: 79\r\n\r\n'
+                             b'{"error":{'
+                               b'"code":-32601,'
+                               b'"message":"Method not found"'
+                             b'},'
+                             b'"id":"1",'
+                             b'"jsonrpc":"2.0"}' )
 
   with patch.object( connection, 'ReadData', side_effect = return_values ):
     with patch.object( connection, 'WriteData' ) as write_data:

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -579,7 +579,9 @@ class HashableDict( Mapping ):
     try:
       return self._hash
     except AttributeError:
-      self._hash = json.dumps( self._dict, sort_keys = True ).__hash__()
+      self._hash = json.dumps( self._dict,
+                               separators = ( ',', ':' ),
+                               sort_keys = True ).__hash__()
       return self._hash
 
 


### PR DESCRIPTION
Send a more compact JSON to ycmd clients and to language complaters (LSP and TSServer). To my surprise, about 1/8 of the json-encoded string is unnecessary whitespace.

Reference: https://docs.python.org/3/library/json.html (search for "Compact encoding")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1295)
<!-- Reviewable:end -->
