### PR TITLE
Don't consider clangd 10 out of date.

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -43,7 +43,7 @@ from ycmd.utils import ( CLANG_RESOURCE_DIR,
                          PathsToAllParentFolders,
                          re )
 
-MIN_SUPPORTED_VERSION = '7.0.0'
+MIN_SUPPORTED_VERSION = ( 7, 0, 0 )
 INCLUDE_REGEX = re.compile(
   '(\\s*#\\s*(?:include|import)\\s*)(?:"[^"]*|<[^>]*)' )
 NOT_CACHED = 'NOT_CACHED'
@@ -82,17 +82,21 @@ def DistanceOfPointToRange( point, range ):
   return 0
 
 
-def GetVersion( clangd_path ):
-  args = [ clangd_path, '--version' ]
-  stdout, _ = subprocess.Popen( args, stdout=subprocess.PIPE ).communicate()
-  version_regexp = r'(\d\.\d\.\d)'
-  m = re.search( version_regexp, stdout.decode() )
+def ParseClangdVersion( version_str ):
+  version_regexp = r'(\d+)\.(\d+)\.(\d+)'
+  m = re.search( version_regexp, version_str )
   try:
-    version = m.group( 1 )
+    version = tuple( int( x ) for x in m.groups() )
   except AttributeError:
     # Custom builds might have different versioning info.
     version = None
   return version
+
+
+def GetVersion( clangd_path ):
+  args = [ clangd_path, '--version' ]
+  stdout, _ = subprocess.Popen( args, stdout=subprocess.PIPE ).communicate()
+  return ParseClangdVersion( stdout.decode() )
 
 
 def CheckClangdVersion( clangd_path ):

--- a/ycmd/tests/clangd/utilities_test.py
+++ b/ycmd/tests/clangd/utilities_test.py
@@ -121,11 +121,17 @@ def ClangdCompleter_GetClangdCommand_CustomBinary_test():
 
 @patch( 'ycmd.completers.cpp.clangd_completer.GetVersion',
         side_effect = [ None,
-                        '5.0.0',
-                        clangd_completer.MIN_SUPPORTED_VERSION ] )
+                        ( 5, 0, 0 ),
+                        clangd_completer.MIN_SUPPORTED_VERSION,
+                        ( 10, 0, 0 ),
+                        ( 10, 10, 10 ),
+                        ( 100, 100, 100 ) ] )
 def ClangdCompleter_CheckClangdVersion_test( *args ):
   eq_( clangd_completer.CheckClangdVersion( 'clangd' ), True )
   eq_( clangd_completer.CheckClangdVersion( 'clangd' ), False )
+  eq_( clangd_completer.CheckClangdVersion( 'clangd' ), True )
+  eq_( clangd_completer.CheckClangdVersion( 'clangd' ), True )
+  eq_( clangd_completer.CheckClangdVersion( 'clangd' ), True )
   eq_( clangd_completer.CheckClangdVersion( 'clangd' ), True )
 
 
@@ -190,6 +196,20 @@ class MockPopen:
 def ClangdCompleter_GetVersion_test( mock_popen ):
   eq_( clangd_completer.GetVersion( '' ), None )
   mock_popen.assert_called()
+
+
+def ClangdCompleter_ParseClangdVersion_test():
+  cases = [
+    ( 'clangd version 10.0.0 (https://github.com/llvm/llvm-project.git '
+      '45be5e477e9216363191a8ac9123bea4585cf14f)', ( 10, 0, 0 ) ),
+    ( 'clangd version 8.0.0-3 (tags/RELEASE_800/final)', ( 8, 0, 0 ) ),
+    ( 'LLVM (http://llvm.org/):\nLLVM version 6.0.0\n'
+      'Optimized build.\nDefault target: x86_64-unknown-linux-gnu\n'
+      'Host CPU: haswell', ( 6, 0, 0 ) ),
+  ]
+
+  for version_str, expected in cases:
+    eq_( clangd_completer.ParseClangdVersion( version_str ), expected )
 
 
 @IsolatedYcmd()


### PR DESCRIPTION
The regex used to parse the clangd version only allows major numbers as
a single digit. Consequently, this results in a parsing failure for the
following version string:

```
    clangd version 10.0.0 (https://github.com/llvm/llvm-project.git bd68a052f292b5df7c5717bd880d796ac7507fc0)
```

This diff changes the regex to allow for two digit major version
numbers, and changes the comparison from a string based comparison to a
tuple/int based comparison to ensure that 10.0.0 > 7.0.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1299)
<!-- Reviewable:end -->
