### PR TITLE
Update ycm_core.cpp

### DIFF
--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -69,7 +69,7 @@ PYBIND11_MODULE( ycm_core, mod )
   mod.def( "YcmCoreVersion", &YcmCoreVersion );
 
   // This is exposed so that we can test it.
-  mod.def( "GetUtf8String", []( py::object o ) -> py::bytes {
+  mod.def( "GetUtf8String", []( const py::object & o ) -> py::bytes {
                                   return GetUtf8String( o ); } );
 
   py::class_< IdentifierCompleter >( mod, "IdentifierCompleter" )


### PR DESCRIPTION
fix gcc error:

cpp/ycm/ycm_core.cpp:72:44: error: the parameter 'o' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1305)
<!-- Reviewable:end -->
