### PR TITLE
Add smart_case option to enable/disable smart case matching

### DIFF
--- a/cpp/ycm/Candidate.cpp
+++ b/cpp/ycm/Candidate.cpp
@@ -75,7 +75,7 @@ Candidate::Candidate( std::string&& text )
 }
 
 
-Result Candidate::QueryMatchResult( const Word &query ) const {
+Result Candidate::QueryMatchResult( const Word &query, bool smart_case ) const {
   // Check if the query is a subsequence of the candidate and return a result
   // accordingly. This is done by simultaneously going through the characters of
   // the query and the candidate. If both characters match, we move to the next
@@ -112,7 +112,7 @@ Result Candidate::QueryMatchResult( const Word &query ) const {
     const auto &candidate_character = *candidate_character_pos;
     const auto &query_character = *query_character_pos;
 
-    if ( query_character->MatchesSmart( *candidate_character ) ) {
+    if ( query_character->Matches( *candidate_character, smart_case ) ) {
       index_sum += candidate_index;
 
       ++query_character_pos;

--- a/cpp/ycm/Candidate.h
+++ b/cpp/ycm/Candidate.h
@@ -50,7 +50,7 @@ public:
     return text_is_lowercase_;
   }
 
-  YCM_EXPORT Result QueryMatchResult( const Word &query ) const;
+  YCM_EXPORT Result QueryMatchResult( const Word &query, bool smart_case ) const;
 
 private:
   void ComputeCaseSwappedText();

--- a/cpp/ycm/Candidate.h
+++ b/cpp/ycm/Candidate.h
@@ -50,7 +50,7 @@ public:
     return text_is_lowercase_;
   }
 
-  YCM_EXPORT Result QueryMatchResult( const Word &query, bool smart_case ) const;
+  YCM_EXPORT Result QueryMatchResult( const Word &query, bool smart_case = 1) const;
 
 private:
   void ComputeCaseSwappedText();

--- a/cpp/ycm/Character.h
+++ b/cpp/ycm/Character.h
@@ -83,6 +83,9 @@ public:
     return folded_case_ == other.folded_case_;
   };
 
+  inline bool Matches( const Character &other, bool smart_case ) const {
+    return smart_case ? MatchesSmart(other) : (normal_ == other.normal_);
+  };
   // Smart base matching on top of smart case matching, e.g.:
   //  - e matches e, é, E, É;
   //  - E matches E, É but not e, é;

--- a/cpp/ycm/IdentifierCompleter.cpp
+++ b/cpp/ycm/IdentifierCompleter.cpp
@@ -79,13 +79,15 @@ std::vector< std::string > IdentifierCompleter::CandidatesForQuery(
 std::vector< std::string > IdentifierCompleter::CandidatesForQueryAndType(
   std::string query,
   const std::string &filetype,
-  const size_t max_candidates ) const {
+  const size_t max_candidates,
+  bool smart_case ) const {
 
   std::vector< Result > results;
   identifier_database_.ResultsForQueryAndType( std::move( query ),
                                                filetype,
                                                results,
-                                               max_candidates );
+                                               max_candidates,
+                                               smart_case );
 
   std::vector< std::string > candidates;
   candidates.reserve( results.size() );

--- a/cpp/ycm/IdentifierCompleter.h
+++ b/cpp/ycm/IdentifierCompleter.h
@@ -72,7 +72,8 @@ public:
   YCM_EXPORT std::vector< std::string > CandidatesForQueryAndType(
     std::string query,
     const std::string &filetype,
-    const size_t max_candidates = 0 ) const;
+    const size_t max_candidates = 0,
+    bool smart_case = true ) const;
 
 private:
 

--- a/cpp/ycm/IdentifierDatabase.cpp
+++ b/cpp/ycm/IdentifierDatabase.cpp
@@ -67,7 +67,8 @@ void IdentifierDatabase::ResultsForQueryAndType(
   std::string&& query,
   const std::string &filetype,
   std::vector< Result > &results,
-  const size_t max_results ) const {
+  const size_t max_results,
+  bool smart_case ) const {
   FiletypeCandidateMap::const_iterator it;
   {
     std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
@@ -96,7 +97,7 @@ void IdentifierDatabase::ResultsForQueryAndType(
           continue;
         }
 
-        Result result = candidate->QueryMatchResult( query_object );
+        Result result = candidate->QueryMatchResult( query_object, smart_case );
 
         if ( result.IsSubsequence() ) {
           results.push_back( result );

--- a/cpp/ycm/IdentifierDatabase.h
+++ b/cpp/ycm/IdentifierDatabase.h
@@ -69,7 +69,8 @@ public:
   void ResultsForQueryAndType( std::string&& query,
                                const std::string &filetype,
                                std::vector< Result >& results,
-                               const size_t max_results ) const;
+                               const size_t max_results,
+                               bool smart_case ) const;
 
 private:
   std::set< const Candidate * > &GetCandidateSet(

--- a/cpp/ycm/PythonSupport.cpp
+++ b/cpp/ycm/PythonSupport.cpp
@@ -65,7 +65,8 @@ pylist FilterAndSortCandidates(
   pylist candidates,
   const std::string &candidate_property,
   std::string query,
-  const size_t max_candidates ) {
+  const size_t max_candidates,
+  bool smart_case ) {
   pylist filtered_candidates;
 
   size_t num_candidates = len( candidates );
@@ -84,7 +85,7 @@ pylist FilterAndSortCandidates(
         continue;
       }
 
-      Result result = candidate->QueryMatchResult( query_object );
+      Result result = candidate->QueryMatchResult( query_object, smart_case );
 
       if ( result.IsSubsequence() ) {
         result_and_objects.emplace_back( result, i );

--- a/cpp/ycm/PythonSupport.h
+++ b/cpp/ycm/PythonSupport.h
@@ -32,7 +32,8 @@ YCM_EXPORT pybind11::list FilterAndSortCandidates(
   pybind11::list candidates,
   const std::string &candidate_property,
   std::string query,
-  const size_t max_candidates = 0 );
+  const size_t max_candidates = 0,
+  bool smart_case = true);
 
 /// Given a Python object that's supposed to be "string-like", returns a UTF-8
 /// encoded std::string. Raises an exception if the object can't be converted to

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -64,7 +64,8 @@ PYBIND11_MODULE( ycm_core, mod )
            py::arg("candidates"),
            py::arg("candidate_property"),
            py::arg("query"),
-           py::arg("max_candidates") = 0 );
+           py::arg("max_candidates") = 0,
+           py::arg("smart_case") = true);
 
   mod.def( "YcmCoreVersion", &YcmCoreVersion );
 
@@ -88,7 +89,8 @@ PYBIND11_MODULE( ycm_core, mod )
           py::call_guard< py::gil_scoped_release >(),
           py::arg( "query" ),
           py::arg( "filetype" ),
-          py::arg( "max_candidates" ) = 0 );
+          py::arg( "max_candidates" ) = 0,
+          py::arg( "smart_case" ) = true);
 
   py::bind_vector< std::vector< std::string > >( mod, "StringVector" );
 

--- a/ycmd/completers/all/identifier_completer.py
+++ b/ycmd/completers/all/identifier_completer.py
@@ -52,7 +52,8 @@ class IdentifierCompleter( GeneralCompleter ):
     completions = self._completer.CandidatesForQueryAndType(
       ToCppStringCompatible( _SanitizeQuery( request_data[ 'query' ] ) ),
       ToCppStringCompatible( request_data[ 'first_filetype' ] ),
-      self._max_candidates )
+      self._max_candidates,
+      self.user_options[ 'smart_case' ] )
 
     completions = _RemoveSmallCandidates(
       completions, self.user_options[ 'min_num_identifier_candidate_chars' ] )

--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -172,6 +172,7 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
 
   def __init__( self, user_options ):
     self.user_options = user_options
+    self.smart_case = user_options.get( 'smart_case', True )
     self.min_num_chars = user_options[ 'min_num_of_chars_for_completion' ]
     self.max_diagnostics_to_display = user_options[
         'max_diagnostics_to_display' ]
@@ -317,7 +318,7 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
 
   def FilterAndSortCandidatesInner( self, candidates, sort_property, query ):
     return completer_utils.FilterAndSortCandidatesWrap(
-      candidates, sort_property, query, self._max_candidates )
+      candidates, sort_property, query, self._max_candidates, self.smart_case )
 
 
   def OnFileReadyToParse( self, request_data ):

--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -176,7 +176,7 @@ def _PrepareTrigger( trigger ):
 
 
 def FilterAndSortCandidatesWrap( candidates, sort_property, query,
-                                 max_candidates ):
+                                 max_candidates, smart_case ):
   from ycm_core import FilterAndSortCandidates
 
   # The c++ interface we use only understands the (*native*) 'str' type (i.e.
@@ -190,7 +190,7 @@ def FilterAndSortCandidatesWrap( candidates, sort_property, query,
   return FilterAndSortCandidates( candidates,
                                   ToCppStringCompatible( sort_property ),
                                   ToCppStringCompatible( query ),
-                                  max_candidates )
+                                  max_candidates, smart_case )
 
 
 TRIGGER_REGEX_PREFIX = 're!'

--- a/ycmd/default_settings.json
+++ b/ycmd/default_settings.json
@@ -1,6 +1,7 @@
 {
   "filepath_completion_use_working_dir": 0,
   "auto_trigger": 1,
+  "smart_case": 1,
   "min_num_of_chars_for_completion": 2,
   "min_num_identifier_candidate_chars": 0,
   "semantic_triggers": {},

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -132,7 +132,8 @@ def FilterAndSortCandidates():
     request_data[ 'candidates' ],
     request_data[ 'sort_property' ],
     request_data[ 'query' ],
-    _server_state.user_options[ 'max_num_candidates' ] ) )
+    _server_state.user_options[ 'max_num_candidates' ],
+    _server_state.user_options[ 'smart_case' ] ) )
 
 
 @app.get( '/healthy' )


### PR DESCRIPTION
Introduce a 'smart_case' option to control query matching behavior.

When disabled, use normal case-sensitive matching, otherwise retain the
existing "smart case" functionality.

Set the default to true to maintain compatibility.

Global option 'g:smart_case' controls this behavior from vim, defaulting to '1'.

### Motivation:

The default smart case behavior may not always be wanted. I've included an example based on some C code that uses a naming convention like so (for subsystem 'foo'):
1) Register contents are #defined like so `#define FOO_CONSTANT`
2) Function names are lowercased `void foo_do_something()`

The default smart case matching can be too noisy, with limited utility:
<img width="903" alt="smart_case_enabled" src="https://user-images.githubusercontent.com/224968/64728217-5e5bd800-d48f-11e9-9eed-8185b9ef2976.png">

With smart_case = 0, lowercase completion:
<img width="898" alt="smart_case_disabled_lower" src="https://user-images.githubusercontent.com/224968/64728289-84817800-d48f-11e9-831f-b9e05b64dda7.png">

With smart_case = 0, uppercase completion:
<img width="902" alt="smart_case_disabled_upper" src="https://user-images.githubusercontent.com/224968/64728322-94995780-d48f-11e9-87ca-9ed2ae3ef496.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1310)
<!-- Reviewable:end -->
