### PR TITLE
[WIP][CI] Azure linux openssl

### DIFF
--- a/azure/linux/install_dependencies.sh
+++ b/azure/linux/install_dependencies.sh
@@ -39,36 +39,21 @@ mkdir ${HOME}/.cache
 # Python setup
 #
 
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
+# python build dependencies
+# See 
+sudo apt-get install make build-essential libssl-dev zlib1g-dev libbz2-dev \
+libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
 
-eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
-
-brew install pyenv
-brew install openssl
-
+# Clone and enable pyenv
+git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"
 
-echo '*******************************************'
-echo '*******************************************'
-echo '*******************************************'
-ls -l /home/linuxbrew/.linuxbrew/opt/openssl@1.1
-echo '*******************************************'
-ls -l /home/linuxbrew/.linuxbrew/opt/openssl@1.1/include
-echo '*******************************************'
-ls -l /home/linuxbrew/.linuxbrew/opt/openssl@1.1/lib
-echo '*******************************************'
-ls -l /home/linuxbrew/.linuxbrew/opt/openssl@1.1/lib/pkgconfig
-echo '*******************************************'
-echo '*******************************************'
-echo '*******************************************'
 # In order to work with ycmd, Python *must* be built as a shared library. This
 # is set via the PYTHON_CONFIGURE_OPTS option.
 PYTHON_CONFIGURE_OPTS="--enable-shared" \
-PKG_CONFIG_PATH="/home/linuxbrew/.linuxbrew/opt/openssl@1.1/lib/pkgconfig" \
-CFLAGS="-I/home/linuxbrew/.linuxbrew/opt/openssl@1.1/include" \
-CPPFLAGS="-I/home/linuxbrew/.linuxbrew/opt/openssl@1.1/include" \
-CXXFLAGS="-I/home/linuxbrew/.linuxbrew/opt/openssl@1.1/include" \
-LDFLAGS="-L/home/linuxbrew/.linuxbrew/opt/openssl@1.1/lib" \
 pyenv install ${YCM_PYTHON_VERSION}
 pyenv global ${YCM_PYTHON_VERSION}
 

--- a/azure/linux/install_dependencies.sh
+++ b/azure/linux/install_dependencies.sh
@@ -44,6 +44,7 @@ sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/i
 eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 
 brew install pyenv
+brew install openssl
 
 eval "$(pyenv init -)"
 

--- a/azure/linux/install_dependencies.sh
+++ b/azure/linux/install_dependencies.sh
@@ -1,6 +1,7 @@
 # Exit immediately if a command returns a non-zero status.
 set -e
 
+
 #
 # Compiler setup
 #
@@ -46,11 +47,27 @@ brew install pyenv
 
 eval "$(pyenv init -)"
 
+echo '*******************************************'
+echo '*******************************************'
+echo '*******************************************'
+ls -l /home/linuxbrew/.linuxbrew/opt/openssl@1.1
+echo '*******************************************'
+ls -l /home/linuxbrew/.linuxbrew/opt/openssl@1.1/include
+echo '*******************************************'
+ls -l /home/linuxbrew/.linuxbrew/opt/openssl@1.1/lib
+echo '*******************************************'
+ls -l /home/linuxbrew/.linuxbrew/opt/openssl@1.1/lib/pkgconfig
+echo '*******************************************'
+echo '*******************************************'
+echo '*******************************************'
 # In order to work with ycmd, Python *must* be built as a shared library. This
 # is set via the PYTHON_CONFIGURE_OPTS option.
 PYTHON_CONFIGURE_OPTS="--enable-shared" \
-CFLAGS="-I$(brew --prefix openssl)/include" \
-LDFLAGS="-L$(brew --prefix openssl)/lib" \
+PKG_CONFIG_PATH="/home/linuxbrew/.linuxbrew/opt/openssl@1.1/lib/pkgconfig" \
+CFLAGS="-I/home/linuxbrew/.linuxbrew/opt/openssl@1.1/include" \
+CPPFLAGS="-I/home/linuxbrew/.linuxbrew/opt/openssl@1.1/include" \
+CXXFLAGS="-I/home/linuxbrew/.linuxbrew/opt/openssl@1.1/include" \
+LDFLAGS="-L/home/linuxbrew/.linuxbrew/opt/openssl@1.1/lib" \
 pyenv install ${YCM_PYTHON_VERSION}
 pyenv global ${YCM_PYTHON_VERSION}
 

--- a/azure/linux/install_dependencies.sh
+++ b/azure/linux/install_dependencies.sh
@@ -54,6 +54,8 @@ eval "$(pyenv init -)"
 # In order to work with ycmd, Python *must* be built as a shared library. This
 # is set via the PYTHON_CONFIGURE_OPTS option.
 PYTHON_CONFIGURE_OPTS="--enable-shared" \
+CFLAGS="-I/usr/include/openssl" \
+LDFLAGS="-L/usr/lib" \
 pyenv install ${YCM_PYTHON_VERSION}
 pyenv global ${YCM_PYTHON_VERSION}
 

--- a/azure/linux/install_dependencies.sh
+++ b/azure/linux/install_dependencies.sh
@@ -45,7 +45,7 @@ sudo apt-get install make build-essential libssl-dev zlib1g-dev libbz2-dev \
 libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
 xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
 
-sudo apt-get install libssl1.0-dev
+sudo apt-get install libssl1.0.0-dev
 
 # Clone and enable pyenv
 git clone https://github.com/pyenv/pyenv.git ~/.pyenv

--- a/azure/linux/install_dependencies.sh
+++ b/azure/linux/install_dependencies.sh
@@ -45,6 +45,8 @@ sudo apt-get install make build-essential libssl-dev zlib1g-dev libbz2-dev \
 libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
 xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
 
+sudo apt-get install libssl1.0-dev
+
 # Clone and enable pyenv
 git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 export PYENV_ROOT="$HOME/.pyenv"


### PR DESCRIPTION
This doesn't fix the CI as `openssl-dev` package doesn't really exist.

I tried `sudo apt-get install openssl`, but Azure claims it's already installed.

Azure says the following:

```
openssl@1.1 is keg-only, which means it was not symlinked into /home/linuxbrew/.linuxbrew,
because this is an alternate version of another formula.

If you need to have openssl@1.1 first in your PATH run:
  echo 'export PATH="/home/linuxbrew/.linuxbrew/opt/openssl@1.1/bin:$PATH"' >> ~/.bash_profile

For compilers to find openssl@1.1 you may need to set:
  export LDFLAGS="-L/home/linuxbrew/.linuxbrew/opt/openssl@1.1/lib"
  export CPPFLAGS="-I/home/linuxbrew/.linuxbrew/opt/openssl@1.1/include"

For pkg-config to find openssl@1.1 you may need to set:
  export PKG_CONFIG_PATH="/home/linuxbrew/.linuxbrew/opt/openssl@1.1/lib/pkgconfig"
```

So I tried that too (PATH, LDFLAGS, CPPFLAGS, CXXFLAGS and CCFLAGS), but still pyenv can't find "OpenSSL lib":

```
Installing Python-2.7.1...
patching file setup.py
patching file ./Modules/readline.c
Hunk #1 succeeded at 200 (offset -6 lines).
Hunk #2 succeeded at 735 (offset -14 lines).
Hunk #3 succeeded at 845 (offset -14 lines).
Hunk #4 succeeded at 885 with fuzz 2 (offset -33 lines).
patching file ./Lib/ssl.py
patching file ./Modules/_ssl.c
python-build: use readline from homebrew
WARNING: The Python readline extension was not compiled. Missing the GNU readline lib?
ERROR: The Python ssl extension was not compiled. Missing the OpenSSL lib?
```

I'm out of ideas and any help is very welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1311)
<!-- Reviewable:end -->
