### PR TITLE
[READY] OnBufferVisit for clangd completer

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -487,6 +487,15 @@ class ClangdCompleter( simple_language_server_completer.SimpleLSPCompleter ):
     ]
 
 
+  def OnBufferVisit( self, request_data ):
+    # In case a header has been changed, we need to make clangd reparse the TU.
+    file_state = self._server_file_state[ request_data[ 'filepath' ] ]
+    if file_state.state == lsp.ServerFileState.OPEN:
+      msg = lsp.DidChangeTextDocument( file_state, None )
+      self.GetConnection().SendNotification( msg )
+
+
+
 def CompilationDatabaseExists( file_dir ):
   for folder in PathsToAllParentFolders( file_dir ):
     if os.path.exists( os.path.join( folder, 'compile_commands.json' ) ):

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -309,6 +309,10 @@ def DidOpenTextDocument( file_state, file_types, file_contents ):
 
 
 def DidChangeTextDocument( file_state, file_contents ):
+  # NOTE: Passing `None` for the second argument will send an empty
+  # textDocument/didChange notification. It is useful when a LSP server
+  # needs to be forced to reparse a file without sending all the changes.
+  # More specifically, clangd completer relies on this.
   return BuildNotification( 'textDocument/didChange', {
     'textDocument': {
       'uri': FilePathToUri( file_state.filename ),
@@ -316,7 +320,7 @@ def DidChangeTextDocument( file_state, file_contents ):
     },
     'contentChanges': [
       { 'text': file_contents },
-    ],
+    ] if file_contents is not None else [],
   } )
 
 


### PR DESCRIPTION
Forces clangd to reparse the file on every `BufferVisit` notification,
so diagnostics are updated to reflect changes in included headers.

Headers still need to be saved to disc because clangd isn't concerned
about dirty files in the TU's main file's preamble.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1332)
<!-- Reviewable:end -->
