### PR TITLE
[READY] Add GetDoc for clangd completer

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -280,8 +280,21 @@ class ClangdCompleter( simple_language_server_completer.SimpleLSPCompleter ):
 
 
   def GetType( self, request_data ):
-    hover_response = self.GetHoverResponse( request_data )
-    return responses.BuildDisplayMessageResponse( hover_response[ 'value' ] )
+    # Clangd's hover response looks like this:
+    #     Declared in namespace <namespace name>
+    #
+    #     <declaration line>
+    #
+    #     <docstring>
+    # GetType gets the first two lines.
+    value = self.GetHoverResponse( request_data )[ 'value' ].split( '\n\n', 2 )
+    return responses.BuildDisplayMessageResponse( '\n\n'.join( value[ : 2 ] ) )
+
+
+  def GetDoc( self, request_data ):
+    # Just pull `value` out of the textDocument/hover response
+    return responses.BuildDisplayMessageResponse(
+        self.GetHoverResponse( request_data )[ 'value' ] )
 
 
   def GetTriggerCharacters( self, server_trigger_characters ):
@@ -317,11 +330,14 @@ class ClangdCompleter( simple_language_server_completer.SimpleLSPCompleter ):
       'RestartServer': (
         lambda self, request_data, args: self._RestartServer( request_data )
       ),
+      'GetDoc': (
+        lambda self, request_data, args: self.GetDoc( request_data )
+      ),
+      'GetDocImprecise': (
+        lambda self, request_data, args: self.GetDoc( request_data )
+      ),
       # To handle the commands below we need extensions to LSP. One way to
       # provide those could be to use workspace/executeCommand requset.
-      # 'GetDoc': (
-      #   lambda self, request_data, args: self.GetType( request_data )
-      # ),
       # 'GetParent': (
       #   lambda self, request_data, args: self.GetType( request_data )
       # )

--- a/ycmd/tests/clangd/testdata/GetDoc_Clang_test.cc
+++ b/ycmd/tests/clangd/testdata/GetDoc_Clang_test.cc
@@ -1,0 +1,8 @@
+#include "docstring.h"
+
+
+/// docstring
+void docstring_int_main_TU_file() {
+  docstring_from_header_file();
+  int x = 3;
+}

--- a/ycmd/tests/clangd/testdata/docstring.h
+++ b/ycmd/tests/clangd/testdata/docstring.h
@@ -1,0 +1,5 @@
+#ifndef DOCS
+#define DOCS
+/// docstring
+void docstring_from_header_file();
+#endif /* ifndef DOCS */


### PR DESCRIPTION
Requires clangd 9.0.0, so half of the tests are commented out. However, since some users are already using clangd 9, we can already provide GetDoc for them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1333)
<!-- Reviewable:end -->
