### PR TITLE
added support for typescriptreact (.tsx) files

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -361,7 +361,7 @@ class TypeScriptCompleter( Completer ):
 
 
   def SupportedFiletypes( self ):
-    return [ 'javascript', 'typescript' ]
+    return [ 'javascript', 'typescript', 'typescriptreact' ]
 
 
   def ComputeCandidatesInner( self, request_data ):

--- a/ycmd/completers/typescriptreact/hook.py
+++ b/ycmd/completers/typescriptreact/hook.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2015 Google Inc.
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+# Not installing aliases from python-future; it's unreliable and slow.
+from builtins import *  # noqa
+
+from ycmd.completers.typescript.typescript_completer import (
+    ShouldEnableTypeScriptCompleter, TypeScriptCompleter )
+
+
+def GetCompleter( user_options ):
+  if not ShouldEnableTypeScriptCompleter():
+    return None
+
+  return TypeScriptCompleter( user_options )

--- a/ycmd/completers/typescriptreact/hook.py
+++ b/ycmd/completers/typescriptreact/hook.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 Google Inc.
+# Copyright (C) 2019 ycmd contributors
 #
 # This file is part of ycmd.
 #

--- a/ycmd/tests/typescript/subcommands_test.py
+++ b/ycmd/tests/typescript/subcommands_test.py
@@ -840,6 +840,10 @@ def Subcommands_RefactorRename_MultipleFiles_test( app ):
               'this-is-a-longer-string',
               LocationMatcher( PathToTestFile( 'file3.ts' ), 1, 15 ),
               LocationMatcher( PathToTestFile( 'file3.ts' ), 1, 18 ) ),
+            ChunkMatcher(
+              'this-is-a-longer-string',
+              LocationMatcher( PathToTestFile( 'test.tsx' ), 10, 8 ),
+              LocationMatcher( PathToTestFile( 'test.tsx' ), 10, 11 ) ),
           ),
           'location': LocationMatcher( PathToTestFile( 'test.ts' ), 25, 9 )
         } ) )

--- a/ycmd/tests/typescript/testdata/test.tsx
+++ b/ycmd/tests/typescript/testdata/test.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+interface MyComponentProps {
+  children: any;
+}
+
+const TestComponent: React.FunctionComponent<MyComponentProps> = (props) => {
+  return (
+    <div>
+      <Bar />
+      {props.children}
+    </div>
+  );
+};


### PR DESCRIPTION
As suggested in https://github.com/ycm-core/YouCompleteMe/issues/3499, this is a pull request for adding support for .tsx files to YouCompleteMe. 

The text of that issue is copied below for convenience.

*******

Since vim has added [two new file types](https://github.com/vim/vim/issues/4830) for Javascript and Typescript files that use JSX syntax, files with extensions .jsx and .tsx now have the filetype "javascriptreact" and "typescriptreact" respectively.

Is it possible to enable the typescript auto completer for those filetypes as well by default? Right now when editing those files I get the error `No semantic completer exists for filetypes: ['typescriptreact']`.

My temporary workaround for now is to put the following line in my .vimrc:

    au BufNewFile,BufRead *.tsx set filetype=typescript

This works, but it would be even better to be able to do this out of the box.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1336)
<!-- Reviewable:end -->
