### PR TITLE
[READY] Implement `applyEdit` to allow incomplete `FixIts`

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -220,6 +220,18 @@
                     </tr>
                     <tr>
                             <td class="swagger--summary-path" rowspan="1">
+                                <a href="#path--resolve_fixit">/resolve_fixit</a>
+                            </td>
+                        <td>
+                            <a href="#operation--resolve_fixit-post">POST</a>
+                        </td>
+                        <td>
+                            <p>Resolve an incomplete FixIt.</p>
+        
+                        </td>
+                    </tr>
+                    <tr>
+                            <td class="swagger--summary-path" rowspan="1">
                                 <a href="#path--run_completer_command">/run_completer_command</a>
                             </td>
                         <td>
@@ -1638,6 +1650,148 @@
                 </div>
             </div>
         
+        <span id="path--resolve_fixit"></span>
+            <div id="operation--resolve_fixit-post" class="swagger--panel-operation-post panel">
+                <div class="panel-heading">
+                    <div class="operation-summary">Resolve an incomplete FixIt.</div>
+                    <h3 class="panel-title"><span class="operation-name">POST</span> <strong>/resolve_fixit</strong></h3>
+                </div>
+                <div class="panel-body">
+                    <section class="sw-operation-description">
+                        <p>Resolves an incomplete fixit, indicated by <code>&#39;resolve&#39;</code> fixit property.
+            Some completers return incomplete fixits in order to avoid blocking on
+            expensive fixit calculations.</p>
+            <p>When a client wishes to resolve a fixit, the entire <code>FixIt</code> object
+            should be sent in the <code>fixit</code> property.</p>
+            <p>If a client tries to resolve an already resolved fixit, the same fixit
+            is returned in a SubcommandResponse.</p>
+            
+                    </section>
+            
+                        
+                            <section class="sw-request-body">
+                                
+                                        <div class="row">
+                                            <div class="col-md-6">
+                                                <p><p>The context data, including the current cursor position, and details
+                        of dirty buffers.</p>
+                        </p>
+                                            </div>
+                                            <div class="col-md-6 sw-request-model">
+                            <div  class="panel panel-definition">
+                                <div class="panel-body">
+                                            <section class="json-schema-example">
+                                                <pre><code class="lang-json">{<br>    &quot;<span class="hljs-attribute">file_data</span>&quot;: <span class="hljs-value">{<br>        &quot;<span class="hljs-attribute">/home/test/dev/test.c</span>&quot;: <span class="hljs-value">{<br>            &quot;<span class="hljs-attribute">contents</span>&quot;: <span class="hljs-value"><span class="hljs-string">&quot;&lt;file contents&gt;&quot;</span></span>,<br>            &quot;<span class="hljs-attribute">filetypes</span>&quot;: <span class="hljs-value">[<br>                <span class="hljs-string">&quot;c&quot;</span><br>            ]<br>        </span>}<br>    </span>}</span>,<br>    &quot;<span class="hljs-attribute">filepath</span>&quot;: <span class="hljs-value"><span class="hljs-string">&quot;/home/test/dev/test.c&quot;</span></span>,<br>    &quot;<span class="hljs-attribute">fixit</span>&quot;: <span class="hljs-value">{<br>        &quot;<span class="hljs-attribute">$ref</span>&quot;: <span class="hljs-value"><span class="hljs-string"><a href="#/definitions/UnresolvedFixIt">&quot;#/definitions/UnresolvedFixIt&quot;</a></span><br>    </span>}<br></span>}
+                                        </code></pre>
+                                        
+                                            </section>
+                                        
+                                                <section class="json-schema-properties">
+                                                    <dl>
+                                                            <dt data-property-name="filepath">
+                                                                <span class="json-property-name">filepath:</span>
+                                                                
+                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/FilePath">FilePath</a>
+                                                                </span>
+                                                                <span class="json-property-range" title="Value limits"></span>
+                                                                
+                                                                    <span class="json-property-required"></span>
+                                                            </dt>
+                                                            <dd>
+                                                                
+                                                                <div class="json-inner-schema">
+                                                                    
+                                                                </div>
+                                                            </dd>
+                                                            <dt data-property-name="file_data">
+                                                                <span class="json-property-name">file_data:</span>
+                                                                
+                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/FileDataMap">FileDataMap</a>
+                                                                </span>
+                                                                <span class="json-property-range" title="Value limits"></span>
+                                                                
+                                                                    <span class="json-property-required"></span>
+                                                            </dt>
+                                                            <dd>
+                                                                
+                                                                <div class="json-inner-schema">
+                                                                    
+                                                                </div>
+                                                            </dd>
+                                                            <dt data-property-name="fixit">
+                                                                <span class="json-property-name">fixit:</span>
+                                                                
+                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/FixIt">FixIt</a>
+                                                                </span>
+                                                                <span class="json-property-range" title="Value limits"></span>
+                                                                
+                                                                    <span class="json-property-required"></span>
+                                                            </dt>
+                                                            <dd>
+                                                                
+                                                                <div class="json-inner-schema">
+                                                                    
+                                                                </div>
+                                                            </dd>
+                                                    </dl>
+                                                </section>
+                                </div>
+                            </div></div>
+                                        </div>
+                            </section>        
+                    
+                        <section class="sw-responses">
+                                <p>
+                    </p>
+                    
+                            <dl>
+                                    <dt class="sw-response-200">
+                                        200 OK
+                                    
+                                    </dt>
+                                    <dd class="sw-response-200">
+                                            <div class="row">
+                                                <div class="col-md-12">
+                                                    <p>The fixit has been resolved and a FixIt response is returned.</p>
+                                            
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                
+                                                <div class="col-md-6 sw-response-model">
+                                                <div  class="panel panel-definition">
+                                                    <div class="panel-body">
+                                                                <a class="json-schema-ref" href="#/definitions/SubcommandResponse">SubcommandResponse</a>
+                                                    </div>
+                                                </div></div>
+                                            
+                                            </div>                </dd>
+                                    <dt class="sw-response-500">
+                                        500 Internal Server Error
+                                    
+                                    </dt>
+                                    <dd class="sw-response-500">
+                                            <div class="row">
+                                                <div class="col-md-12">
+                                                    <p>An error occured</p>
+                                            
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                
+                                                <div class="col-md-6 sw-response-model">
+                                                <div  class="panel panel-definition">
+                                                    <div class="panel-body">
+                                                                <a class="json-schema-ref" href="#/definitions/ExceptionResponse">ExceptionResponse</a>
+                                                    </div>
+                                                </div></div>
+                                            
+                                            </div>                </dd>
+                            </dl>
+                        </section>
+                </div>
+            </div>
+        
         <span id="path--run_completer_command"></span>
             <div id="operation--run_completer_command-post" class="swagger--panel-operation-post panel">
                 <div class="panel-heading">
@@ -1928,114 +2082,7 @@
                                                 <div class="col-md-6 sw-response-model">
                                                 <div  class="panel panel-definition">
                                                     <div class="panel-body">
-                                                            
-                                                                    <section class="json-schema-properties">
-                                                                        <dl>
-                                                                                <dt data-property-name="fixits">
-                                                                                    <span class="json-property-name">fixits:</span>
-                                                                                    
-                                                                                    <span class="json-property-type">object[]</span>
-                                                                                    <span class="json-property-range" title="Value limits"></span>
-                                                                                    
-                                                                                </dt>
-                                                                                <dd>
-                                                                                    <p>If present, this is a <em>FixIt</em> or <em>Refactor</em> response and the
-                                                                    value of this property is a list of potential changes to
-                                                                    buffers to apply the quick fix or refactoring operation.</p>
-                                                                    <p>An empty <code>fixits</code> list means that no FixIt or refactoring
-                                                                    was available. If multiple entries are supplied, the user is
-                                                                    prompted to select which one to apply.</p>
-                                                                    
-                                                                                    <div class="json-inner-schema">
-                                                                                        
-                                                                                                        <section class="json-schema-array-items">
-                                                                                                            
-                                                                                                            <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/FixIt">FixIt</a>
-                                                                                                            </span>
-                                                                                                            <span class="json-property-range" title="Value limits"></span>
-                                                                                                            
-                                                                                                            <div class="json-inner-schema">
-                                                                                                                
-                                                                                                            </div>
-                                                                                                        </section>                </div>
-                                                                                </dd>
-                                                                                <dt data-property-name="message">
-                                                                                    <span class="json-property-name">message:</span>
-                                                                                    
-                                                                                    <span class="json-property-type">string</span>
-                                                                                    <span class="json-property-range" title="Value limits"></span>
-                                                                                    
-                                                                                </dt>
-                                                                                <dd>
-                                                                                    <p>If present, this is a <em>simple display message</em> and the value
-                                                                    of this property is the message to display.</p>
-                                                                    
-                                                                                    <div class="json-inner-schema">
-                                                                                        
-                                                                                    </div>
-                                                                                </dd>
-                                                                                <dt data-property-name="detailed_info">
-                                                                                    <span class="json-property-name">detailed_info:</span>
-                                                                                    
-                                                                                    <span class="json-property-type">string</span>
-                                                                                    <span class="json-property-range" title="Value limits"></span>
-                                                                                    
-                                                                                </dt>
-                                                                                <dd>
-                                                                                    <p>If present, this is a <em>detailed information</em> response and
-                                                                    the value of this property is the multi-line information
-                                                                    to display as unformatted plain text.</p>
-                                                                    
-                                                                                    <div class="json-inner-schema">
-                                                                                        
-                                                                                    </div>
-                                                                                </dd>
-                                                                                <dt data-property-name="filepath">
-                                                                                    <span class="json-property-name">filepath:</span>
-                                                                                    
-                                                                                    <span class="json-property-type">string</span>
-                                                                                    <span class="json-property-range" title="Value limits"></span>
-                                                                                    
-                                                                                </dt>
-                                                                                <dd>
-                                                                                    <p>If present, this is a single <em>GoTo response</em> and this value
-                                                                    contains the absolute path of the buffer containing the
-                                                                    target location (identified in <code>line_num</code> and <code>column_num</code>).</p>
-                                                                    
-                                                                                    <div class="json-inner-schema">
-                                                                                        
-                                                                                    </div>
-                                                                                </dd>
-                                                                                <dt data-property-name="line_num">
-                                                                                    <span class="json-property-name">line_num:</span>
-                                                                                    
-                                                                                    <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/LineNumber">LineNumber</a>
-                                                                                    </span>
-                                                                                    <span class="json-property-range" title="Value limits"></span>
-                                                                                    
-                                                                                </dt>
-                                                                                <dd>
-                                                                                    
-                                                                                    <div class="json-inner-schema">
-                                                                                        
-                                                                                    </div>
-                                                                                </dd>
-                                                                                <dt data-property-name="column_num">
-                                                                                    <span class="json-property-name">column_num:</span>
-                                                                                    
-                                                                                    <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/ColumnNumber">ColumnNumber</a>
-                                                                                    </span>
-                                                                                    <span class="json-property-range" title="Value limits"></span>
-                                                                                    
-                                                                                </dt>
-                                                                                <dd>
-                                                                                    
-                                                                                    <div class="json-inner-schema">
-                                                                                        
-                                                                                    </div>
-                                                                                </dd>
-                                                                        </dl>
-                                                                    </section>
+                                                                <a class="json-schema-ref" href="#/definitions/SubcommandResponse">SubcommandResponse</a>
                                                     </div>
                                                 </div></div>
                                             
@@ -3541,6 +3588,21 @@
                                                         
                                                     </div>
                                                 </dd>
+                                                <dt data-property-name="resolve">
+                                                    <span class="json-property-name">resolve:</span>
+                                                    
+                                                    <span class="json-property-type">boolean</span>
+                                                    <span class="json-property-range" title="Value limits"></span>
+                                                    
+                                                        <span class="json-property-required"></span>
+                                                </dt>
+                                                <dd>
+                                                    <p>Indicates wether the fixit requires additional processing.</p>
+                                    
+                                                    <div class="json-inner-schema">
+                                                        
+                                                    </div>
+                                                </dd>
                                                 <dt data-property-name="chunks">
                                                     <span class="json-property-name">chunks:</span>
                                                     
@@ -4193,6 +4255,160 @@
                                                 </dt>
                                                 <dd>
                                                     
+                                                    <div class="json-inner-schema">
+                                                        
+                                                    </div>
+                                                </dd>
+                                        </dl>
+                                    </section>
+                    </div>
+                </div>        
+                <div id="definition-SubcommandResponse" class="panel panel-definition">
+                        <div class="panel-heading">
+                                <h3 class="panel-title"><a name="/definitions/SubcommandResponse"></a>SubcommandResponse:
+                                    <span class="json-property-type">
+                <span class="json-property-type">object</span>
+                <span class="json-property-range" title="Value limits"></span>
+                
+                </span>
+                                </h3>
+                        </div>
+                    <div class="panel-body">
+                            
+                                    <section class="json-schema-properties">
+                                        <dl>
+                                                <dt data-property-name="fixits">
+                                                    <span class="json-property-name">fixits:</span>
+                                                    
+                                                    <span class="json-property-type">object[]</span>
+                                                    <span class="json-property-range" title="Value limits"></span>
+                                                    
+                                                </dt>
+                                                <dd>
+                                                    <p>If present, this is a <em>FixIt</em> or <em>Refactor</em> response and the
+                                    value of this property is a list of potential changes to
+                                    buffers to apply the quick fix or refactoring operation.</p>
+                                    <p>An empty <code>fixits</code> list means that no FixIt or refactoring
+                                    was available. If multiple entries are supplied, the user is
+                                    prompted to select which one to apply.</p>
+                                    
+                                                    <div class="json-inner-schema">
+                                                        
+                                                                        <section class="json-schema-array-items">
+                                                                            
+                                                                            <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/FixIt">FixIt</a>
+                                                                            </span>
+                                                                            <span class="json-property-range" title="Value limits"></span>
+                                                                            
+                                                                            <div class="json-inner-schema">
+                                                                                
+                                                                            </div>
+                                                                        </section>                </div>
+                                                </dd>
+                                                <dt data-property-name="message">
+                                                    <span class="json-property-name">message:</span>
+                                                    
+                                                    <span class="json-property-type">string</span>
+                                                    <span class="json-property-range" title="Value limits"></span>
+                                                    
+                                                </dt>
+                                                <dd>
+                                                    <p>If present, this is a <em>simple display message</em> and the value
+                                    of this property is the message to display.</p>
+                                    
+                                                    <div class="json-inner-schema">
+                                                        
+                                                    </div>
+                                                </dd>
+                                                <dt data-property-name="detailed_info">
+                                                    <span class="json-property-name">detailed_info:</span>
+                                                    
+                                                    <span class="json-property-type">string</span>
+                                                    <span class="json-property-range" title="Value limits"></span>
+                                                    
+                                                </dt>
+                                                <dd>
+                                                    <p>If present, this is a <em>detailed information</em> response and
+                                    the value of this property is the multi-line information
+                                    to display as unformatted plain text.</p>
+                                    
+                                                    <div class="json-inner-schema">
+                                                        
+                                                    </div>
+                                                </dd>
+                                                <dt data-property-name="filepath">
+                                                    <span class="json-property-name">filepath:</span>
+                                                    
+                                                    <span class="json-property-type">string</span>
+                                                    <span class="json-property-range" title="Value limits"></span>
+                                                    
+                                                </dt>
+                                                <dd>
+                                                    <p>If present, this is a single <em>GoTo response</em> and this value
+                                    contains the absolute path of the buffer containing the
+                                    target location (identified in <code>line_num</code> and <code>column_num</code>).</p>
+                                    
+                                                    <div class="json-inner-schema">
+                                                        
+                                                    </div>
+                                                </dd>
+                                                <dt data-property-name="line_num">
+                                                    <span class="json-property-name">line_num:</span>
+                                                    
+                                                    <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/LineNumber">LineNumber</a>
+                                                    </span>
+                                                    <span class="json-property-range" title="Value limits"></span>
+                                                    
+                                                </dt>
+                                                <dd>
+                                                    
+                                                    <div class="json-inner-schema">
+                                                        
+                                                    </div>
+                                                </dd>
+                                                <dt data-property-name="column_num">
+                                                    <span class="json-property-name">column_num:</span>
+                                                    
+                                                    <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/ColumnNumber">ColumnNumber</a>
+                                                    </span>
+                                                    <span class="json-property-range" title="Value limits"></span>
+                                                    
+                                                </dt>
+                                                <dd>
+                                                    
+                                                    <div class="json-inner-schema">
+                                                        
+                                                    </div>
+                                                </dd>
+                                        </dl>
+                                    </section>
+                    </div>
+                </div>        
+                <div id="definition-UnresolvedFixIt" class="panel panel-definition">
+                        <div class="panel-heading">
+                                <h3 class="panel-title"><a name="/definitions/UnresolvedFixIt"></a>UnresolvedFixIt:
+                                    <span class="json-property-type">
+                <span class="json-property-type">object</span>
+                <span class="json-property-range" title="Value limits"></span>
+                
+                </span>
+                                </h3>
+                        </div>
+                    <div class="panel-body">
+                            
+                                    <section class="json-schema-properties">
+                                        <dl>
+                                                <dt data-property-name="resolve">
+                                                    <span class="json-property-name">resolve:</span>
+                                                    
+                                                    <span class="json-property-type">boolean</span>
+                                                    <span class="json-property-range" title="Value limits"></span>
+                                                    
+                                                        <span class="json-property-required"></span>
+                                                </dt>
+                                                <dd>
+                                                    <p>Indicates wether the fixit requires additional processing.</p>
+                                    
                                                     <div class="json-inner-schema">
                                                         
                                                     </div>

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -335,10 +335,58 @@ definitions:
     items:
       $ref: "#/definitions/DiagnosticData"
 
+  SubcommandResponse:
+    type: object
+    properties:
+      fixits:
+        type: array
+        description: |-
+          If present, this is a *FixIt* or *Refactor* response and the
+          value of this property is a list of potential changes to
+          buffers to apply the quick fix or refactoring operation.
+
+          An empty `fixits` list means that no FixIt or refactoring
+          was available. If multiple entries are supplied, the user is
+          prompted to select which one to apply.
+        items:
+          $ref: "#/definitions/FixIt"
+        minItems: 0
+      message:
+        type: string
+        description: |-
+          If present, this is a *simple display message* and the value
+          of this property is the message to display.
+      detailed_info:
+        type: string
+        description: |-
+          If present, this is a *detailed information* response and
+          the value of this property is the multi-line information
+          to display as unformatted plain text.
+      filepath:
+        type: string
+        description: |-
+          If present, this is a single *GoTo response* and this value
+          contains the absolute path of the buffer containing the
+          target location (identified in `line_num` and `column_num`).
+      line_num:
+        $ref: "#/definitions/LineNumber"
+      column_num:
+        $ref: "#/definitions/ColumnNumber"
+
+  UnresolvedFixIt:
+    type: object
+    required:
+      - resolve
+    properties:
+      resolve:
+        type: boolean
+        description: |-
+          Indicates wether the fixit requires additional processing.
   FixIt:
     type: object
     required:
       - location
+      - resolve
       - chunks
     properties:
       text:
@@ -349,6 +397,10 @@ definitions:
           available FixIts.
       location:
         $ref: "#/definitions/Location"
+      resolve:
+        type: boolean
+        description: |-
+          Indicates wether the fixit requires additional processing.
       chunks:
         type: array
         description: |-
@@ -824,43 +876,7 @@ paths:
                     items in the list are of type `GoToLocations`
                     (see definitions).
           schema:
-            type: object
-            properties:
-              fixits:
-                type: array
-                description: |-
-                  If present, this is a *FixIt* or *Refactor* response and the
-                  value of this property is a list of potential changes to
-                  buffers to apply the quick fix or refactoring operation.
-
-                  An empty `fixits` list means that no FixIt or refactoring
-                  was available. If multiple entries are supplied, the user is
-                  prompted to select which one to apply.
-                items:
-                  $ref: "#/definitions/FixIt"
-                maxItems: 1
-                minItems: 0
-              message:
-                type: string
-                description: |-
-                  If present, this is a *simple display message* and the value
-                  of this property is the message to display.
-              detailed_info:
-                type: string
-                description: |-
-                  If present, this is a *detailed information* response and
-                  the value of this property is the multi-line information
-                  to display as unformatted plain text.
-              filepath:
-                type: string
-                description: |-
-                  If present, this is a single *GoTo response* and this value
-                  contains the absolute path of the buffer containing the
-                  target location (identified in `line_num` and `column_num`).
-              line_num:
-                $ref: "#/definitions/LineNumber"
-              column_num:
-                $ref: "#/definitions/ColumnNumber"
+            $ref: "#/definitions/SubcommandResponse"
         500:
           description: An error occurred.
           schema:
@@ -1497,5 +1513,58 @@ paths:
                     fixit_available: true
         500:
           description: An error occurred.
+          schema:
+            $ref: "#/definitions/ExceptionResponse"
+  /resolve_fixit:
+    post:
+      summary: Resolve an incomplete FixIt.
+      description: |-
+        Resolves an incomplete fixit, indicated by `'resolve'` fixit property.
+        Some completers return incomplete fixits in order to avoid blocking on
+        expensive fixit calculations.
+
+        When a client wishes to resolve a fixit, the entire `FixIt` object
+        should be sent in the `fixit` property.
+
+        If a client tries to resolve an already resolved fixit, the same fixit
+        is returned in a SubcommandResponse.
+      produces:
+        application/json
+      parameters:
+        - name: request_data
+          in: body
+          description: |-
+            The context data, including the current cursor position, and details
+            of dirty buffers.
+          required: true
+          schema:
+            type: object
+            required:
+              - filepath
+              - file_data
+              - fixit
+            properties:
+              filepath:
+                $ref: "#/definitions/FilePath"
+              file_data:
+                $ref: "#/definitions/FileDataMap"
+              fixit:
+                $ref: "#/definitions/FixIt"
+            example:
+              filepath: "/home/test/dev/test.c"
+              file_data:
+                "/home/test/dev/test.c":
+                  filetypes: [ 'c' ]
+                  contents: "<file contents>"
+              fixit:
+                $ref: "#/definitions/UnresolvedFixIt"
+      responses:
+        200:
+          description: |-
+            The fixit has been resolved and a FixIt response is returned.
+          schema:
+            $ref: "#/definitions/SubcommandResponse"
+        500:
+          description: An error occured
           schema:
             $ref: "#/definitions/ExceptionResponse"

--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -175,6 +175,9 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
     - something which calls self._signature_triggers.SetServerTriggerCharacters
     - ComputeSignaturesInner
   See the language_server_completer or Python completers for examples.
+
+  If your server returns lists of "code actions" that need to be resolved,
+  instead of returning FixIts right away, you should override ResolveFixit.
   """
 
   def __init__( self, user_options ):
@@ -338,6 +341,10 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
              empty.
     """
     return {}
+
+
+  def ResolveFixit( self, request_data ):
+    return { 'fixits': [ request_data[ 'fixit' ] ] }
 
 
   def UserCommandsHelpMessage( self ):

--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -351,6 +351,9 @@ class ClangdCompleter( simple_language_server_completer.SimpleLSPCompleter ):
         command[ 'arguments' ][ 0 ],
         text = command[ 'title' ] )
 
+    if command[ 'command' ] == 'clangd.applyTweak':
+      return responses.UnresolvedFixIt( command, command[ 'title' ] )
+
     return None
 
 

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -738,14 +738,15 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
 
 
   def OrganizeImports( self, request_data ):
-    workspace_edit = self.GetCommandResponse(
-      request_data,
-      'java.edit.organizeImports',
-      [ lsp.FilePathToUri( request_data[ 'filepath' ] ) ] )
-
-    fixit = language_server_completer.WorkspaceEditToFixIt( request_data,
-                                                            workspace_edit )
-    return responses.BuildFixItResponse( [ fixit ] )
+    fixit = {
+      'resolve': True,
+      'command': {
+        'title': 'Organize Imports',
+        'command': 'java.edit.organizeImports',
+        'arguments': [ lsp.FilePathToUri( request_data[ 'filepath' ] ) ]
+      }
+    }
+    return self._ResolveFixit( request_data, fixit )
 
 
   def HandleServerCommand( self, request_data, command ):

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -242,6 +242,7 @@ def Initialize( request_id, project_directory, settings ):
     'rootUri': FilePathToUri( project_directory ),
     'initializationOptions': settings,
     'capabilities': {
+      'workspace': { 'applyEdit': True },
       'textDocument': {
         'completion': {
           'completionItemKind': {
@@ -300,6 +301,18 @@ def Reject( request, request_error, data = None ):
     msg[ 'error' ][ 'data' ] = data
 
   return BuildResponse( request, msg )
+
+
+def Accept( request, result ):
+  msg = {
+    'result': result
+  }
+  return BuildResponse( request, msg )
+
+
+def ApplyEditResponse( request ):
+  msg = { 'applied': True }
+  return Accept( request, msg )
 
 
 def DidChangeConfiguration( config ):

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -102,6 +102,15 @@ def RunCompleterCommand():
       request_data ) )
 
 
+@app.post( '/resolve_fixit' )
+def ResolveFixit():
+  LOGGER.info( 'Received resolve_fixit request' )
+  request_data = RequestWrap( request.json )
+  completer = _GetCompleterForRequestData( request_data )
+
+  return _JsonResponse( completer.ResolveFixit( request_data ) )
+
+
 @app.post( '/completions' )
 def GetCompletions():
   LOGGER.info( 'Received completion request' )

--- a/ycmd/request_wrap.py
+++ b/ycmd/request_wrap.py
@@ -93,7 +93,7 @@ class RequestWrap( object ):
 
       'lines': ( self._CurrentLines, None ),
 
-      'extra_conf_data': ( self._GetExtraConfData, None )
+      'extra_conf_data': ( self._GetExtraConfData, None ),
     }
     self._cached_computed = {}
 

--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -186,6 +186,13 @@ class Diagnostic( object ):
     self.fixits_ = fixits
 
 
+class UnresolvedFixIt( object ):
+  def __init__( self, command, text ):
+    self.command = command
+    self.text = text
+    self.resolve = True
+
+
 class FixIt( object ):
   """A set of replacements (of type FixItChunk) to be applied to fix a single
   diagnostic. This can be used for any type of refactoring command, not just
@@ -287,11 +294,19 @@ def BuildFixItResponse( fixits ):
     }
 
   def BuildFixItData( fixit ):
-    return {
-      'location': BuildLocationData( fixit.location ),
-      'chunks' : [ BuildFixitChunkData( x ) for x in fixit.chunks ],
-      'text': fixit.text,
-    }
+    if hasattr( fixit, 'resolve' ):
+      return {
+        'command': fixit.command,
+        'text': fixit.text,
+        'resolve': fixit.resolve
+      }
+    else:
+      return {
+        'location': BuildLocationData( fixit.location ),
+        'chunks' : [ BuildFixitChunkData( x ) for x in fixit.chunks ],
+        'text': fixit.text,
+        'resolve': False
+      }
 
   return {
     'fixits' : [ BuildFixItData( x ) for x in fixits ]

--- a/ycmd/tests/clangd/testdata/FixIt_Clang_cpp11.cpp
+++ b/ycmd/tests/clangd/testdata/FixIt_Clang_cpp11.cpp
@@ -71,3 +71,15 @@ namespace Typo {
 void typo() {
   Typo::SpellingIsNotMyStringPiont *p;
 }
+
+
+int foo(int);
+
+#define DECLARE_INT(name) int name
+
+auto to_raw_str = "\\\\r\\asd\n\\v";
+
+int bar() {
+  DECLARE_INT(i) = 4;
+  return foo( i + 3 );
+}

--- a/ycmd/tests/rust/subcommands_test.py
+++ b/ycmd/tests/rust/subcommands_test.py
@@ -94,6 +94,14 @@ def RunTest( app, test, contents = None ):
                equal_to( test[ 'expect' ][ 'response' ] ) )
   assert_that( response.json, test[ 'expect' ][ 'data' ] )
 
+  if test.get( 'run_resolve_fixit_test', False ):
+    fixit = response.json[ 'fixits' ][ 0 ]
+    response = app.post_json(
+      '/resolve_fixit',
+      CombineRequest( test[ 'request' ], { 'fixit': fixit } ) ).json
+    assert_that( response, has_entries( {
+      'fixits': contains( fixit ) } ) )
+
 
 @SharedYcmd
 def Subcommands_DefinedSubcommands_test( app ):
@@ -516,7 +524,8 @@ def Subcommands_FixIt_ApplySuggestion_test( app ):
           )
         } ) )
       } )
-    }
+    },
+    'run_resolve_fixit_test': True
   } )
 
 


### PR DESCRIPTION
When making an `executeCommand` request, a LSP server might in exchange
send a series of "things", which we expect to be `applyEdit` requests.

We then store those requests in a list until the LSP server responds to
the original `executeCommand` and finally let the specific LSP completer
implementation figure out what to do with those unconsumed `applyEdit`s.

This allows ycmd to forward an incomplete `codeAction` from clangd to a
client in order to save time computing expensive `codeActions`.

The exchange should look like this:

- A client makes a `FixIt` request.
- ycmd makes a `codeAction` request to clangd.
- clangd responds with a mix of resolved and unresolved code actions.
- ycmd transforms resolved code actions in `FixIts` and forwards
unresolved ones.
- A client lets a user choose a fixit from the list.
- If the chosen fixit is unresolved, the client sends a /resolve_fixit
request.
- ycmd executes LSP server specific logic to resolve the fixit and
responds with another `FixItResponse`.
- In case of clangd, the server specific logic is:
  - Make the appropriate `executeCommand` request.
  - Store the received `applyEdit`.
  - Turn the `applyEdit` into a ycmd `FixIt`.
  - Send a `FixItResponse` to the client.

Open questions:

- ~~Should `ResolveFixit` in `ClangdCompleter` be moved to
`SimpleLSPCompleter` or even `LanguageServerCompleter`?~~
- ~~How should "stray" `applyEdit`s be drained?~~
- ~~What if an `executeCommand` triggers server-to-client requests other
than `applyEdit`?~~
- ~~@puremourning mentioned `codeActionLiteralSupport` capability, but I'm not sure what is that supposed to do.~~
- ~~Should we advertise `applyEdit` capability?~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1338)
<!-- Reviewable:end -->
