### PR TITLE
Allow user configuration of Format subcommand for JDT completer

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,23 @@ def Settings( **kwargs ):
   }
 ```
 
+##### Java settings
+
+[The java subserver][jdtls] allows [formatter configuration][jdt-formatter],
+but it expects the configuration to be supplied in a different way than the rest.
+For this purpose the `Settings` function can return a `formatter` property.
+
+An example of the formatter configuration would be:
+
+```python
+def Settings( **kwargs ):
+  return {
+    'formatting_options': {
+       'org.eclipse.jdt.core.formatter.lineSplit': 30, 
+    }
+  }
+```
+
 ##### Python settings
 
 The `Settings` function allows users to specify the Python interpreter and
@@ -475,6 +492,7 @@ This software is licensed under the [GPL v3 license][gpl].
 [gycm]: https://github.com/jakeanq/gycm
 [nano-ycmd]: https://github.com/orsonteodoro/nano-ycmd
 [jdtls]: https://github.com/eclipse/eclipse.jdt.ls
+[jdt-formatter]: https://github.com/eclipse/eclipse.jdt.ls/blob/master/org.eclipse.jdt.ls.core/.settings/org.eclipse.jdt.core.prefs
 [api-docs]: https://ycm-core.github.io/ycmd/
 [ycmd-extra-conf]: https://github.com/ycm-core/ycmd/blob/master/.ycm_extra_conf.py
 [clangd]: https://clang.llvm.org/extra/clangd.html

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1851,6 +1851,15 @@ class LanguageServerCompleter( Completer ):
     return responses.BuildFixItResponse( [ fixit ] )
 
 
+  def AdditionalFormattingOptions( self, request_data ):
+    module = extra_conf_store.ModuleForSourceFile( request_data[ 'filepath' ] )
+    try:
+      settings = self.GetSettings( module, request_data )
+      return settings.get( 'formatting_options', {} )
+    except AttributeError:
+      return {}
+
+
   def Format( self, request_data ):
     """Issues the formatting or rangeFormatting request (depending on the
     presence of a range) and returns the result as a FixIt response."""
@@ -1859,6 +1868,8 @@ class LanguageServerCompleter( Completer ):
 
     self._UpdateServerWithFileContents( request_data )
 
+    request_data[ 'options' ].update(
+      self.AdditionalFormattingOptions( request_data ) )
     request_id = self.GetConnection().NextRequestId()
     if 'range' in request_data:
       message = lsp.RangeFormatting( request_id, request_data )

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -449,10 +449,12 @@ def RangeFormatting( request_id, request_data ):
 
 def FormattingOptions( request_data ):
   options = request_data[ 'options' ]
-  return {
-    'tabSize': options[ 'tab_size' ],
-    'insertSpaces': options[ 'insert_spaces' ]
+  format_options = {
+    'tabSize': options.pop( 'tab_size' ),
+    'insertSpaces': options.pop( 'insert_spaces' )
   }
+  format_options.update( options )
+  return format_options
 
 
 def Range( request_data ):

--- a/ycmd/tests/java/subcommands_test.py
+++ b/ycmd/tests/java/subcommands_test.py
@@ -1908,6 +1908,85 @@ def Subcommands_ExtraConf_SettingsValid_test( app ):
 
 
 @WithRetry
+@IsolatedYcmd( { 'extra_conf_globlist':
+                 PathToTestFile( 'extra_confs', '*' ) } )
+def Subcommands_AdditionalFormatterOptions_test( app ):
+  filepath = PathToTestFile( 'extra_confs',
+                             'simple_extra_conf_project',
+                             'src',
+                             'ExtraConf.java' )
+  RunTest( app, {
+    'description': 'Format respects settings from extra conf.',
+    'request': {
+      'command': 'Format',
+      'filepath': filepath,
+      'options': {
+        'tab_size': 4,
+        'insert_spaces': True
+      }
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'fixits': contains( has_entries( {
+          'chunks': contains(
+            ChunkMatcher( '\n    ',
+                          LocationMatcher( filepath,  1, 18 ),
+                          LocationMatcher( filepath,  2,  3 ) ),
+            ChunkMatcher( '\n            ',
+                          LocationMatcher( filepath,  2, 20 ),
+                          LocationMatcher( filepath,  2, 21 ) ),
+            ChunkMatcher( '',
+                          LocationMatcher( filepath,  2, 29 ),
+                          LocationMatcher( filepath,  2, 30 ) ),
+            ChunkMatcher( '\n    ',
+                          LocationMatcher( filepath,  2, 33 ),
+                          LocationMatcher( filepath,  2, 33 ) ),
+            ChunkMatcher( '\n\n    ',
+                          LocationMatcher( filepath,  2, 34 ),
+                          LocationMatcher( filepath,  4,  3 ) ),
+            ChunkMatcher( '\n            ',
+                          LocationMatcher( filepath,  4, 27 ),
+                          LocationMatcher( filepath,  4, 28 ) ),
+            ChunkMatcher( '',
+                          LocationMatcher( filepath,  4, 41 ),
+                          LocationMatcher( filepath,  4, 42 ) ),
+            ChunkMatcher( '\n        ',
+                          LocationMatcher( filepath,  4, 45 ),
+                          LocationMatcher( filepath,  5,  5 ) ),
+            ChunkMatcher( '\n                ',
+                          LocationMatcher( filepath,  5, 33 ),
+                          LocationMatcher( filepath,  5, 34 ) ),
+            ChunkMatcher( '',
+                          LocationMatcher( filepath,  5, 36 ),
+                          LocationMatcher( filepath,  5, 37 ) ),
+            ChunkMatcher( '\n        ',
+                          LocationMatcher( filepath,  5, 39 ),
+                          LocationMatcher( filepath,  6,  5 ) ),
+            ChunkMatcher( '\n                ',
+                          LocationMatcher( filepath,  6, 33 ),
+                          LocationMatcher( filepath,  6, 34 ) ),
+            ChunkMatcher( '',
+                          LocationMatcher( filepath,  6, 35 ),
+                          LocationMatcher( filepath,  6, 36 ) ),
+            ChunkMatcher( '\n        ',
+                          LocationMatcher( filepath,  6, 38 ),
+                          LocationMatcher( filepath,  7,  5 ) ),
+            ChunkMatcher( '\n        ',
+                          LocationMatcher( filepath,  7, 11 ),
+                          LocationMatcher( filepath,  8,  5 ) ),
+            ChunkMatcher( '\n    ',
+                          LocationMatcher( filepath,  8, 11 ),
+                          LocationMatcher( filepath,  9,  3 ) ),
+          ),
+          'location': LocationMatcher( filepath, 1, 1 )
+        } ) )
+      } )
+    }
+  } )
+
+
+@WithRetry
 @IsolatedYcmd()
 def Subcommands_ExtraConf_SettingsValid_UnknownExtraConf_test( app ):
   filepath = PathToTestFile( 'extra_confs',

--- a/ycmd/tests/java/testdata/extra_confs/.ycm_extra_conf.py
+++ b/ycmd/tests/java/testdata/extra_confs/.ycm_extra_conf.py
@@ -1,2 +1,5 @@
 def Settings( **kwargs ):
-    return { 'ls': { 'java.rename.enabled' : False } }
+    return {
+      'ls': { 'java.rename.enabled' : False },
+      'formatting_options': { 'org.eclipse.jdt.core.formatter.lineSplit': 30, }
+    }


### PR DESCRIPTION
fixes ycm-core/YouCompleteMe#3505

I also considered just letting every LSP completer do this kind of configuration. For that I'd like to check if and how are other LSP servers configured.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1339)
<!-- Reviewable:end -->
