### PR TITLE
Python: implement signature help

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1641,7 +1641,7 @@ class LanguageServerCompleter( Completer ):
     return server_trigger_characters
 
 
-  def _GetSignatureTriggerCharacters( self, server_trigger_characters ):
+  def GetSignatureTriggerCharacters( self, server_trigger_characters ):
     """Same as _GetTriggerCharacters but for signature help."""
     return server_trigger_characters
 
@@ -1703,7 +1703,7 @@ class LanguageServerCompleter( Completer ):
                       self.Language(),
                       server_trigger_characters )
 
-        trigger_characters = self._GetSignatureTriggerCharacters(
+        trigger_characters = self.GetSignatureTriggerCharacters(
           server_trigger_characters )
 
         if trigger_characters:

--- a/ycmd/tests/python/signature_help_test.py
+++ b/ycmd/tests/python/signature_help_test.py
@@ -1,0 +1,275 @@
+# coding: utf-8
+#
+# Copyright (C) 2019 ycmd contributors
+#
+# This file is part of ycmd.
+#
+# ycmd is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ycmd is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+# Not installing aliases from python-future; it's unreliable and slow.
+from builtins import *  # noqa
+
+from nose.tools import eq_
+from hamcrest import ( assert_that,
+                       contains,
+                       empty,
+                       has_entries )
+import requests
+
+from ycmd.utils import ReadFile
+from ycmd.tests.python import PathToTestFile, SharedYcmd
+from ycmd.tests.test_utils import ( CombineRequest,
+                                    ParameterMatcher,
+                                    SignatureMatcher,
+                                    SignatureAvailableMatcher )
+
+
+def RunTest( app, test ):
+  """
+  Method to run a simple signature help test and verify the result
+
+  test is a dictionary containing:
+    'request': kwargs for BuildRequest
+    'expect': {
+       'response': server response code (e.g. httplib.OK)
+       'data': matcher for the server response json
+    }
+  """
+  contents = ReadFile( test[ 'request' ][ 'filepath' ] )
+
+  app.post_json( '/event_notification',
+                 CombineRequest( test[ 'request' ], {
+                                 'event_name': 'FileReadyToParse',
+                                 'contents': contents,
+                                 } ),
+                 expect_errors = True )
+
+  # We ignore errors here and we check the response code ourself.
+  # This is to allow testing of requests returning errors.
+  response = app.post_json( '/signature_help',
+                            CombineRequest( test[ 'request' ], {
+                              'contents': contents
+                            } ),
+                            expect_errors = True )
+
+  eq_( response.status_code, test[ 'expect' ][ 'response' ] )
+
+  assert_that( response.json, test[ 'expect' ][ 'data' ] )
+
+
+@SharedYcmd
+def Signature_Help_Available_test( app ):
+  response = app.get( '/signature_help_available',
+                      { 'subserver': 'python' } ).json
+  assert_that( response, SignatureAvailableMatcher( 'YES' ) )
+
+
+@SharedYcmd
+def SignatureHelp_MethodTrigger_test( app ):
+  RunTest( app, {
+    'description': 'Trigger after (',
+    'request': {
+      'filetype'  : 'python',
+      'filepath'  : PathToTestFile( 'general_fallback',
+                                    'lang_python.py' ),
+      'line_num'  : 6,
+      'column_num': 10,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'errors': empty(),
+        'signature_help': has_entries( {
+          'activeSignature': 0,
+          'activeParameter': 0,
+          'signatures': contains(
+            SignatureMatcher( 'def hack( obj )',
+                              [ ParameterMatcher( 10, 13 ) ] )
+          ),
+        } ),
+      } )
+    }
+  } )
+
+
+@SharedYcmd
+def SignatureHelp_MultipleParameters_test( app ):
+  RunTest( app, {
+    'description': 'Trigger after ,',
+    'request': {
+      'filetype'  : 'python',
+      'filepath'  : PathToTestFile( 'signature_help.py' ),
+      'line_num'  : 14,
+      'column_num': 50,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'errors': empty(),
+        'signature_help': has_entries( {
+          'activeSignature': 0,
+          'activeParameter': 1,
+          'signatures': contains(
+            SignatureMatcher( 'def MultipleArguments( a, b, c )',
+                              [ ParameterMatcher( 23, 24 ),
+                                ParameterMatcher( 26, 27 ),
+                                ParameterMatcher( 29, 30 ) ] )
+          ),
+        } ),
+      } )
+    }
+  } )
+
+
+@SharedYcmd
+def SignatureHelp_CallWithinCall_test( app ):
+  RunTest( app, {
+    'description': 'Trigger after , within a call-within-a-call',
+    'request': {
+      'filetype'  : 'python',
+      'filepath'  : PathToTestFile( 'signature_help.py' ),
+      'line_num'  : 14,
+      'column_num': 43,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'errors': empty(),
+        'signature_help': has_entries( {
+          'activeSignature': 0,
+          'activeParameter': 1,
+          'signatures': contains(
+            SignatureMatcher( 'def center( width: int, fillchar: str=... )',
+                              [ ParameterMatcher( 12, 22 ),
+                                ParameterMatcher( 24, 41 ) ] )
+          ),
+        } ),
+      } )
+    }
+  } )
+
+
+@SharedYcmd
+def SignatureHelp_Constructor_test( app ):
+  RunTest( app, {
+    'description': 'Trigger after , within a call-within-a-call',
+    'request': {
+      'filetype'  : 'python',
+      'filepath'  : PathToTestFile( 'signature_help.py' ),
+      'line_num'  : 14,
+      'column_num': 61,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'errors': empty(),
+        'signature_help': has_entries( {
+          'activeSignature': 0,
+          'activeParameter': 0,
+          'signatures': contains(
+            SignatureMatcher( 'class Class( argument )',
+                              [ ParameterMatcher( 13, 21 ) ] )
+          ),
+        } ),
+      } )
+    }
+  } )
+
+
+@SharedYcmd
+def SignatureHelp_MultipleDefinitions_test( app ):
+  RunTest( app, {
+    'description': 'Jedi returns multiple signatures - both active',
+    'request': {
+      'filetype'  : 'python',
+      'filepath'  : PathToTestFile( 'signature_help.py' ),
+      'line_num'  : 30,
+      'column_num': 27,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'errors': empty(),
+        'signature_help': has_entries( {
+          'activeSignature': 0,
+          'activeParameter': 2,
+          'signatures': contains(
+            SignatureMatcher( 'def MultipleDefinitions( a, b, c )',
+                              [ ParameterMatcher( 25, 26 ),
+                                ParameterMatcher( 28, 29 ),
+                                ParameterMatcher( 31, 32 ) ] ),
+
+            SignatureMatcher( 'def MultipleDefinitions( many,'
+                                                      ' more,'
+                                                      ' arguments,'
+                                                      ' to,'
+                                                      ' this,'
+                                                      ' one )',
+                              [ ParameterMatcher( 25, 29 ),
+                                ParameterMatcher( 31, 35 ),
+                                ParameterMatcher( 37, 46 ),
+                                ParameterMatcher( 48, 50 ),
+                                ParameterMatcher( 52, 56 ),
+                                ParameterMatcher( 58, 61 ) ] )
+          ),
+        } ),
+      } )
+    }
+  } )
+
+
+@SharedYcmd
+def SignatureHelp_MultipleDefinitions_OneActive_test( app ):
+  RunTest( app, {
+    'description': 'Jedi returns multiple signatures - both active',
+    'request': {
+      'filetype'  : 'python',
+      'filepath'  : PathToTestFile( 'signature_help.py' ),
+      'line_num'  : 30,
+      'column_num': 30,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'errors': empty(),
+        'signature_help': has_entries( {
+          'activeSignature': 1,
+          'activeParameter': 3,
+          'signatures': contains(
+            SignatureMatcher( 'def MultipleDefinitions( a, b, c )',
+                              [ ParameterMatcher( 25, 26 ),
+                                ParameterMatcher( 28, 29 ),
+                                ParameterMatcher( 31, 32 ) ] ),
+
+            SignatureMatcher( 'def MultipleDefinitions( many,'
+                                                      ' more,'
+                                                      ' arguments,'
+                                                      ' to,'
+                                                      ' this,'
+                                                      ' one )',
+                              [ ParameterMatcher( 25, 29 ),
+                                ParameterMatcher( 31, 35 ),
+                                ParameterMatcher( 37, 46 ),
+                                ParameterMatcher( 48, 50 ),
+                                ParameterMatcher( 52, 56 ),
+                                ParameterMatcher( 58, 61 ) ] )
+          ),
+        } ),
+      } )
+    }
+  } )

--- a/ycmd/tests/python/testdata/signature_help.py
+++ b/ycmd/tests/python/testdata/signature_help.py
@@ -1,0 +1,33 @@
+def MultipleArguments( a, b, c ):
+  pass
+
+
+def KeywordArguments( d, e, *args, **kwargs ):
+  pass
+
+
+class Class( object ):
+  def __init__( self, argument ):
+    self.Method()
+    self.MultipleArgumentsMethod( argument )
+    KeywordArguments( 1, 2, 4, 5, test=6 )
+    MultipleArguments( 'test'.center( 100, ' ' ), 10, Class( 10 ) )
+
+  def Method( self ):
+    pass
+
+  def MultipleArgumentsMethod( self, this_is_an_argument ):
+    pass
+
+
+if something:
+  def MultipleDefinitions( many, more, arguments, to, this, one ):
+    pass
+else:
+  def MultipleDefinitions( a, b, c ):
+    pass
+
+MultipleDefinitions( 1, 2, 3, 4,
+
+
+


### PR DESCRIPTION
We use the Jedi API [`call_signatures`](https://jedi.readthedocs.io/en/latest/docs/api.html#jedi.Script.call_signatures) for this.

We require some code to:

* Generate a signature string that makes sense to users (the call_signatures returns just the [metadata](https://jedi.readthedocs.io/en/latest/docs/api-classes.html#jedi.api.classes.CallSignature)). 
* Some stuff to work out what that means for parameters in terms of offsets (in bytes) into the resulting string
* Working out the active signature and parameter (using [index](https://jedi.readthedocs.io/en/latest/docs/api-classes.html#jedi.api.classes.CallSignature.index))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1344)
<!-- Reviewable:end -->
