### PR TITLE
[READY] Respect completion capability of LSP servers

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -802,6 +802,7 @@ class LanguageServerCompleter( Completer ):
       self._initialize_event = threading.Event()
       self._on_initialize_complete_handlers = []
       self._server_capabilities = None
+      self._is_completion_provider = False
       self._resolve_completion_items = False
       self._project_directory = None
       self._settings = {}
@@ -899,7 +900,7 @@ class LanguageServerCompleter( Completer ):
 
 
   def ComputeCandidatesInner( self, request_data, codepoint ):
-    if not self._ServerIsInitialized():
+    if not self._is_completion_provider:
       return None, False
 
     self._UpdateServerWithFileContents( request_data )
@@ -1666,6 +1667,9 @@ class LanguageServerCompleter( Completer ):
     with self._server_info_mutex:
       self._server_capabilities = response[ 'result' ][ 'capabilities' ]
       self._resolve_completion_items = self._ShouldResolveCompletionItems()
+
+      self._is_completion_provider = (
+          'completionProvider' in self._server_capabilities )
 
       if 'textDocumentSync' in self._server_capabilities:
         sync = self._server_capabilities[ 'textDocumentSync' ]

--- a/ycmd/tests/java/get_completions_test.py
+++ b/ycmd/tests/java/get_completions_test.py
@@ -37,7 +37,10 @@ from pprint import pformat
 import requests
 
 from ycmd import handlers
-from ycmd.tests.java import DEFAULT_PROJECT_DIR, PathToTestFile, SharedYcmd
+from ycmd.tests.java import ( DEFAULT_PROJECT_DIR,
+                              IsolatedYcmd,
+                              PathToTestFile,
+                              SharedYcmd )
 from ycmd.tests.test_utils import ( CombineRequest,
                                     ChunkMatcher,
                                     CompletionEntryMatcher,
@@ -490,7 +493,7 @@ def GetCompletions_ResolveFailed_test( app ):
     } )
 
 
-@SharedYcmd
+@IsolatedYcmd
 def GetCompletions_ServerNotInitialized_test( app ):
   filepath = PathToTestFile( 'simple_eclipse_project',
                              'src',
@@ -500,7 +503,14 @@ def GetCompletions_ServerNotInitialized_test( app ):
 
   completer = handlers._server_state.GetFiletypeCompleter( [ 'java' ] )
 
-  with patch.object( completer, '_ServerIsInitialized', return_value = False ):
+
+  def MockHandleInitializeInPollThread( self, response ):
+    pass
+
+
+  with patch.object( completer,
+                     '_HandleInitializeInPollThread',
+                     MockHandleInitializeInPollThread ):
     RunTest( app, {
       'description': 'Completion works for unicode identifier',
       'request': {

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -633,7 +633,7 @@ def LanguageServerCompleter_GetCompletions_List_test():
     { 'result': { 'label': 'test' } },
   ]
 
-  with patch.object( completer, '_ServerIsInitialized', return_value = True ):
+  with patch.object( completer, '_is_completion_provider', True ):
     with patch.object( completer.GetConnection(),
                        'GetResponse',
                        side_effect = [ completion_response ] +
@@ -658,7 +658,7 @@ def LanguageServerCompleter_GetCompletions_UnsupportedKinds_test():
     { 'result': { 'label': 'test' } },
   ]
 
-  with patch.object( completer, '_ServerIsInitialized', return_value = True ):
+  with patch.object( completer, '_is_completion_provider', True ):
     with patch.object( completer.GetConnection(),
                        'GetResponse',
                        side_effect = [ completion_response ] +
@@ -687,7 +687,7 @@ def LanguageServerCompleter_GetCompletions_CompleteOnStartColumn_test():
     }
   }
 
-  with patch.object( completer, '_ServerIsInitialized', return_value = True ):
+  with patch.object( completer, '_is_completion_provider', True ):
     request_data = RequestWrap( BuildRequest(
       column_num = 2,
       contents = 'a',
@@ -772,7 +772,7 @@ def LanguageServerCompleter_GetCompletions_CompleteOnCurrentColumn_test():
     }
   }
 
-  with patch.object( completer, '_ServerIsInitialized', return_value = True ):
+  with patch.object( completer, '_is_completion_provider', True ):
     # User starts by typing the character "a".
     request_data = RequestWrap( BuildRequest(
       column_num = 2,


### PR DESCRIPTION
A server may not be a `completionProvider`, in which case we shouldn't
send `textDocument/completion` requests.

In the current state of the PR, `_is_completion_provider` can only be set to `True` after server responded to `initialize` request. That's why we can just test `if self._is_completion_provider` in `ComputeCandidatesInner`, making the `self._ServerIsInitialized()` check redundant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1348)
<!-- Reviewable:end -->
