### PR TITLE
[READY] Implement GetDoc for gopls

### DIFF
--- a/ycmd/tests/go/get_completions_test.py
+++ b/ycmd/tests/go/get_completions_test.py
@@ -38,7 +38,7 @@ def GetCompletions_Basic_test( app ):
                                   filetype = 'go',
                                   contents = ReadFile( filepath ),
                                   force_semantic = True,
-                                  line_num = 9,
+                                  line_num = 10,
                                   column_num = 9 )
 
   results = app.post_json( '/completions',

--- a/ycmd/tests/go/go_module/td/test.go
+++ b/ycmd/tests/go/go_module/td/test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 )
 
+// Now with doc!
 func Hello() {
 	log.Log
 }

--- a/ycmd/tests/go/subcommands_test.py
+++ b/ycmd/tests/go/subcommands_test.py
@@ -118,6 +118,7 @@ def Subcommands_DefinedSubcommands_test( app ):
 
   assert_that( app.post_json( '/defined_subcommands', subcommands_data ).json,
                contains_inanyorder( 'Format',
+                                    'GetDoc',
                                     'GetType',
                                     'RefactorRename',
                                     'GoTo',
@@ -154,6 +155,7 @@ def Subcommands_ServerNotInitialized_test():
     } )
 
   yield Test, 'Format', []
+  yield Test, 'GetDoc', []
   yield Test, 'GetType', []
   yield Test, 'GoTo', []
   yield Test, 'GoToDeclaration', []
@@ -261,6 +263,40 @@ def Subcommands_Format_Range_test( app ):
 
 
 @SharedYcmd
+def Subcommands_GetDoc_UnknownType_test( app ):
+  RunTest( app, {
+    'description': 'GetDoc on a unknown type raises an error',
+    'request': {
+      'command': 'GetDoc',
+      'line_num': 2,
+      'column_num': 4,
+      'filepath': PathToTestFile( 'td', 'test.go' ),
+    },
+    'expect': {
+      'response': requests.codes.internal_server_error,
+      'data': ErrorMatcher( RuntimeError, 'No documentation available.' )
+    }
+  } )
+
+
+@SharedYcmd
+def Subcommands_GetDoc_Function_test( app ):
+  RunTest( app, {
+    'description': 'GetDoc on a function returns its type',
+    'request': {
+      'command': 'GetDoc',
+      'line_num': 9,
+      'column_num': 6,
+      'filepath': PathToTestFile( 'td', 'test.go' ),
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entry( 'message', 'Now with doc!\nfunc Hello()' ),
+    }
+  } )
+
+
+@SharedYcmd
 def Subcommands_GetType_UnknownType_test( app ):
   RunTest( app, {
     'description': 'GetType on a unknown type raises an error',
@@ -283,7 +319,7 @@ def Subcommands_GetType_Function_test( app ):
     'description': 'GetType on a function returns its type',
     'request': {
       'command': 'GetType',
-      'line_num': 8,
+      'line_num': 9,
       'column_num': 6,
       'filepath': PathToTestFile( 'td', 'test.go' ),
     },


### PR DESCRIPTION
I don't when this happened, but gopls can apparently provide docs, with some curious [initialization options](https://github.com/golang/tools/blob/2b779830f9d33eccacea7d9e741475351b225b1a/internal/lsp/source/hover.go#L20-L36).

We always get `signature` appended to the hover info. That's what `GetType` displays. Besides that, we also get `Synopsis` when available. To get `FullDocumentation` we need to pass that as `HoverKind` in initialization options: https://github.com/golang/tools/blob/2b544e3f2db1e740d696ff91381987f6357e6bda/internal/lsp/source/options.go#L74-L107.

Speaking of initialization options, [the default completion options](https://github.com/golang/tools/blob/2b544e3f2db1e740d696ff91381987f6357e6bda/internal/lsp/source/options.go#L63-L69) are just as interesting. Then again, maybe it doesn't matter, since we never send any query for gopls to filter completions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1350)
<!-- Reviewable:end -->
