### PR TITLE
[READY] Implement GetDoc for gopls

### DIFF
--- a/ycmd/tests/go/debug_info_test.py
+++ b/ycmd/tests/go/debug_info_test.py
@@ -26,7 +26,8 @@ from hamcrest import ( assert_that,
                        contains,
                        has_entries,
                        has_entry,
-                       instance_of )
+                       instance_of,
+                       matches_regexp )
 
 from ycmd.tests.go import ( IsolatedYcmd,
                             PathToTestFile,
@@ -64,7 +65,8 @@ def DebugInfo_test( app ):
           } ),
           has_entries( {
             'key': 'Settings',
-            'value': '{}'
+            'value': matches_regexp( '{\n  "fuzzyMatching": false,\\s?\n'
+                                     '  "hoverKind": "Structured"\n}' )
           } ),
         )
       } ) ),
@@ -102,7 +104,8 @@ def DebugInfo_ProjectDirectory_test( app ):
           } ),
           has_entries( {
             'key': 'Settings',
-            'value': '{}'
+            'value': matches_regexp( '{\n  "fuzzyMatching": false,\\s?\n'
+                                     '  "hoverKind": "Structured"\n}' )
           } ),
         )
       } ) ),

--- a/ycmd/tests/go/diagnostics_test.py
+++ b/ycmd/tests/go/diagnostics_test.py
@@ -85,7 +85,8 @@ def Diagnostics_Poll_test( app ):
                                     { 'filepath': filepath,
                                       'contents': contents,
                                       'filetype': 'go' } ):
-      if message[ 'diagnostics' ][ 0 ][ 'text' ] == "expected ';', found 'EOF'":
+      if message[ 'diagnostics' ][ 0 ][ 'text' ].endswith(
+          "is not part of a package" ):
         continue
       print( 'Message {}'.format( pformat( message ) ) )
       if 'diagnostics' in message:

--- a/ycmd/tests/go/get_completions_test.py
+++ b/ycmd/tests/go/get_completions_test.py
@@ -38,7 +38,7 @@ def GetCompletions_Basic_test( app ):
                                   filetype = 'go',
                                   contents = ReadFile( filepath ),
                                   force_semantic = True,
-                                  line_num = 9,
+                                  line_num = 10,
                                   column_num = 9 )
 
   results = app.post_json( '/completions',

--- a/ycmd/tests/go/go_module/td/test.go
+++ b/ycmd/tests/go/go_module/td/test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 )
 
+// Now with doc!
 func Hello() {
 	log.Log
 }

--- a/ycmd/tests/go/subcommands_test.py
+++ b/ycmd/tests/go/subcommands_test.py
@@ -118,6 +118,7 @@ def Subcommands_DefinedSubcommands_test( app ):
 
   assert_that( app.post_json( '/defined_subcommands', subcommands_data ).json,
                contains_inanyorder( 'Format',
+                                    'GetDoc',
                                     'GetType',
                                     'RefactorRename',
                                     'GoTo',
@@ -154,6 +155,7 @@ def Subcommands_ServerNotInitialized_test():
     } )
 
   yield Test, 'Format', []
+  yield Test, 'GetDoc', []
   yield Test, 'GetType', []
   yield Test, 'GoTo', []
   yield Test, 'GoToDeclaration', []
@@ -261,6 +263,40 @@ def Subcommands_Format_Range_test( app ):
 
 
 @SharedYcmd
+def Subcommands_GetDoc_UnknownType_test( app ):
+  RunTest( app, {
+    'description': 'GetDoc on a unknown type raises an error',
+    'request': {
+      'command': 'GetDoc',
+      'line_num': 2,
+      'column_num': 4,
+      'filepath': PathToTestFile( 'td', 'test.go' ),
+    },
+    'expect': {
+      'response': requests.codes.internal_server_error,
+      'data': ErrorMatcher( RuntimeError, 'No documentation available.' )
+    }
+  } )
+
+
+@SharedYcmd
+def Subcommands_GetDoc_Function_test( app ):
+  RunTest( app, {
+    'description': 'GetDoc on a function returns its type',
+    'request': {
+      'command': 'GetDoc',
+      'line_num': 9,
+      'column_num': 6,
+      'filepath': PathToTestFile( 'td', 'test.go' ),
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entry( 'message', 'func Hello()\nNow with doc!' ),
+    }
+  } )
+
+
+@SharedYcmd
 def Subcommands_GetType_UnknownType_test( app ):
   RunTest( app, {
     'description': 'GetType on a unknown type raises an error',
@@ -283,7 +319,7 @@ def Subcommands_GetType_Function_test( app ):
     'description': 'GetType on a function returns its type',
     'request': {
       'command': 'GetType',
-      'line_num': 8,
+      'line_num': 9,
       'column_num': 6,
       'filepath': PathToTestFile( 'td', 'test.go' ),
     },


### PR DESCRIPTION
Attempt 2, it passed tests in my fork.

- We're using `DefaultSettings()` to set `hoverKind` to `Structured`, beecause gopls is inconsistent with hover formatting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1351)
<!-- Reviewable:end -->
