### PR TITLE
[READY] Make LSP codeActions generic

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -283,10 +283,6 @@ class ClangdCompleter( simple_language_server_completer.SimpleLSPCompleter ):
 
   def GetCustomSubcommands( self ):
     return {
-      'FixIt': (
-        lambda self, request_data, args: self.GetCodeActions( request_data,
-                                                              args )
-      ),
       'GetType': (
         # In addition to type information we show declaration.
         lambda self, request_data, args: self.GetType( request_data )
@@ -319,19 +315,6 @@ class ClangdCompleter( simple_language_server_completer.SimpleLSPCompleter ):
       #   lambda self, request_data, args: self.GetType( request_data )
       # )
     }
-
-
-  def HandleServerCommand( self, request_data, command ):
-    if command[ 'command' ] == 'clangd.applyFix':
-      return language_server_completer.WorkspaceEditToFixIt(
-        request_data,
-        command[ 'arguments' ][ 0 ],
-        text = command[ 'title' ] )
-
-    if command[ 'command' ] == 'clangd.applyTweak':
-      return responses.UnresolvedFixIt( command, command[ 'title' ] )
-
-    return None
 
 
   def ShouldCompleteIncludeStatement( self, request_data ):

--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -28,8 +28,7 @@ import os
 
 from ycmd import responses
 from ycmd import utils
-from ycmd.completers.language_server import ( simple_language_server_completer,
-                                              language_server_completer )
+from ycmd.completers.language_server import simple_language_server_completer
 
 
 PATH_TO_GOPLS = os.path.abspath( os.path.join( os.path.dirname( __file__ ),
@@ -116,10 +115,6 @@ class GoCompleter( simple_language_server_completer.SimpleLSPCompleter ):
       'RestartServer': (
         lambda self, request_data, args: self._RestartServer( request_data )
       ),
-      'FixIt': (
-        lambda self, request_data, args: self.GetCodeActions( request_data,
-                                                              args )
-      ),
       'GetDoc': (
         lambda self, request_data, args: self.GetDoc( request_data )
       ),
@@ -127,10 +122,3 @@ class GoCompleter( simple_language_server_completer.SimpleLSPCompleter ):
         lambda self, request_data, args: self.GetType( request_data )
       ),
     }
-
-
-  def HandleServerCommand( self, request_data, command ):
-    return language_server_completer.WorkspaceEditToFixIt(
-      request_data,
-      command[ 'edit' ],
-      text = command[ 'title' ] )

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -244,6 +244,20 @@ def Initialize( request_id, project_directory, settings ):
     'capabilities': {
       'workspace': { 'applyEdit': True },
       'textDocument': {
+        'codeAction': {
+          'codeActionLiteralSupport': {
+            'codeActionKind': {
+              'valueSet': [ '',
+                            'quickfix',
+                            'refactor',
+                            'refactor.extract',
+                            'refactor.inline',
+                            'refactor.rewrite',
+                            'source',
+                            'source.organizeImports' ]
+            }
+          }
+        },
         'completion': {
           'completionItemKind': {
             # ITEM_KIND list is 1-based.

--- a/ycmd/completers/language_server/simple_language_server_completer.py
+++ b/ycmd/completers/language_server/simple_language_server_completer.py
@@ -185,7 +185,3 @@ class SimpleLSPCompleter( lsc.LanguageServerCompleter ):
     with self._server_state_mutex:
       self.Shutdown()
       self._StartAndInitializeServer( request_data )
-
-
-  def HandleServerCommand( self, request_data, command ):
-    return None

--- a/ycmd/tests/java/java_completer_test.py
+++ b/ycmd/tests/java/java_completer_test.py
@@ -218,19 +218,6 @@ def JavaCompleter_GetDoc_test( app ):
                  raises( RuntimeError, NO_DOCUMENTATION_MESSAGE ) )
 
 
-@SharedYcmd
-def JavaCompleter_UnknownCommand_test( app ):
-  completer = handlers._server_state.GetFiletypeCompleter( [ 'java' ] )
-
-  notification = {
-    'command': 'this_is_not_a_real_command',
-    'params': {}
-  }
-  assert_that( completer.HandleServerCommand( BuildRequest(), notification ),
-               equal_to( None ) )
-
-
-
 @patch( 'ycmd.completers.java.hook.ShouldEnableJavaCompleter',
         return_value = False )
 def JavaHook_JavaNotEnabled_test( *args ):


### PR DESCRIPTION
We can finally move all the FixIt LSP mess into the `LanguageServerCompleter`. It should even work for `GenericLSPCompleter`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1354)
<!-- Reviewable:end -->
