### PR TITLE
[READY] Implement /detailed_diagnostic for LSP servers

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -27,7 +27,6 @@ import os
 import subprocess
 
 from ycmd import extra_conf_store, responses
-from ycmd.completers.completer_utils import GetFileLines
 from ycmd.completers.cpp.flags import ( AddMacIncludePaths,
                                         RemoveUnusedFlags,
                                         ShouldAllowWinStyleFlags )
@@ -58,28 +57,6 @@ PRE_BUILT_CLANGD_DIR = os.path.abspath( os.path.join(
   'output',
   'bin' ) )
 PRE_BUILT_CLANDG_PATH = os.path.join( PRE_BUILT_CLANGD_DIR, 'clangd' )
-
-
-def DistanceOfPointToRange( point, range ):
-  """Calculate the distance from a point to a range.
-
-  Assumes point is covered by lines in the range.
-  Returns 0 if point is already inside range. """
-  start = range[ 'start' ]
-  end = range[ 'end' ]
-
-  # Single-line range.
-  if start[ 'line' ] == end[ 'line' ]:
-    # 0 if point is within range, otherwise distance from start/end.
-    return max( 0, point[ 'character' ] - end[ 'character' ],
-                start[ 'character' ] - point[ 'character' ] )
-
-  if start[ 'line' ] == point[ 'line' ]:
-    return max( 0, start[ 'character' ] - point[ 'character' ] )
-  if end[ 'line' ] == point[ 'line' ]:
-    return max( 0, point[ 'character' ] - end[ 'character' ] )
-  # If not on the first or last line, then point is within range for sure.
-  return 0
 
 
 def ParseClangdVersion( version_str ):
@@ -391,46 +368,6 @@ class ClangdCompleter( simple_language_server_completer.SimpleLSPCompleter ):
                            self ).ComputeCandidatesInner( request_data,
                                                           codepoint )
     return candidates
-
-
-  def GetDetailedDiagnostic( self, request_data ):
-    self._UpdateServerWithFileContents( request_data )
-
-    current_line_lsp = request_data[ 'line_num' ] - 1
-    current_file = request_data[ 'filepath' ]
-
-    if not self._latest_diagnostics:
-      return responses.BuildDisplayMessageResponse(
-          'Diagnostics are not ready yet.' )
-
-    with self._server_info_mutex:
-      diagnostics = list( self._latest_diagnostics[
-          lsp.FilePathToUri( current_file ) ] )
-
-    if not diagnostics:
-      return responses.BuildDisplayMessageResponse(
-          'No diagnostics for current file.' )
-
-    current_column = lsp.CodepointsToUTF16CodeUnits(
-        GetFileLines( request_data, current_file )[ current_line_lsp ],
-        request_data[ 'column_codepoint' ] )
-    minimum_distance = None
-
-    message = 'No diagnostics for current line.'
-    for diagnostic in diagnostics:
-      start = diagnostic[ 'range' ][ 'start' ]
-      end = diagnostic[ 'range' ][ 'end' ]
-      if current_line_lsp < start[ 'line' ] or end[ 'line' ] < current_line_lsp:
-        continue
-      point = { 'line': current_line_lsp, 'character': current_column }
-      distance = DistanceOfPointToRange( point, diagnostic[ 'range' ] )
-      if minimum_distance is None or distance < minimum_distance:
-        message = diagnostic[ 'message' ]
-        if distance == 0:
-          break
-        minimum_distance = distance
-
-    return responses.BuildDisplayMessageResponse( message )
 
 
   def _SendFlagsFromExtraConf( self, request_data ):

--- a/ycmd/tests/clangd/utilities_test.py
+++ b/ycmd/tests/clangd/utilities_test.py
@@ -34,37 +34,6 @@ from ycmd.tests.test_utils import BuildRequest
 from ycmd.user_options_store import DefaultOptions
 
 
-def _TupleToLSPRange( tuple ):
-  return { 'line': tuple[ 0 ], 'character': tuple[ 1 ] }
-
-
-def _Check_Distance( point, start, end, expected ):
-  point = _TupleToLSPRange( point )
-  start = _TupleToLSPRange( start )
-  end = _TupleToLSPRange( end )
-  range = { 'start': start, 'end': end }
-  result = clangd_completer.DistanceOfPointToRange( point, range )
-  eq_( result, expected )
-
-
-def ClangdCompleter_DistanceOfPointToRange_SingleLineRange_test():
-  # Point to the left of range.
-  _Check_Distance( ( 0, 0 ), ( 0, 2 ), ( 0, 5 ) , 2 )
-  # Point inside range.
-  _Check_Distance( ( 0, 4 ), ( 0, 2 ), ( 0, 5 ) , 0 )
-  # Point to the right of range.
-  _Check_Distance( ( 0, 8 ), ( 0, 2 ), ( 0, 5 ) , 3 )
-
-
-def ClangdCompleter_DistanceOfPointToRange_MultiLineRange_test():
-  # Point to the left of range.
-  _Check_Distance( ( 0, 0 ), ( 0, 2 ), ( 3, 5 ) , 2 )
-  # Point inside range.
-  _Check_Distance( ( 1, 4 ), ( 0, 2 ), ( 3, 5 ) , 0 )
-  # Point to the right of range.
-  _Check_Distance( ( 3, 8 ), ( 0, 2 ), ( 3, 5 ) , 3 )
-
-
 def ClangdCompleter_GetClangdCommand_NoCustomBinary_test():
   user_options = DefaultOptions()
 

--- a/ycmd/tests/go/diagnostics_test.py
+++ b/ycmd/tests/go/diagnostics_test.py
@@ -26,12 +26,14 @@ from future.utils import iterkeys
 from hamcrest import ( assert_that,
                        contains,
                        contains_inanyorder,
-                       has_entries )
+                       has_entries,
+                       has_entry )
 from pprint import pformat
 import json
 
 from ycmd.tests.go import PathToTestFile, SharedYcmd
-from ycmd.tests.test_utils import ( LocationMatcher,
+from ycmd.tests.test_utils import ( BuildRequest,
+                                    LocationMatcher,
                                     PollForMessages,
                                     PollForMessagesTimeoutException,
                                     RangeMatcher,
@@ -55,6 +57,23 @@ DIAG_MATCHERS_PER_FILE = {
     } )
   )
 }
+
+
+@WithRetry
+@SharedYcmd
+def Diagnostics_DetailedDiags_test( app ):
+  filepath = PathToTestFile( 'goto.go' )
+  contents = ReadFile( filepath )
+  WaitForDiagnosticsToBeReady( app, filepath, contents, 'go' )
+  request_data = BuildRequest( contents = contents,
+                               filepath = filepath,
+                               filetype = 'go',
+                               line_num = 12,
+                               column_num = 5 )
+
+  results = app.post_json( '/detailed_diagnostic', request_data ).json
+  assert_that( results,
+               has_entry( 'message', 'undeclared name: diagnostics_test' ) )
 
 
 @WithRetry

--- a/ycmd/tests/java/diagnostics_test.py
+++ b/ycmd/tests/java/diagnostics_test.py
@@ -33,6 +33,7 @@ from hamcrest import ( assert_that,
                        empty,
                        equal_to,
                        has_entries,
+                       has_entry,
                        has_item )
 from nose.tools import eq_
 
@@ -249,6 +250,24 @@ def _WaitForDiagnosticsForFile( app,
     )
 
   return diags
+
+
+@WithRetry
+@SharedYcmd
+def Diagnostics_DetailedDiags_test( app ):
+  filepath = TestFactory
+  contents = ReadFile( filepath )
+  WaitForDiagnosticsToBeReady( app, filepath, contents, 'java' )
+  request_data = BuildRequest( contents = contents,
+                               filepath = filepath,
+                               filetype = 'java',
+                               line_num = 15,
+                               column_num = 19 )
+
+  results = app.post_json( '/detailed_diagnostic', request_data ).json
+  assert_that( results, has_entry(
+      'message',
+      'The value of the field TestFactory.Bar.testString is not used' ) )
 
 
 @WithRetry

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -1346,3 +1346,34 @@ def LanguageServerCompleter_OnFileReadyToParse_InvalidURI_test():
                     uri_to_filepath:
       assert_that( completer.OnFileReadyToParse( request_data ), diagnostics )
       uri_to_filepath.assert_called()
+
+
+def _TupleToLSPRange( tuple ):
+  return { 'line': tuple[ 0 ], 'character': tuple[ 1 ] }
+
+
+def _Check_Distance( point, start, end, expected ):
+  point = _TupleToLSPRange( point )
+  start = _TupleToLSPRange( start )
+  end = _TupleToLSPRange( end )
+  range = { 'start': start, 'end': end }
+  result = lsc._DistanceOfPointToRange( point, range )
+  eq_( result, expected )
+
+
+def LanguageServerCompleter_DistanceOfPointToRange_SingleLineRange_test():
+  # Point to the left of range.
+  _Check_Distance( ( 0, 0 ), ( 0, 2 ), ( 0, 5 ) , 2 )
+  # Point inside range.
+  _Check_Distance( ( 0, 4 ), ( 0, 2 ), ( 0, 5 ) , 0 )
+  # Point to the right of range.
+  _Check_Distance( ( 0, 8 ), ( 0, 2 ), ( 0, 5 ) , 3 )
+
+
+def LanguageServerCompleter_DistanceOfPointToRange_MultiLineRange_test():
+  # Point to the left of range.
+  _Check_Distance( ( 0, 0 ), ( 0, 2 ), ( 3, 5 ) , 2 )
+  # Point inside range.
+  _Check_Distance( ( 1, 4 ), ( 0, 2 ), ( 3, 5 ) , 0 )
+  # Point to the right of range.
+  _Check_Distance( ( 3, 8 ), ( 0, 2 ), ( 3, 5 ) , 3 )

--- a/ycmd/tests/rust/diagnostics_test.py
+++ b/ycmd/tests/rust/diagnostics_test.py
@@ -23,12 +23,17 @@ from __future__ import division
 from builtins import *  # noqa
 
 from future.utils import iterkeys
-from hamcrest import assert_that, contains, contains_inanyorder, has_entries
+from hamcrest import ( assert_that,
+                       contains,
+                       contains_inanyorder,
+                       has_entries,
+                       has_entry )
 from pprint import pformat
 import json
 
 from ycmd.tests.rust import PathToTestFile, SharedYcmd
-from ycmd.tests.test_utils import ( LocationMatcher,
+from ycmd.tests.test_utils import ( BuildRequest,
+                                    LocationMatcher,
                                     PollForMessages,
                                     PollForMessagesTimeoutException,
                                     RangeMatcher,
@@ -52,6 +57,23 @@ DIAG_MATCHERS_PER_FILE = {
     } )
   )
 }
+
+
+@SharedYcmd
+def Diagnostics_DetailedDiags_test( app ):
+  filepath = PathToTestFile( 'common', 'src', 'main.rs' )
+  contents = ReadFile( filepath )
+  WaitForDiagnosticsToBeReady( app, filepath, contents, 'rust' )
+  request_data = BuildRequest( contents = contents,
+                               filepath = filepath,
+                               filetype = 'rust',
+                               line_num = 14,
+                               column_num = 13 )
+
+  results = app.post_json( '/detailed_diagnostic', request_data ).json
+  assert_that( results, has_entry(
+      'message',
+      'no field `build_` on type `test::Builder`\n\nunknown field' ) )
 
 
 @SharedYcmd


### PR DESCRIPTION
Seems like the original LSP implementation forgot about
/detailed_diagnostic. Later, clangd completer implemented locally what
works for all LSP completers.

This commit moves the code from ClangdCompleter to
LanguageServerCompleter and adds a few tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1355)
<!-- Reviewable:end -->
