### PR TITLE
[READY] Properly handle textDocument/completions null response

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -910,7 +910,7 @@ class LanguageServerCompleter( Completer ):
     response = self.GetConnection().GetResponse( request_id,
                                                  msg,
                                                  REQUEST_TIMEOUT_COMPLETION )
-    result = response[ 'result' ]
+    result = response.get( 'result' ) or []
 
     if isinstance( result, list ):
       items = result

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -673,6 +673,28 @@ def LanguageServerCompleter_GetCompletions_UnsupportedKinds_test():
       )
 
 
+def LanguageServerCompleter_GetCompletions_NullNoError_test():
+  completer = MockCompleter()
+  request_data = RequestWrap( BuildRequest() )
+  complete_response = { 'result': None }
+  resolve_responses = []
+  with patch.object( completer, '_ServerIsInitialized', return_value = True ):
+    with patch.object( completer,
+                       '_is_completion_provider',
+                       return_value = True ):
+      with patch.object( completer.GetConnection(),
+                         'GetResponse',
+                         side_effect = [ complete_response ] +
+                                       resolve_responses ):
+        assert_that(
+          completer.ComputeCandidatesInner( request_data, 1 ),
+          contains(
+            empty(),
+            False
+          )
+        )
+
+
 def LanguageServerCompleter_GetCompletions_CompleteOnStartColumn_test():
   completer = MockCompleter()
   completer._resolve_completion_items = False


### PR DESCRIPTION
4chan server can return `'result':null` which is ok by the protocol.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1360)
<!-- Reviewable:end -->
