### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ wouldn't usually know about. The value is a list of dictionaries containing:
 When plugging in a completer in this way, the `kwargs[ 'language' ]` will be set
 to the value of the `name` key, i.e. `gopls` in the above example.
 
-LSP completers currecntly supported without `language_server`:
+LSP completers currently supported without `language_server`:
 
 - Java
 - Rust


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1361)
<!-- Reviewable:end -->
