### PR TITLE
Add detection for python 3.8 and 3.9

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -253,7 +253,7 @@ if ( USE_PYTHON2 )
       "necessary python2 headers & libraries." )
   endif()
 else()
-  set( Python_ADDITIONAL_VERSIONS 3.7 3.6 3.5 )
+  set( Python_ADDITIONAL_VERSIONS 3.9 3.8 3.7 3.6 3.5 )
   find_package( PythonLibs 3.5 REQUIRED )  # 3.5 is ONLY the mininum
 endif()
 


### PR DESCRIPTION
Arch now uses python3.8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1362)
<!-- Reviewable:end -->
