### PR TITLE
[READY] Remove frozendict

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "third_party/bottle"]
 	path = third_party/bottle
 	url = https://github.com/defnull/bottle
-[submodule "third_party/frozendict"]
-	path = third_party/frozendict
-	url = https://github.com/slezica/python-frozendict
 [submodule "third_party/waitress"]
 	path = third_party/waitress
 	url = https://github.com/Pylons/waitress

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,21 +10,21 @@ jobs:
       # Tests are failing on Python 2.7.0 with the exception
       # "TypeError: argument can't be <type 'unicode'>"
       'Python 2.7 without libclang completer':
-        YCM_PYTHON_VERSION: '2.7.1'
+        YCM_PYTHON_VERSION: '2.7.13'
         USE_CLANG_COMPLETER: false
       'Python 2.7':
-        YCM_PYTHON_VERSION: '2.7.1'
+        YCM_PYTHON_VERSION: '2.7.13'
       'Python 3.5':
-        YCM_PYTHON_VERSION: '3.5.1'
+        YCM_PYTHON_VERSION: '3.5.3'
       'Python 3.5 using Clang compiler':
-        YCM_PYTHON_VERSION: '3.5.1'
+        YCM_PYTHON_VERSION: '3.5.3'
         YCM_COMPILER: 'clang'
       'C++ benchmark':
-        YCM_PYTHON_VERSION: '3.5.1'
+        YCM_PYTHON_VERSION: '3.5.3'
         YCM_BENCHMARK: true
         COVERAGE: false
       'C++ linting':
-        YCM_PYTHON_VERSION: '3.5.1'
+        YCM_PYTHON_VERSION: '3.5.3'
         YCM_CLANG_TIDY: true
         COVERAGE: false
     maxParallel: 6
@@ -61,11 +61,11 @@ jobs:
       'Python 2.7':
         # Prior versions fail to compile with error "ld: library not found for
         # -lSystemStubs"
-        YCM_PYTHON_VERSION: '2.7.2'
+        YCM_PYTHON_VERSION: '2.7.13'
       'Python 3.5':
-        YCM_PYTHON_VERSION: '3.5.1'
+        YCM_PYTHON_VERSION: '3.5.3'
       'C++ benchmark':
-        YCM_PYTHON_VERSION: '3.5.1'
+        YCM_PYTHON_VERSION: '3.5.3'
         YCM_BENCHMARK: true
     maxParallel: 3
   variables:

--- a/azure/linux/install_dependencies.sh
+++ b/azure/linux/install_dependencies.sh
@@ -45,15 +45,15 @@ eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 # We need to use openssl 1.0 because the versions of python we build don't
 # compile with openssl 1.1. We could bump python versions until they do, but
 # we've generally committed to testing older versions.
-brew install openssl@1.0 pyenv
+brew install pyenv
 
 eval "$(pyenv init -)"
 
 # In order to work with ycmd, Python *must* be built as a shared library. This
 # is set via the PYTHON_CONFIGURE_OPTS option.
 PYTHON_CONFIGURE_OPTS="--enable-shared" \
-CFLAGS="-I$(brew --prefix openssl@1.0)/include" \
-LDFLAGS="-L$(brew --prefix openssl@1.0)/lib" \
+CFLAGS="-I$(brew --prefix openssl)/include" \
+LDFLAGS="-L$(brew --prefix openssl)/lib" \
 pyenv install ${YCM_PYTHON_VERSION}
 pyenv global ${YCM_PYTHON_VERSION}
 

--- a/ycmd/user_options_store.py
+++ b/ycmd/user_options_store.py
@@ -24,16 +24,15 @@ from builtins import *  # noqa
 
 import json
 import os
-from frozendict import frozendict
 
-from ycmd.utils import ReadFile
+from ycmd.utils import HashableDict, ReadFile
 
 _USER_OPTIONS = {}
 
 
 def SetAll( new_options ):
   global _USER_OPTIONS
-  _USER_OPTIONS = frozendict( new_options )
+  _USER_OPTIONS = HashableDict( new_options )
 
 
 def GetAll():


### PR DESCRIPTION
Python deprecated accessing abstract collections through `collections` module in favour of `collections.abc`. Frozendict was never fixed, but ycmd has had `HashableDict` for a while which is also an immutable dictionary and a more robust\* one than `frozendict`. Thus the fix for the broken `frozendict` dependency is to just use our own `HashableDict` even for user options.

\* `frozendict.__getitem__()` returned values by reference, so it was still possible to mutate the dictionary. `HashableDict.__getitem__()` calls `deepcopy()` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1367)
<!-- Reviewable:end -->
