### PR TITLE
[READY] Implement WorkspaceClientCapabilities.workspaceEdit.documentChanges

### DIFF
--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -242,7 +242,7 @@ def Initialize( request_id, project_directory, settings ):
     'rootUri': FilePathToUri( project_directory ),
     'initializationOptions': settings,
     'capabilities': {
-      'workspace': { 'applyEdit': True },
+      'workspace': { 'applyEdit': True, 'documentChanges': True },
       'textDocument': {
         'codeAction': {
           'codeActionLiteralSupport': {


### PR DESCRIPTION
As discussed on gitter, this implements `documentChanges` because some servers ignore thte capabilities and always send `WorkspaceEdits` containing versioned `documentChanges`. Speaking of "versioned", we are just ignoring the versions, which seemed to work for typescript-language-server and rust-analyzer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1368)
<!-- Reviewable:end -->
