### PR TITLE
[READY] Simplify LSP completer subcommand discovery

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -284,10 +284,6 @@ class ClangdCompleter( simple_language_server_completer.SimpleLSPCompleter ):
 
   def GetCustomSubcommands( self ):
     return {
-      'GetType': (
-        # In addition to type information we show declaration.
-        lambda self, request_data, args: self.GetType( request_data )
-      ),
       'GetTypeImprecise': (
         lambda self, request_data, args: self.GetType( request_data )
       ),
@@ -300,12 +296,6 @@ class ClangdCompleter( simple_language_server_completer.SimpleLSPCompleter ):
       'GoToInclude': (
         lambda self, request_data, args: self.GoTo( request_data,
                                                     [ 'Definition' ] )
-      ),
-      'RestartServer': (
-        lambda self, request_data, args: self._RestartServer( request_data )
-      ),
-      'GetDoc': (
-        lambda self, request_data, args: self.GetDoc( request_data )
       ),
       'GetDocImprecise': (
         lambda self, request_data, args: self.GetDoc( request_data )

--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -108,17 +108,3 @@ class GoCompleter( simple_language_server_completer.SimpleLSPCompleter ):
   def DefaultSettings( self, request_data ):
     return { 'hoverKind': 'Structured',
              'fuzzyMatching': False }
-
-
-  def GetCustomSubcommands( self ):
-    return {
-      'RestartServer': (
-        lambda self, request_data, args: self._RestartServer( request_data )
-      ),
-      'GetDoc': (
-        lambda self, request_data, args: self.GetDoc( request_data )
-      ),
-      'GetType': (
-        lambda self, request_data, args: self.GetType( request_data )
-      ),
-    }

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -334,20 +334,11 @@ class JavaCompleter( simple_language_server_completer.SimpleLSPCompleter ):
 
   def GetCustomSubcommands( self ):
     return {
-      'GetDoc': (
-        lambda self, request_data, args: self.GetDoc( request_data )
-      ),
-      'GetType': (
-        lambda self, request_data, args: self.GetType( request_data )
-      ),
       'OrganizeImports': (
         lambda self, request_data, args: self.OrganizeImports( request_data )
       ),
       'OpenProject': (
         lambda self, request_data, args: self._OpenProject( request_data, args )
-      ),
-      'RestartServer': (
-        lambda self, request_data, args: self._RestartServer( request_data )
       ),
       'WipeWorkspace': (
         lambda self, request_data, args: self._WipeWorkspace( request_data,

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -124,24 +124,10 @@ class RustCompleter( simple_language_server_completer.SimpleLSPCompleter ):
     return []
 
 
-  def GetCustomSubcommands( self ):
-    return {
-      'GetDoc': (
-        lambda self, request_data, args: self.GetDoc( request_data )
-      ),
-      'GetType': (
-        lambda self, request_data, args: self.GetType( request_data )
-      ),
-      'RestartServer': (
-        lambda self, request_data, args: self._RestartServer( request_data )
-      )
-    }
-
-
-  def CommonDebugItems( self ):
+  def ExtraDebugItems( self, request_data ):
     project_state = ', '.join(
       set( itervalues( self._server_progress ) ) ).capitalize()
-    return super( RustCompleter, self ).CommonDebugItems() + [
+    return [
       responses.DebugInfoItem( 'Project State', project_state ),
       responses.DebugInfoItem( 'Version', _GetRlsVersion() )
     ]

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -85,6 +85,10 @@ class MockCompleter( lsc.LanguageServerCompleter, DummyCompleter ):
     return self._started
 
 
+  def _RestartServer( self, request_data ):
+    pass
+
+
 @IsolatedYcmd( { 'global_ycm_extra_conf':
                  PathToTestFile( 'extra_confs', 'settings_extra_conf.py' ) } )
 def LanguageServerCompleter_ExtraConf_ServerReset_test( app ):


### PR DESCRIPTION
All LSP completers were already using the exact same `_RestartSever()`, so this PR moves it into the base class.
When `GetType` and/or `GetDoc` is defined for an LSP completer, it is automatically discovered in the base class, so we don't have to repeat it everywhere in the `GetCustomSubcommands`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1369)
<!-- Reviewable:end -->
