### PR TITLE
[READY] Make textDocument/sigantureHelp response handling more robust

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1109,9 +1109,14 @@ class LanguageServerCompleter( Completer ):
                                                  REQUEST_TIMEOUT_COMPLETION )
 
     result = response[ 'result' ]
+    if result is None:
+      return {}
+
     for sig in result[ 'signatures' ]:
       sig_label = sig[ 'label' ]
       end = 0
+      if sig.get( 'parameters' ) is None:
+        sig[ 'parameters' ] = []
       for arg in sig[ 'parameters' ]:
         arg_label = arg[ 'label' ]
         assert not isinstance( arg_label, list )

--- a/ycmd/tests/go/go_module/td/signature_help.go
+++ b/ycmd/tests/go/go_module/td/signature_help.go
@@ -8,6 +8,7 @@ func add(x int, y int) int {
 
 func main() {
 	fmt.Println(add(42, 13))
+	does_not_exist(
 }
 
 

--- a/ycmd/tests/go/signature_help_test.py
+++ b/ycmd/tests/go/signature_help_test.py
@@ -81,6 +81,56 @@ def RunTest( app, test ):
 
 
 @SharedYcmd
+def SignatureHelp_NoParams_test( app ):
+  RunTest( app, {
+    'description': 'Trigger after (',
+    'request': {
+      'filetype'  : 'go',
+      'filepath'  : PathToTestFile( 'goto.go' ),
+      'line_num'  : 8,
+      'column_num': 11,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'errors': empty(),
+        'signature_help': has_entries( {
+          'activeSignature': 0,
+          'activeParameter': 0,
+          'signatures': contains(
+            SignatureMatcher( 'dummy()', [] )
+          ),
+        } ),
+      } )
+    }
+  } )
+
+
+@SharedYcmd
+def SignatureHelp_NullResponse_test( app ):
+  RunTest( app, {
+    'description': 'No error on null response',
+    'request': {
+      'filetype'  : 'go',
+      'filepath'  : PathToTestFile( 'td', 'signature_help.go' ),
+      'line_num'  : 11,
+      'column_num': 17,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'errors': empty(),
+        'signature_help': has_entries( {
+          'activeSignature': 0,
+          'activeParameter': 0,
+          'signatures': empty(),
+        } ),
+      } )
+    }
+  } )
+
+
+@SharedYcmd
 def SignatureHelp_MethodTrigger_test( app ):
   RunTest( app, {
     'description': 'Trigger after (',


### PR DESCRIPTION
Ycmd couldn't cope with the following:

- `result:null` - happens with gopls on `non_existent_func(`
- `result:{'signature':[]}` - i.e. no parameters; happens with gopls for every function that has no parameters.

Both of those are valid responses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1370)
<!-- Reviewable:end -->
