### PR TITLE
[READY] User-friendly clangd hover errors

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -257,22 +257,28 @@ class ClangdCompleter( simple_language_server_completer.SimpleLSPCompleter ):
 
 
   def GetType( self, request_data ):
-    # Clangd's hover response looks like this:
-    #     Declared in namespace <namespace name>
-    #
-    #     <declaration line>
-    #
-    #     <docstring>
-    # GetType gets the first two lines.
-    value = self.GetHoverResponse( request_data )[ 'value' ].split( '\n\n', 2 )
-    return responses.BuildDisplayMessageResponse(
-        value[ 1 ] + '; ' + value[ 0 ] )
+    try:
+      # Clangd's hover response looks like this:
+      #     Declared in namespace <namespace name>
+      #
+      #     <declaration line>
+      #
+      #     <docstring>
+      # GetType gets the first two lines.
+      hover_value = self.GetHoverResponse( request_data )[ 'value' ]
+      type_info = '\n\n'.join( hover_value.split( '\n\n', 2 )[ : 2 ] )
+      return responses.BuildDisplayMessageResponse( type_info )
+    except language_server_completer.NoHoverInfoException:
+      raise RuntimeError( 'Unknown type.' )
 
 
   def GetDoc( self, request_data ):
-    # Just pull `value` out of the textDocument/hover response
-    return responses.BuildDetailedInfoResponse(
-        self.GetHoverResponse( request_data )[ 'value' ] )
+    try:
+      # Just pull `value` out of the textDocument/hover response
+      return responses.BuildDetailedInfoResponse(
+          self.GetHoverResponse( request_data )[ 'value' ] )
+    except language_server_completer.NoHoverInfoException:
+      raise RuntimeError( 'No documentation available.' )
 
 
   def GetTriggerCharacters( self, server_trigger_characters ):

--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -29,6 +29,7 @@ import os
 from ycmd import responses
 from ycmd import utils
 from ycmd.completers.language_server import simple_language_server_completer
+from ycmd.completers.language_server import language_server_completer
 
 
 PATH_TO_GOPLS = os.path.abspath( os.path.join( os.path.dirname( __file__ ),
@@ -88,10 +89,8 @@ class GoCompleter( simple_language_server_completer.SimpleLSPCompleter ):
       result = json.loads( self.GetHoverResponse( request_data )[ 'value' ] )
       docs = result[ 'signature' ] + '\n' + result[ 'fullDocumentation' ]
       return responses.BuildDetailedInfoResponse( docs.strip() )
-    except RuntimeError as e:
-      if e.args[ 0 ] == 'No hover information.':
-        raise RuntimeError( 'No documentation available.' )
-      raise
+    except language_server_completer.NoHoverInfoException:
+      raise RuntimeError( 'No documentation available.' )
 
 
   def GetType( self, request_data ):
@@ -99,10 +98,8 @@ class GoCompleter( simple_language_server_completer.SimpleLSPCompleter ):
       result = json.loads(
           self.GetHoverResponse( request_data )[ 'value' ] )[ 'signature' ]
       return responses.BuildDisplayMessageResponse( result )
-    except RuntimeError as e:
-      if e.args[ 0 ] == 'No hover information.':
-        raise RuntimeError( 'Unknown type.' )
-      raise
+    except language_server_completer.NoHoverInfoException:
+      raise RuntimeError( 'Unknown type.' )
 
 
   def DefaultSettings( self, request_data ):

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -112,6 +112,12 @@ DEFAULT_SUBCOMMANDS_MAP = {
 }
 
 
+class NoHoverInfoException( Exception ):
+  """ Raised instead of RuntimeError for empty hover responses, to allow
+      completers to easily distinguish empty hover from other errors."""
+  pass # pragma: no cover
+
+
 class ResponseTimeoutException( Exception ):
   """Raised by LanguageServerConnection if a request exceeds the supplied
   time-to-live."""
@@ -1855,7 +1861,7 @@ class LanguageServerCompleter( Completer ):
     result = response[ 'result' ]
     if result:
       return result[ 'contents' ]
-    raise RuntimeError( NO_HOVER_INFORMATION )
+    raise NoHoverInfoException( NO_HOVER_INFORMATION )
 
 
   def _GoToRequest( self, request_data, handler ):

--- a/ycmd/tests/clangd/subcommands_test.py
+++ b/ycmd/tests/clangd/subcommands_test.py
@@ -29,10 +29,12 @@ from hamcrest import ( assert_that,
                        has_entries,
                        has_entry,
                        matches_regexp )
+from mock import patch
 from pprint import pprint
 import requests
 import os.path
 
+from ycmd import handlers
 from ycmd.tests.clangd import ( IsolatedYcmd,
                                 SharedYcmd,
                                 PathToTestFile,
@@ -81,6 +83,47 @@ def Subcommands_DefinedSubcommands_test( app ):
       },
       'route': '/defined_subcommands',
   } )
+
+
+def Subcommands_ServerNotInitialized_test():
+
+  completer = handlers._server_state.GetFiletypeCompleter( [ 'cpp' ] )
+
+  @SharedYcmd
+  @patch.object( completer, '_ServerIsInitialized', return_value = False )
+  def Test( app, cmd, *args ):
+    request = {
+      'line_num': 1,
+      'column_num': 1,
+      'event_name': 'FileReadyToParse',
+      'filetype': 'cpp',
+      'command_arguments': [ cmd ]
+    }
+    app.post_json( '/event_notification',
+                   BuildRequest( **request ),
+                   expect_errors = True )
+    response = app.post_json(
+      '/run_completer_command',
+      BuildRequest( **request ),
+      expect_errors = True
+    )
+    assert_that( response.status_code, equal_to( requests.codes.server_error ) )
+    assert_that( response.json,
+                 ErrorMatcher( RuntimeError,
+                               'Server is initializing. Please wait.' ) )
+
+  yield Test, 'FixIt'
+  yield Test, 'Format'
+  yield Test, 'GetDoc'
+  yield Test, 'GetDocImprecise'
+  yield Test, 'GetType'
+  yield Test, 'GetTypeImprecise'
+  yield Test, 'GoTo'
+  yield Test, 'GoToDeclaration'
+  yield Test, 'GoToDefinition'
+  yield Test, 'GoToInclude'
+  yield Test, 'GoToReferences'
+  yield Test, 'RefactorRename'
 
 
 @SharedYcmd
@@ -294,26 +337,31 @@ def Subcommands_GetType_test():
   tests = [
     # Basic pod types
     [ { 'line_num': 24, 'column_num':  3 },
-      has_entry( 'message', contains_string( 'Foo' ) ) ],
-    # [ { 'line_num': 12, 'column_num':  2 }, 'Foo' ],
+      has_entry( 'message', contains_string( 'Foo' ) ),
+      requests.codes.ok ],
+    # [ { 'line_num': 12, 'column_num':  2 }, 'Foo',
     [ { 'line_num': 12, 'column_num':  8 },
-      has_entry( 'message', contains_string( 'Foo' ) ) ],
+      has_entry( 'message', contains_string( 'Foo' ) ),
+      requests.codes.ok ],
     [ { 'line_num': 12, 'column_num':  9 },
-      has_entry( 'message', contains_string( 'Foo' ) ) ],
+      has_entry( 'message', contains_string( 'Foo' ) ),
+      requests.codes.ok ],
     [ { 'line_num': 12, 'column_num': 10 },
-      has_entry( 'message', contains_string( 'Foo' ) ) ],
-    # [ { 'line_num': 13, 'column_num':  3 }, 'int' ],
+      has_entry( 'message', contains_string( 'Foo' ) ),
+      requests.codes.ok ],
+    # [ { 'line_num': 13, 'column_num':  3 }, 'int',
     [ { 'line_num': 13, 'column_num':  7 },
-      has_entry( 'message', contains_string( 'int' ) ) ],
+      has_entry( 'message', contains_string( 'int' ) ),
+      requests.codes.ok ],
     # [ { 'line_num': 15, 'column_num':  7 }, 'char' ],
 
     # Function
     # [ { 'line_num': 22, 'column_num':  2 }, 'int main()' ],
-    [ { 'line_num': 22, 'column_num':  6 }, 'int main()' ],
+    [ { 'line_num': 22, 'column_num':  6 }, 'int main()', requests.codes.ok ],
 
     # Declared and canonical type
     # On Ns::
-    [ { 'line_num': 25, 'column_num':  3 }, 'namespace Ns' ],
+    [ { 'line_num': 25, 'column_num':  3 }, 'namespace Ns', requests.codes.ok ],
     # On Type (Type)
     # [ { 'line_num': 25, 'column_num':  8 },
     # 'Ns::Type => Ns::BasicType<char>' ],
@@ -325,49 +373,65 @@ def Subcommands_GetType_test():
 
     # Cursor on decl for refs & pointers
     [ { 'line_num': 39, 'column_num':  3 },
-      has_entry( 'message', contains_string( 'Foo' ) ) ],
+      has_entry( 'message', contains_string( 'Foo' ) ),
+      requests.codes.ok ],
     [ { 'line_num': 39, 'column_num': 11 },
-      has_entry( 'message', contains_string( 'Foo &' ) ) ],
+      has_entry( 'message', contains_string( 'Foo &' ) ),
+      requests.codes.ok ],
     [ { 'line_num': 39, 'column_num': 15 },
-      has_entry( 'message', contains_string( 'Foo' ) ) ],
+      has_entry( 'message', contains_string( 'Foo' ) ),
+      requests.codes.ok ],
     [ { 'line_num': 40, 'column_num':  3 },
-      has_entry( 'message', contains_string( 'Foo' ) ) ],
+      has_entry( 'message', contains_string( 'Foo' ) ),
+      requests.codes.ok ],
     [ { 'line_num': 40, 'column_num': 11 },
-      has_entry( 'message', contains_string( 'Foo *' ) ) ],
+      has_entry( 'message', contains_string( 'Foo *' ) ),
+      requests.codes.ok ],
     [ { 'line_num': 40, 'column_num': 18 },
-      has_entry( 'message', contains_string( 'Foo' ) ) ],
+      has_entry( 'message', contains_string( 'Foo' ) ),
+      requests.codes.ok ],
     # [ { 'line_num': 42, 'column_num':  3 }, 'const Foo &' ],
     [ { 'line_num': 42, 'column_num': 16 },
-      has_entry( 'message', contains_string( 'const struct Foo &' ) ) ],
+      has_entry( 'message', contains_string( 'const struct Foo &' ) ),
+      requests.codes.ok ],
     # [ { 'line_num': 43, 'column_num':  3 }, 'const Foo *' ],
     [ { 'line_num': 43, 'column_num': 16 },
-      has_entry( 'message', contains_string( 'const struct Foo *' ) ) ],
+      has_entry( 'message', contains_string( 'const struct Foo *' ) ),
+      requests.codes.ok ],
 
     # Cursor on usage
     [ { 'line_num': 45, 'column_num': 13 },
-      has_entry( 'message', contains_string( 'const struct Foo' ) ) ],
+      has_entry( 'message', contains_string( 'const struct Foo' ) ),
+      requests.codes.ok ],
     # [ { 'line_num': 45, 'column_num': 19 }, 'const int' ],
     [ { 'line_num': 46, 'column_num': 13 },
-      has_entry( 'message', contains_string( 'const struct Foo *' ) ) ],
+      has_entry( 'message', contains_string( 'const struct Foo *' ) ),
+      requests.codes.ok ],
     # [ { 'line_num': 46, 'column_num': 20 }, 'const int' ],
     [ { 'line_num': 47, 'column_num': 12 },
-      has_entry( 'message', contains_string( 'Foo' ) ) ],
+      has_entry( 'message', contains_string( 'Foo' ) ),
+      requests.codes.ok ],
     [ { 'line_num': 47, 'column_num': 17 },
-      has_entry( 'message', contains_string( 'int' ) ) ],
+      has_entry( 'message', contains_string( 'int' ) ),
+      requests.codes.ok ],
     [ { 'line_num': 48, 'column_num': 12 },
-      has_entry( 'message', contains_string( 'Foo *' ) ) ],
+      has_entry( 'message', contains_string( 'Foo *' ) ),
+      requests.codes.ok ],
     [ { 'line_num': 48, 'column_num': 18 },
-      has_entry( 'message', contains_string( 'int' ) ) ],
+      has_entry( 'message', contains_string( 'int' ) ),
+      requests.codes.ok ],
 
     # Auto in declaration
     # [ { 'line_num': 28, 'column_num':  3 }, 'struct Foo &' ],
     # [ { 'line_num': 28, 'column_num': 11 }, 'struct Foo &' ],
     [ { 'line_num': 28, 'column_num': 18 },
-      has_entry( 'message', contains_string( 'struct Foo' ) ) ],
+      has_entry( 'message', contains_string( 'struct Foo' ) ),
+      requests.codes.ok ],
     # [ { 'line_num': 29, 'column_num':  3 }, 'Foo *' ],
     # [ { 'line_num': 29, 'column_num': 11 }, 'Foo *' ],
     [ { 'line_num': 29, 'column_num': 18 },
-      has_entry( 'message', contains_string( 'Foo' ) ) ],
+      has_entry( 'message', contains_string( 'Foo' ) ),
+      requests.codes.ok ],
     # [ { 'line_num': 31, 'column_num':  3 }, 'const Foo &' ],
     # [ { 'line_num': 31, 'column_num': 16 }, 'const Foo &' ],
     # [ { 'line_num': 32, 'column_num':  3 }, 'const Foo *' ],
@@ -379,16 +443,20 @@ def Subcommands_GetType_test():
     # [ { 'line_num': 35, 'column_num': 14 }, 'const Foo *' ],
     # [ { 'line_num': 35, 'column_num': 22 }, 'const int' ],
     [ { 'line_num': 36, 'column_num': 13 },
-      has_entry( 'message', contains_string( 'Foo' ) ) ],
+      has_entry( 'message', contains_string( 'Foo' ) ),
+      requests.codes.ok ],
     [ { 'line_num': 36, 'column_num': 19 },
-      has_entry( 'message', contains_string( 'int' ) ) ],
+      has_entry( 'message', contains_string( 'int' ) ),
+      requests.codes.ok ],
     # [ { 'line_num': 37, 'column_num': 13 }, 'Foo *' ],
     [ { 'line_num': 37, 'column_num': 20 },
-      has_entry( 'message', contains_string( 'int' ) ) ],
+      has_entry( 'message', contains_string( 'int' ) ),
+      requests.codes.ok ],
 
     # Unicode
     [ { 'line_num': 51, 'column_num': 13 },
-      has_entry( 'message', contains_string( 'Unicøde *' ) ) ],
+      has_entry( 'message', contains_string( 'Unicøde *' ) ),
+      requests.codes.ok ],
 
     # Bound methods
     # On Win32, methods pick up an __attribute__((thiscall)) to annotate their
@@ -396,10 +464,12 @@ def Subcommands_GetType_test():
     # also prohibitively complex to try and strip out.
     [ { 'line_num': 53, 'column_num': 15 },
       has_entry( 'message', matches_regexp(
-          r'int bar\(int i\)(?: __attribute__\(\(thiscall\)\))?' ) ) ],
+          r'int bar\(int i\)(?: __attribute__\(\(thiscall\)\))?' ) ),
+      requests.codes.ok ],
     [ { 'line_num': 54, 'column_num': 18 },
       has_entry( 'message', matches_regexp(
-          r'int bar\(int i\)(?: __attribute__\(\(thiscall\)\))?' ) ) ],
+          r'int bar\(int i\)(?: __attribute__\(\(thiscall\)\))?' ) ),
+      requests.codes.ok ],
   ]
 
   for subcommand in [ 'GetType', 'GetTypeImprecise' ]:
@@ -408,7 +478,8 @@ def Subcommands_GetType_test():
               PathToTestFile( 'GetType_Clang_test.cc' ),
               'cpp',
               test,
-              [ subcommand ] )
+              [ subcommand ],
+              test[ 2 ] )
 
 
 def Subcommands_GetDoc_test():
@@ -427,7 +498,7 @@ def Subcommands_GetDoc_test():
       requests.codes.ok ],
     # no hover
     [ { 'line_num': 8, 'column_num': 1 },
-      ErrorMatcher( RuntimeError, 'No hover information.' ),
+      ErrorMatcher( RuntimeError, 'No documentation available.' ),
       requests.codes.server_error ]
   ]
   for subcommand in [ 'GetDoc', 'GetDocImprecise' ]:

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -40,6 +40,7 @@ from hamcrest import ( all_of,
 
 from ycmd.completers.language_server import language_server_completer as lsc
 from ycmd.completers.language_server.language_server_completer import (
+    NoHoverInfoException,
     NO_HOVER_INFORMATION )
 from ycmd.completers.language_server import language_server_protocol as lsp
 from ycmd.tests.language_server import MockConnection
@@ -1194,7 +1195,7 @@ def LanguageServerCompleter_GetHoverResponse_test():
                        side_effect = [ { 'result': None } ] ):
       assert_that(
         calling( completer.GetHoverResponse ).with_args( request_data ),
-        raises( RuntimeError, NO_HOVER_INFORMATION )
+        raises( NoHoverInfoException, NO_HOVER_INFORMATION )
       )
     with patch.object( completer.GetConnection(),
                        'GetResponse',


### PR DESCRIPTION
Instead of reporting `No hover information.` we can actually report `No diagnostic/type information available.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1371)
<!-- Reviewable:end -->
