### PR TITLE
Feature Request: Add build.py CMake executable location argument

### DIFF
--- a/build.py
+++ b/build.py
@@ -444,6 +444,10 @@ def ParseArguments():
                               'on the ycm_core code itself.' )
   parser.add_argument( '--core-tests', nargs = '?', const = '*',
                        help = 'Run core tests and optionally filter them.' )
+  parser.add_argument( '--cmake-path',
+                       help = 'For developers: specify the cmake executable. '
+                              'Useful for testing with specific versions, or '
+                              'if the system is unable to find cmake.' )
 
   # These options are deprecated.
   parser.add_argument( '--omnisharp-completer', action = 'store_true',
@@ -480,8 +484,13 @@ def ParseArguments():
   return args
 
 
-def FindCmake():
-  return FindExecutableOrDie( 'cmake', 'CMake is required to build ycmd' )
+def FindCmake( args ):
+  cmake_exe = 'cmake'
+
+  if args.cmake_path:
+    cmake_exe = args.cmake_path
+
+  return FindExecutableOrDie( cmake_exe, 'CMake is required to build ycmd' )
 
 
 def GetCmakeCommonArgs( args ):
@@ -1106,7 +1115,7 @@ def WritePythonUsedDuringBuild():
 
 
 def DoCmakeBuilds( args ):
-  cmake = FindCmake()
+  cmake = FindCmake( args )
   cmake_common_args = GetCmakeCommonArgs( args )
 
   if not args.skip_build:


### PR DESCRIPTION
I run YouCompleteMe on Windows at work. I frequently run into issues with the CMake detection logic in `build.py`. 

In these cases CMake is always installed, in `%PATH%`, and callable from `cmd.exe`:
``` bash
> where python
{ Prints path to cmake.exe }
> cmake --version
{ Prints CMake version }
> build.py
ERROR: Unable to find executable 'cmake'. CMake is required to build ycmd
```

I usually work around this issue temporarily by hard-coding the problematic line:
```patch
-return FindExecutableOrDie( 'cmake' , 'CMake is required to build ycmd' )
+return '''C:\Program Files\CMake\bin\cmake.exe'''
```

It would be nice to have an argument where the CMake executable can be quickly specified. Any thoughts on adding such an argument?

Here is a simple patch... I'm happy to change anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1375)
<!-- Reviewable:end -->
