### PR TITLE
increased timeout since some bigger projects seemed to hit the timeout

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -42,7 +42,7 @@ from ycmd.utils import LOGGER, re
 SERVER_NOT_RUNNING_MESSAGE = 'TSServer is not running.'
 NO_DIAGNOSTIC_MESSAGE = 'No diagnostic for current line!'
 
-RESPONSE_TIMEOUT_SECONDS = 10
+RESPONSE_TIMEOUT_SECONDS = 20
 
 TSSERVER_DIR = os.path.abspath(
   os.path.join( os.path.dirname( __file__ ), '..', '..', '..', 'third_party',


### PR DESCRIPTION
@bstaletic as discussed
this pull request is related to a problem that occurred on a bigger project
where on initial tsserver go to def load it would take up to more then 10 seconds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1376)
<!-- Reviewable:end -->
