### PR TITLE
[READY] Add typescriptreact default semantic triggers

### DIFF
--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -226,6 +226,7 @@ DEFAULT_FILETYPE_TRIGGERS = {
     'python,'
     'scala,'
     'typescript,'
+    'typescriptreact,'
     'vb' ) : [ '.' ],
   'ruby,rust' : [ '.', '::' ],
   'lua' : [ '.', ':' ],

--- a/ycmd/tests/typescript/get_completions_test.py
+++ b/ycmd/tests/typescript/get_completions_test.py
@@ -49,12 +49,12 @@ from ycmd.utils import ReadFile
 
 def RunTest( app, test ):
   contents = ReadFile( test[ 'request' ][ 'filepath' ] )
-
+  filetype = test[ 'request' ].get( 'filetype', 'typescript' )
   app.post_json(
     '/event_notification',
     CombineRequest( test[ 'request' ], {
       'contents': contents,
-      'filetype': 'typescript',
+      'filetype': filetype,
       'event_name': 'BufferVisit'
     } )
   )
@@ -285,6 +285,31 @@ def GetCompletions_AutoImport_test( app ):
               } )
             )
           } )
+        } ) )
+      } )
+    }
+  } )
+
+
+@SharedYcmd
+def GetCompletions_TypeScriptReact_DefaultTriggers_test( app ):
+  filepath = PathToTestFile( 'test.tsx' )
+  RunTest( app, {
+    'description': 'No need to force after a semantic trigger',
+    'request': {
+      'line_num': 17,
+      'column_num': 3,
+      'filepath': filepath,
+      'filetype': 'typescriptreact'
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completions': has_item( has_entries( {
+          'insertion_text':  'foo',
+          'extra_menu_info': "(property) 'foo': number",
+          'detailed_info':   "(property) 'foo': number",
+          'kind':            'property',
         } ) )
       } )
     }

--- a/ycmd/tests/typescript/testdata/test.tsx
+++ b/ycmd/tests/typescript/testdata/test.tsx
@@ -12,3 +12,6 @@ const TestComponent: React.FunctionComponent<MyComponentProps> = (props) => {
     </div>
   );
 };
+
+const a = { 'foo': 3 }
+a.


### PR DESCRIPTION
Fixes #1377 

The pull reequest that added typescriptreact support did not add the default semantic completion triggers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1378)
<!-- Reviewable:end -->
