### PR TITLE
[READY] Implement `Format` subcommand for the C# completer

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -33,7 +33,10 @@ import threading
 from ycmd.completers.completer import Completer
 from ycmd.completers.completer_utils import GetFileLines
 from ycmd.completers.cs import solutiondetection
-from ycmd.utils import CodepointOffsetToByteOffset, LOGGER, urljoin
+from ycmd.utils import ( ByteOffsetToCodepointOffset,
+                         CodepointOffsetToByteOffset,
+                         LOGGER,
+                         urljoin )
 from ycmd import responses
 from ycmd import utils
 
@@ -605,7 +608,30 @@ class CsharpSolutionCompleter( object ):
   def _Format( self, request_data ):
     request = self._DefaultParameters( request_data )
     request[ 'WantsTextChanges' ] = True
-    result = self._GetResponse( '/codeformat', request )
+    if 'range' in request_data:
+      lines = request_data[ 'lines' ]
+      start = request_data[ 'range' ][ 'start' ]
+      start_line_num = start[ 'line_num' ]
+      start_line_value = lines[ start_line_num ]
+
+      start_codepoint = ByteOffsetToCodepointOffset( start_line_value,
+                                                     start[ 'column_num' ] )
+
+      end = request_data[ 'range' ][ 'end' ]
+      end_line_num = end[ 'line_num' ]
+      end_line_value = lines[ end_line_num ]
+      end_codepoint = ByteOffsetToCodepointOffset( end_line_value,
+                                                   end[ 'column_num' ] )
+      request.update( {
+        'line': start_line_num,
+        'column': start_codepoint,
+        'EndLine': end_line_num,
+        'EndColumn': end_codepoint
+      } )
+      result = self._GetResponse( '/formatRange', request )
+    else:
+      result = self._GetResponse( '/codeformat', request )
+
     fixit = responses.FixIt(
       _BuildLocation(
         request_data,

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -194,6 +194,9 @@ class CsharpCompleter( Completer ):
       'GetType'                          : ( lambda self, request_data, args:
          self._SolutionSubcommand( request_data,
                                    method = '_GetType' ) ),
+      'Format'                           : ( lambda self, request_data, args:
+         self._SolutionSubcommand( request_data,
+                                   method = '_Format' ) ),
       'FixIt'                            : ( lambda self, request_data, args:
          self._SolutionSubcommand( request_data,
                                    method = '_FixIt' ) ),
@@ -597,6 +600,23 @@ class CsharpSolutionCompleter( object ):
     message = result[ "Type" ]
 
     return responses.BuildDisplayMessageResponse( message )
+
+
+  def _Format( self, request_data ):
+    request = self._DefaultParameters( request_data )
+    request[ 'WantsTextChanges' ] = True
+    result = self._GetResponse( '/codeformat', request )
+    fixit = responses.FixIt(
+      _BuildLocation(
+        request_data,
+        request_data[ 'filepath' ],
+        request_data[ 'line_num' ],
+        request_data[ 'column_codepoint' ] ),
+      _LinePositionSpanTextChangeToFixItChunks(
+        result[ 'Changes' ],
+        request_data[ 'filepath' ],
+        request_data ) )
+    return responses.BuildFixItResponse( [ fixit ] )
 
 
   def _FixIt( self, request_data ):

--- a/ycmd/tests/cs/subcommands_test.py
+++ b/ycmd/tests/cs/subcommands_test.py
@@ -31,6 +31,7 @@ from ycmd import user_options_store
 from ycmd.tests.cs import ( IsolatedYcmd, PathToTestFile, SharedYcmd,
                             WrapOmniSharpServer )
 from ycmd.tests.test_utils import ( BuildRequest,
+                                    ChunkMatcher,
                                     ErrorMatcher,
                                     LocationMatcher,
                                     MockProcessTerminationTimingOut,
@@ -791,3 +792,50 @@ def Subcommands_StopServer_Timeout_test( app ):
                    has_entry( 'is_running', False )
                  ) )
                ) )
+
+
+@SharedYcmd
+def Subcommands_Format_Works_test( app ):
+  filepath = PathToTestFile( 'testy', 'Program.cs' )
+  with WrapOmniSharpServer( app, filepath ):
+    contents = ReadFile( filepath )
+
+    getdoc_data = BuildRequest( command_arguments = [ 'Format' ],
+                                line_num = 1,
+                                column_num = 1,
+                                contents = contents,
+                                filetype = 'cs',
+                                filepath = filepath )
+
+    response = app.post_json( '/run_completer_command', getdoc_data ).json
+    print( 'completer response = ', response )
+    assert_that( response, has_entries( { 'fixits': contains( has_entries( {
+      'location': LocationMatcher( filepath, 1, 1 ),
+      'chunks': contains(
+        ChunkMatcher(
+          '\n        }\n    ',
+          LocationMatcher( filepath, 11, 1 ),
+          LocationMatcher( filepath, 12, 2 )
+        ),
+        ChunkMatcher(
+          '            ',
+          LocationMatcher( filepath, 10, 1 ),
+          LocationMatcher( filepath, 10, 4 )
+        ),
+        ChunkMatcher(
+          '        {\n            ',
+          LocationMatcher( filepath, 8, 1 ),
+          LocationMatcher( filepath, 9, 4 )
+        ),
+        ChunkMatcher(
+          '',
+          LocationMatcher( filepath, 7, 26 ),
+          LocationMatcher( filepath, 7, 27 )
+        ),
+        ChunkMatcher(
+          '    class MainClass\n    {\n        ',
+          LocationMatcher( filepath, 5, 1 ),
+          LocationMatcher( filepath, 7, 3 )
+        ),
+      )
+    } ) ) } ) )

--- a/ycmd/tests/cs/subcommands_test.py
+++ b/ycmd/tests/cs/subcommands_test.py
@@ -800,14 +800,14 @@ def Subcommands_Format_Works_test( app ):
   with WrapOmniSharpServer( app, filepath ):
     contents = ReadFile( filepath )
 
-    getdoc_data = BuildRequest( command_arguments = [ 'Format' ],
-                                line_num = 1,
-                                column_num = 1,
-                                contents = contents,
-                                filetype = 'cs',
-                                filepath = filepath )
+    request = BuildRequest( command_arguments = [ 'Format' ],
+                            line_num = 1,
+                            column_num = 1,
+                            contents = contents,
+                            filetype = 'cs',
+                            filepath = filepath )
 
-    response = app.post_json( '/run_completer_command', getdoc_data ).json
+    response = app.post_json( '/run_completer_command', request ).json
     print( 'completer response = ', response )
     assert_that( response, has_entries( { 'fixits': contains( has_entries( {
       'location': LocationMatcher( filepath, 1, 1 ),
@@ -836,6 +836,46 @@ def Subcommands_Format_Works_test( app ):
           '    class MainClass\n    {\n        ',
           LocationMatcher( filepath, 5, 1 ),
           LocationMatcher( filepath, 7, 3 )
+        ),
+      )
+    } ) ) } ) )
+
+
+@SharedYcmd
+def Subcommands_RangeFormat_Works_test( app ):
+  filepath = PathToTestFile( 'testy', 'Program.cs' )
+  with WrapOmniSharpServer( app, filepath ):
+    contents = ReadFile( filepath )
+
+    request = BuildRequest( command_arguments = [ 'Format' ],
+                            line_num = 11,
+                            column_num = 2,
+                            contents = contents,
+                            filetype = 'cs',
+                            filepath = filepath )
+    request[ 'range' ] = {
+      'start': { 'line_num':  8, 'column_num': 1 },
+      'end':   { 'line_num': 11, 'column_num': 4 }
+    }
+    response = app.post_json( '/run_completer_command', request ).json
+    print( 'completer response = ', response )
+    assert_that( response, has_entries( { 'fixits': contains( has_entries( {
+      'location': LocationMatcher( filepath, 11, 2 ),
+      'chunks': contains(
+        ChunkMatcher(
+          '\n        ',
+          LocationMatcher( filepath, 11, 1 ),
+          LocationMatcher( filepath, 11, 3 )
+        ),
+        ChunkMatcher(
+          '            ',
+          LocationMatcher( filepath, 10, 1 ),
+          LocationMatcher( filepath, 10, 4 )
+        ),
+        ChunkMatcher(
+          '        {\n            ',
+          LocationMatcher( filepath, 8, 1 ),
+          LocationMatcher( filepath, 9, 4 )
         ),
       )
     } ) ) } ) )


### PR DESCRIPTION
Just what the title says. There are two things I need to point out. 

There *is* a [`/formatRange`](https://github.com/OmniSharp/omnisharp-roslyn/blob/master/src/OmniSharp.Abstractions/OmniSharpEndpoints.cs#L12) request, but it is only concerned with the end codepoint. Without the start codepoint, ranged formatting request seems completely broken. https://github.com/OmniSharp/omnisharp-roslyn/blob/master/src/OmniSharp.Abstractions/Models/v1/Format/FormatRangeRequest.cs

The `/codeformat` request formats the entire file and has no format options: https://github.com/OmniSharp/omnisharp-roslyn/blob/master/src/OmniSharp.Abstractions/Models/v1/CodeFormat/CodeFormatRequest.cs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1380)
<!-- Reviewable:end -->
