### PR TITLE
[READY] Support user-specified project directory in LSP servers

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -19,7 +19,8 @@ import ycm_core
 import os
 import inspect
 from ycmd import extra_conf_store
-from ycmd.utils import ( OnMac,
+from ycmd.utils import ( AbsoluatePath,
+                         OnMac,
                          OnWindows,
                          PathsToAllParentFolders,
                          re,
@@ -609,9 +610,7 @@ def _MakeRelativePathsInFlagsAbsolute( flags, working_directory ):
 
     if make_next_absolute:
       make_next_absolute = False
-      if not os.path.isabs( new_flag ):
-        new_flag = os.path.join( working_directory, flag )
-      new_flag = os.path.normpath( new_flag )
+      new_flag = AbsoluatePath( flag, working_directory )
     else:
       for path_flag in path_flags:
         # Single dash argument alone, e.g. -isysroot <path>
@@ -623,10 +622,7 @@ def _MakeRelativePathsInFlagsAbsolute( flags, working_directory ):
         # or double-dash argument, e.g. --isysroot=<path>
         if flag.startswith( path_flag ):
           path = flag[ len( path_flag ): ]
-          if not os.path.isabs( path ):
-            path = os.path.join( working_directory, path )
-          path = os.path.normpath( path )
-
+          path = AbsoluatePath( path, working_directory )
           new_flag = '{0}{1}'.format( path_flag, path )
           break
 

--- a/ycmd/completers/go/go_completer.py
+++ b/ycmd/completers/go/go_completer.py
@@ -73,7 +73,7 @@ class GoCompleter( simple_language_server_completer.SimpleLSPCompleter ):
 
 
   def GetDoc( self, request_data ):
-    assert self._settings[ 'hoverKind' ] == 'Structured'
+    assert self._settings[ 'ls' ][ 'hoverKind' ] == 'Structured'
     try:
       result = json.loads( self.GetHoverResponse( request_data )[ 'value' ] )
       docs = result[ 'signature' ] + '\n' + result[ 'fullDocumentation' ]
@@ -92,5 +92,7 @@ class GoCompleter( simple_language_server_completer.SimpleLSPCompleter ):
 
 
   def DefaultSettings( self, request_data ):
-    return { 'hoverKind': 'Structured',
-             'fuzzyMatching': False }
+    return {
+      'hoverKind': 'Structured',
+      'fuzzyMatching': False,
+    }

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -441,6 +441,10 @@ class JavaCompleter( simple_language_server_completer.SimpleLSPCompleter ):
 
       if project_directory:
         self._java_project_dir = project_directory
+      elif 'project_directory' in self._settings:
+        self._java_project_dir = utils.AbsoluatePath(
+          self._settings[ 'project_directory' ],
+          self._extra_conf_dir )
       else:
         self._java_project_dir = _FindProjectDir(
           os.path.dirname( request_data[ 'filepath' ] ) )

--- a/ycmd/tests/java/conftest.py
+++ b/ycmd/tests/java/conftest.py
@@ -50,10 +50,15 @@ def teardown_module():
 
 
 def StartJavaCompleterServerInDirectory( app, directory ):
+  StartJavaCompleterServerWithFile( app,
+                                    os.path.join( directory, 'test.java' ) )
+
+
+def StartJavaCompleterServerWithFile( app, file_path ):
   app.post_json( '/event_notification',
                  BuildRequest(
-                   filepath = os.path.join( directory, 'test.java' ),
                    event_name = 'FileReadyToParse',
+                   filepath = file_path,
                    filetype = 'java' ) )
   WaitUntilCompleterServerReady( app, 'java', SERVER_STARTUP_TIMEOUT )
 

--- a/ycmd/tests/java/server_management_test.py
+++ b/ycmd/tests/java/server_management_test.py
@@ -32,7 +32,8 @@ from hamcrest import ( assert_that,
 from ycmd.tests.java import ( PathToTestFile,
                               IsolatedYcmd,
                               SharedYcmd,
-                              StartJavaCompleterServerInDirectory )
+                              StartJavaCompleterServerInDirectory,
+                              StartJavaCompleterServerWithFile )
 from ycmd.tests.test_utils import ( BuildRequest,
                                     CompleterProjectDirectoryMatcher,
                                     ErrorMatcher,
@@ -213,6 +214,29 @@ def ServerManagement_WipeWorkspace_WithConfig_test( isolated_app ):
             ) )
           ) )
         ) )
+
+
+@IsolatedYcmd( {
+  'extra_conf_globlist': PathToTestFile( 'multiple_projects', '*' )
+} )
+def ServerManagement_ProjectDetection_MultipleProjects_test( app ):
+  # The ycm_extra_conf.py file should set the project path to
+  # multiple_projects/src
+  project = PathToTestFile( 'multiple_projects', 'src' )
+  StartJavaCompleterServerWithFile( app,
+                                    os.path.join( project,
+                                                  'core',
+                                                  'java',
+                                                  'com',
+                                                  'puremourning',
+                                                  'widget',
+                                                  'core',
+                                                  'Utils.java' ) )
+
+  # Run the debug info to check that we have the correct project dir
+  request_data = BuildRequest( filetype = 'java' )
+  assert_that( app.post_json( '/debug_info', request_data ).json,
+               CompleterProjectDirectoryMatcher( project ) )
 
 
 @IsolatedYcmd()

--- a/ycmd/tests/java/testdata/multiple_projects/.ycm_extra_conf.py
+++ b/ycmd/tests/java/testdata/multiple_projects/.ycm_extra_conf.py
@@ -1,0 +1,4 @@
+def Settings( **kwargs ):
+  return {
+    'project_directory': './src'
+  }

--- a/ycmd/tests/java/testdata/multiple_projects/src/core/.classpath
+++ b/ycmd/tests/java/testdata/multiple_projects/src/core/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+        <classpathentry kind="src" output="target/classes" path="java" />
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+        <classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/ycmd/tests/java/testdata/multiple_projects/src/core/.project
+++ b/ycmd/tests/java/testdata/multiple_projects/src/core/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This is the minimal project configuration (combined with .cloasspath) that
+  allow JDT LS to fully work with a trivial eclipse project.
+  Specification:
+     https://help.eclipse.org/oxygen/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fmisc%2Fproject_description_file.html
+-->
+<projectDescription>
+  <name>com.puremourning.widget.core</name>
+  <comment></comment>
+  <projects>
+  </projects>
+  <buildSpec>
+    <buildCommand>
+      <name>org.eclipse.jdt.core.javabuilder</name>
+      <arguments>
+      </arguments>
+    </buildCommand>
+  </buildSpec>
+  <natures>
+    <nature>org.eclipse.jdt.core.javanature</nature>
+  </natures>
+</projectDescription>

--- a/ycmd/tests/java/testdata/multiple_projects/src/core/java/com/puremourning/widget/core/Utils.java
+++ b/ycmd/tests/java/testdata/multiple_projects/src/core/java/com/puremourning/widget/core/Utils.java
@@ -1,0 +1,10 @@
+package com.puremourning.widget.core;
+
+public class Utils
+{
+  public static int Test = 100;
+
+  public static void DoSomething() {
+    System.out.println( "test " + Test );
+  }
+}

--- a/ycmd/tests/java/testdata/multiple_projects/src/input/.classpath
+++ b/ycmd/tests/java/testdata/multiple_projects/src/input/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+        <classpathentry kind="src" output="target/classes" path="java" />
+        <classpathentry exported="true" kind="src" path="/com.puremourning.widget.core/" />
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+        <classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/ycmd/tests/java/testdata/multiple_projects/src/input/.project
+++ b/ycmd/tests/java/testdata/multiple_projects/src/input/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This is the minimal project configuration (combined with .cloasspath) that
+  allow JDT LS to fully work with a trivial eclipse project.
+  Specification:
+     https://help.eclipse.org/oxygen/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fmisc%2Fproject_description_file.html
+-->
+<projectDescription>
+  <name>com.puremourning.widget.input</name>
+  <comment></comment>
+  <projects>
+  </projects>
+  <buildSpec>
+    <buildCommand>
+      <name>org.eclipse.jdt.core.javabuilder</name>
+      <arguments>
+      </arguments>
+    </buildCommand>
+  </buildSpec>
+  <natures>
+    <nature>org.eclipse.jdt.core.javanature</nature>
+  </natures>
+</projectDescription>

--- a/ycmd/tests/java/testdata/multiple_projects/src/input/java/com/puremourning/widget/input/InputApp.java
+++ b/ycmd/tests/java/testdata/multiple_projects/src/input/java/com/puremourning/widget/input/InputApp.java
@@ -1,0 +1,12 @@
+package com.puremourning.widget.input;
+
+import com.puremourning.widget.core.Utils;
+
+public class InputApp {
+  public static void main( String[] args ) {
+    Utils.DoSomething();
+    if ( Utils.Test == 1 ) {
+
+    }
+  }
+}

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -100,10 +100,10 @@ def LanguageServerCompleter_ExtraConf_ServerReset_test( app ):
 
   completer.OnFileReadyToParse( request_data )
   assert_that( completer._project_directory, is_not( None ) )
-  assert_that( completer._settings, is_not( empty() ) )
+  assert_that( completer._settings.get( 'ls', {} ), is_not( empty() ) )
 
   completer.ServerReset()
-  assert_that( completer._settings, empty() )
+  assert_that( completer._settings.get( 'ls', {} ), empty() )
   assert_that( None, equal_to( completer._project_directory ) )
 
 
@@ -117,7 +117,7 @@ def LanguageServerCompleter_ExtraConf_FileEmpty_test( app ):
                                             filetype = 'ycmtest',
                                             contents = '' ) )
   completer.OnFileReadyToParse( request_data )
-  assert_that( {}, equal_to( completer._settings ) )
+  assert_that( {}, equal_to( completer._settings.get( 'ls', {} ) ) )
 
   # Simulate receipt of response and initialization complete
   initialize_response = {
@@ -126,7 +126,7 @@ def LanguageServerCompleter_ExtraConf_FileEmpty_test( app ):
     }
   }
   completer._HandleInitializeInPollThread( initialize_response )
-  assert_that( {}, equal_to( completer._settings ) )
+  assert_that( {}, equal_to( completer._settings.get( 'ls', {} ) ) )
   # We shouldn't have used the extra_conf path for the project directory, but
   # that _also_ happens to be the path of the file we opened.
   assert_that( PathToTestFile( 'extra_confs' ),
@@ -144,7 +144,7 @@ def LanguageServerCompleter_ExtraConf_SettingsReturnsNone_test( app ):
                                             filetype = 'ycmtest',
                                             contents = '' ) )
   completer.OnFileReadyToParse( request_data )
-  assert_that( {}, equal_to( completer._settings ) )
+  assert_that( {}, equal_to( completer._settings.get( 'ls', {} ) ) )
   # We shouldn't have used the extra_conf path for the project directory, but
   # that _also_ happens to be the path of the file we opened.
   assert_that( PathToTestFile( 'extra_confs' ),
@@ -162,10 +162,10 @@ def LanguageServerCompleter_ExtraConf_SettingValid_test( app ):
                                             working_dir = PathToTestFile(),
                                             contents = '' ) )
 
-  assert_that( {}, equal_to( completer._settings ) )
+  assert_that( {}, equal_to( completer._settings.get( 'ls', {} ) ) )
   completer.OnFileReadyToParse( request_data )
   assert_that( { 'java.rename.enabled' : False },
-               equal_to( completer._settings ) )
+               equal_to( completer._settings.get( 'ls', {} ) ) )
   # We use the working_dir not the path to the global extra conf (which is
   # ignored)
   assert_that( PathToTestFile(), equal_to( completer._project_directory ) )
@@ -181,9 +181,9 @@ def LanguageServerCompleter_ExtraConf_NoExtraConf_test( app ):
                                             working_dir = PathToTestFile(),
                                             contents = '' ) )
 
-  assert_that( {}, equal_to( completer._settings ) )
+  assert_that( {}, equal_to( completer._settings.get( 'ls', {} ) ) )
   completer.OnFileReadyToParse( request_data )
-  assert_that( {}, equal_to( completer._settings ) )
+  assert_that( {}, equal_to( completer._settings.get( 'ls', {} ) ) )
 
   # Simulate receipt of response and initialization complete
   initialize_response = {
@@ -192,7 +192,7 @@ def LanguageServerCompleter_ExtraConf_NoExtraConf_test( app ):
     }
   }
   completer._HandleInitializeInPollThread( initialize_response )
-  assert_that( {}, equal_to( completer._settings ) )
+  assert_that( {}, equal_to( completer._settings.get( 'ls', {} ) ) )
   # We use the client working directory
   assert_that( PathToTestFile(), equal_to( completer._project_directory ) )
 
@@ -210,10 +210,10 @@ def LanguageServerCompleter_ExtraConf_NonGlobal_test( app ):
                                             working_dir = 'ignore_this',
                                             contents = '' ) )
 
-  assert_that( {}, equal_to( completer._settings ) )
+  assert_that( {}, equal_to( completer._settings.get( 'ls', {} ) ) )
   completer.OnFileReadyToParse( request_data )
   assert_that( { 'java.rename.enabled' : False },
-               equal_to( completer._settings ) )
+               equal_to( completer._settings.get( 'ls', {} ) ) )
 
   # Simulate receipt of response and initialization complete
   initialize_response = {

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -508,3 +508,12 @@ def GetClangResourceDir():
 
 
 CLANG_RESOURCE_DIR = GetClangResourceDir()
+
+
+def AbsoluatePath( path, relative_to ):
+  """Returns a normalised, absoluate path to |path|. If |path| is relative, it
+  is resolved relative to |relative_to|."""
+  if not os.path.isabs( path ):
+    path = os.path.join( relative_to, path )
+
+  return os.path.normpath( path )


### PR DESCRIPTION
Store all settings returned from the Settings function

Allow extra conf to supply project directory. This is useful at least
for java with complex workspaces containing multiple .project files

For the output in debug info, we _could_ change to show all settings,
but for now, let's keep it as it was before.

TODO:
* [ ] Tests for other language server backends

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1381)
<!-- Reviewable:end -->
