### PR TITLE
[READY] Run valgrind in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
         YCM_BENCHMARK: true
         COVERAGE: false
       'C++ linting':
-        YCM_PYTHON_VERSION: '3.6.3'
+        YCM_PYTHON_VERSION: '3.8.0'
         YCM_CLANG_TIDY: true
         COVERAGE: false
     maxParallel: 6

--- a/azure/lint.sh
+++ b/azure/lint.sh
@@ -13,7 +13,7 @@ pyenv global ${YCM_PYTHON_VERSION}
 python_version=$(python -c 'import sys; print( "{}.{}.{}".format( *sys.version_info[:3] ) )')
 echo "Checking python version (actual ${python_version} vs expected ${YCM_PYTHON_VERSION})"
 test ${python_version} == ${YCM_PYTHON_VERSION}
-
-python build.py --clang-completer --clang-tidy --no-regex
+YCM_TESTRUN=1 python build.py --clang-completer --clang-tidy --valgrind
+python run_tests.py --valgrind --skip-build --no-flake8
 
 set +e

--- a/azure/linux/install_dependencies.sh
+++ b/azure/linux/install_dependencies.sh
@@ -20,7 +20,7 @@ if [ "${YCM_CLANG_TIDY}" ]; then
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
   sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
   sudo apt-get update
-  sudo apt-get install -y clang-tidy-8
+  sudo apt-get install -y clang-tidy-8 valgrind
   sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-8 100
 fi
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ xfail_strict = true
 log_level = debug
 log_date_format = "%Y-%m-%d %H:%M:%S"
 log_format = "%(asctime)s - %(levelname)s - %(message)s"
+markers = valgrind_skip

--- a/run_tests.py
+++ b/run_tests.py
@@ -149,6 +149,9 @@ def ParseArguments():
   parser.add_argument( '--quiet', action = 'store_true',
                        help = 'Quiet installation mode. Just print overall '
                               'progress and errors' )
+  parser.add_argument( '--valgrind',
+                       action = 'store_true',
+                       help = 'Run tests inside valgrind.' )
 
   parsed_args, pytests_args = parser.parse_known_args()
 
@@ -211,6 +214,37 @@ def BuildYcmdLibs( args ):
       build_cmd.append( '--quiet' )
 
     subprocess.check_call( build_cmd )
+
+
+def PytestValgrind( parsed_args, extra_pytests_args ):
+  pytests_args = [ '-v' ]
+  if extra_pytests_args:
+    pytests_args.extend( extra_pytests_args )
+  else:
+    pytests_args += glob.glob(
+      p.join( DIR_OF_THIS_SCRIPT, 'ycmd', 'tests', 'bindings', '*_test.py' ) )
+    pytests_args += glob.glob(
+      p.join( DIR_OF_THIS_SCRIPT, 'ycmd', 'tests', 'clang', '*_test.py' ) )
+    pytests_args += glob.glob(
+      p.join( DIR_OF_THIS_SCRIPT, 'ycmd', 'tests', '*_test.py' ) )
+    # Avoids needing all completers for a valgrind run
+    pytests_args += [ '-m', 'not valgrind_skip' ]
+
+  new_env = os.environ.copy()
+  new_env[ 'PYTHONMALLOC' ] = 'malloc'
+  new_env[ 'LD_LIBRARY_PATH' ] = LIBCLANG_DIR
+  cmd = [ 'valgrind',
+          '--gen-suppressions=all',
+          '--error-exitcode=1',
+          '--leak-check=full',
+          '--show-leak-kinds=all',
+          '--show-reachable=no',
+          '--suppressions=' + p.join( DIR_OF_THIS_SCRIPT,
+                                      'valgrind.suppressions' ) ]
+  subprocess.check_call( cmd +
+                         [ sys.executable, '-m', 'pytest' ] +
+                         pytests_args,
+                         env = new_env )
 
 
 def PytestTests( parsed_args, extra_pytests_args ):
@@ -305,7 +339,10 @@ def Main():
   if not parsed_args.no_flake8:
     RunFlake8()
   BuildYcmdLibs( parsed_args )
-  PytestTests( parsed_args, pytests_args )
+  if parsed_args.valgrind:
+    PytestValgrind( parsed_args, pytests_args )
+  else:
+    PytestTests( parsed_args, pytests_args )
 
 
 if __name__ == "__main__":

--- a/valgrind.suppressions
+++ b/valgrind.suppressions
@@ -1,0 +1,352 @@
+{
+	Python default invocation - possibly lost
+	Memcheck:Leak
+	fun:malloc
+	fun:_PyLong_New
+}
+{
+	Python default invocation - possibly lost
+	Memcheck:Leak
+	fun:malloc
+	fun:_PyBytes_FromSize
+}
+{
+	Python default invocation - possibly lost
+	Memcheck:Leak
+	fun:malloc
+	fun:_PyObject_GC_Alloc
+}
+{
+	Python default invocation - possibly lost
+	Memcheck:Leak
+	fun:malloc
+	fun:new_dict_with_shared_keys
+	fun:_PyObjectDict_SetItem
+}
+{
+	Python default invocation - possibly lost
+	Memcheck:Leak
+	fun:malloc
+	fun:new_keys_object
+	fun:dictresize
+	fun:insertion_resize
+	fun:insertdict
+	fun:PyDict_SetItem
+}
+{
+	Python default invocation - possibly lost
+	Memcheck:Leak
+	fun:malloc
+	fun:new_keys_object
+	fun:insert_to_emptydict
+	fun:PyDict_SetItem
+}
+{
+	Python default invocation - possibly lost
+	Memcheck:Leak
+	fun:malloc
+	fun:PyFloat_FromDouble
+}
+{
+	Python default invocation - possibly lost
+	Memcheck:Leak
+	fun:malloc
+	fun:PyUnicode_New
+}
+{
+	Python default invocation - possibly lost
+	Memcheck:Leak
+	fun:malloc
+	fun:clone_combined_dict
+	fun:PyDict_Copy
+}
+{
+	Python default invocation - possibly lost
+	Memcheck:Leak
+	fun:realloc
+	fun:_PyObject_GC_Resize
+}
+{
+	Python default invocation - possibly lost
+	Memcheck:Leak
+	fun:malloc
+	fun:PyCode_NewWithPosOnlyArgs
+}
+{
+	Python default invocation - possibly lost
+	Memcheck:Leak
+	fun:malloc
+	fun:new_keys_object
+	fun:_PyDict_NewPresized
+}
+{
+	Python default invocation - possibly lost
+	Memcheck:Leak
+	fun:malloc
+	fun:new_keys_object
+	fun:dictresize
+	fun:insertion_resize
+	fun:PyDict_SetDefault
+}
+{
+	Python default invocation - possibly lost
+	Memcheck:Leak
+	fun:malloc
+	fun:new_keys_object
+	fun:dictresize
+	fun:dict_merge
+	fun:PyDict_Update
+	fun:PyImport_Cleanup
+	fun:Py_FinalizeEx
+}
+{
+	GTest use of uninitialized value of size 8
+	Memcheck:Value8
+	fun:_itoa_word
+	fun:vfprintf
+	fun:__vsnprintf_chk
+	fun:__snprintf_chk
+	fun:_ZN7testing12_GLOBAL__N_126PrintByteSegmentInObjectToEPKhmmPSo
+	fun:_ZN7testing9internal220PrintBytesInObjectToEPKhmPSo
+	fun:_ZN7testing8internal20MatchPrintAndExplainIKSt6vectorIN13YouCompleteMe14CompletionDataESaIS4_EERS7_EEbRT_RKNS_7MatcherIT0_EEPNS_19MatchResultListenerE
+	fun:_ZNK7testing8internal29PredicateFormatterFromMatcherINS0_15ContainsMatcherINS_18PolymorphicMatcherINS0_15PropertyMatcherIN13YouCompleteMe14CompletionDataESsEEEEEEEclISt6vectorIS6_SaIS6_EEEENS_15AssertionResultEPKcRKT_
+	fun:_ZN13YouCompleteMe42ClangCompleterTest_BufferTextNoParens_Test8TestBodyEv
+	fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
+	fun:_ZN7testing4Test3RunEv
+	fun:_ZN7testing8TestInfo3RunEv
+}
+{
+	GTest conditional jump depends on uninitialized variable
+	Memcheck:Cond
+	fun:vfprintf
+	fun:__vsnprintf_chk
+	fun:__snprintf_chk
+	fun:_ZN7testing12_GLOBAL__N_126PrintByteSegmentInObjectToEPKhmmPSo
+	fun:_ZN7testing9internal220PrintBytesInObjectToEPKhmPSo
+	fun:_ZN7testing8internal20MatchPrintAndExplainIKSt6vectorIN13YouCompleteMe14CompletionDataESaIS4_EERS7_EEbRT_RKNS_7MatcherIT0_EEPNS_19MatchResultListenerE
+	fun:_ZNK7testing8internal29PredicateFormatterFromMatcherINS0_15ContainsMatcherINS_18PolymorphicMatcherINS0_15PropertyMatcherIN13YouCompleteMe14CompletionDataESsEEEEEEEclISt6vectorIS6_SaIS6_EEEENS_15AssertionResultEPKcRKT_
+	fun:_ZN13YouCompleteMe42ClangCompleterTest_BufferTextNoParens_Test8TestBodyEv
+	fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
+	fun:_ZN7testing4Test3RunEv
+	fun:_ZN7testing8TestInfo3RunEv
+	fun:_ZN7testing8TestCase3RunEv
+}
+{
+	GTest conditional jump depends on uninitialized variable
+	Memcheck:Cond
+	fun:_itoa_word
+	fun:vfprintf
+	fun:__vsnprintf_chk
+	fun:__snprintf_chk
+	fun:_ZN7testing12_GLOBAL__N_126PrintByteSegmentInObjectToEPKhmmPSo
+	fun:_ZN7testing9internal220PrintBytesInObjectToEPKhmPSo
+	fun:_ZN7testing8internal20MatchPrintAndExplainIKSt6vectorIN13YouCompleteMe14CompletionDataESaIS4_EERS7_EEbRT_RKNS_7MatcherIT0_EEPNS_19MatchResultListenerE
+	fun:_ZNK7testing8internal29PredicateFormatterFromMatcherINS0_15ContainsMatcherINS_18PolymorphicMatcherINS0_15PropertyMatcherIN13YouCompleteMe14CompletionDataESsEEEEEEEclISt6vectorIS6_SaIS6_EEEENS_15AssertionResultEPKcRKT_
+	fun:_ZN13YouCompleteMe42ClangCompleterTest_BufferTextNoParens_Test8TestBodyEv
+	fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
+	fun:_ZN7testing4Test3RunEv
+	fun:_ZN7testing8TestInfo3RunEv
+}
+{
+	Pytest during collection
+	Memcheck:Addr8
+	fun:strncmp
+	fun:is_dst
+	fun:_dl_dst_count
+	fun:expand_dynamic_string_token
+	fun:fillin_rpath
+	fun:decompose_rpath.isra.0
+	fun:_dl_map_object
+	fun:openaux
+	fun:_dl_catch_exception
+	fun:_dl_map_object_deps
+	fun:dl_open_worker
+	fun:_dl_catch_exception
+}
+{
+	Pytest during collection
+	Memcheck:Addr8
+	fun:strncmp
+	fun:is_dst
+	fun:_dl_dst_substitute
+	fun:fillin_rpath
+	fun:decompose_rpath.isra.0
+	fun:_dl_map_object
+	fun:openaux
+	fun:_dl_catch_exception
+	fun:_dl_map_object_deps
+	fun:dl_open_worker
+	fun:_dl_catch_exception
+	fun:_dl_open
+}
+{
+	Pybind11 leak, see https://github.com/pybind/pybind11/pull/2024 - definitely lost
+	Memcheck:Leak
+	match-leak-kinds: definite
+	fun:_Znwm
+	fun:_ZN8pybind116moduleC1EPKcS2_
+	fun:PyInit_ycm_core
+	fun:_PyImport_LoadDynamicModuleWithSpec
+	fun:_imp_create_dynamic_impl
+	fun:_imp_create_dynamic
+	fun:cfunction_vectorcall_FASTCALL
+	fun:PyVectorcall_Call
+	fun:do_call_core
+	fun:_PyEval_EvalFrameDefault
+	fun:_PyEval_EvalCodeWithName
+	fun:_PyFunction_Vectorcall
+	fun:_PyObject_Vectorcall
+	fun:call_function
+	fun:_PyEval_EvalFrameDefault
+	fun:function_code_fastcall
+}
+{
+	Libclang leak? - definitely lost
+	Memcheck:Leak
+	fun:_ZnwmRKSt9nothrow_t
+	fun:_ZN4llvm20WritableMemoryBuffer21getNewUninitMemBufferEmRKNS_5TwineE
+	fun:_ZN4llvm12MemoryBuffer16getMemBufferCopyENS_9StringRefERKNS_5TwineE
+	fun:_ZN4llvm12function_refIFvvEE11callback_fnIZ35clang_parseTranslationUnit2FullArgvEUlvE_EEvl
+	fun:_ZN4llvm20CrashRecoveryContext9RunSafelyENS_12function_refIFvvEEE
+	fun:_ZL26RunSafelyOnThread_DispatchPv
+	fun:_ZL24ExecuteOnThread_DispatchPv
+	fun:start_thread
+}
+{
+	Pytest at shutdown?
+	Memcheck:Leak
+	match-leak-kinds: possible
+	fun:malloc
+	fun:PyType_GenericAlloc
+	fun:s_new
+	fun:type_call
+	fun:_PyObject_MakeTpCall
+	fun:_PyObject_Vectorcall
+	fun:_PyObject_FastCall
+	fun:object_vacall
+	fun:PyObject_CallFunctionObjArgs
+	fun:cache_struct_converter
+	fun:pack
+	fun:cfunction_vectorcall_FASTCALL
+	fun:_PyObject_Vectorcall
+	fun:call_function
+	fun:_PyEval_EvalFrameDefault
+	fun:function_code_fastcall
+	fun:_PyObject_Vectorcall
+	fun:call_function
+	fun:_PyEval_EvalFrameDefault
+}
+{
+	Pytest at shutdown?
+	Memcheck:Leak
+	match-leak-kinds: possible
+	fun:malloc
+	fun:prepare_s
+	fun:Struct___init___impl
+	fun:Struct___init__
+	fun:type_call
+	fun:_PyObject_MakeTpCall
+	fun:_PyObject_Vectorcall
+	fun:_PyObject_FastCall
+	fun:object_vacall
+	fun:PyObject_CallFunctionObjArgs
+	fun:cache_struct_converter
+	fun:pack
+	fun:cfunction_vectorcall_FASTCALL
+	fun:_PyObject_Vectorcall
+	fun:call_function
+	fun:_PyEval_EvalFrameDefault
+	fun:function_code_fastcall
+	fun:_PyObject_Vectorcall
+	fun:call_function
+	fun:_PyEval_EvalFrameDefault
+	fun:function_code_fastcall
+}
+{
+	Pytest at shutdown?
+	Memcheck:Leak
+	match-leak-kinds: possible
+	fun:malloc
+	fun:PyType_GenericAlloc
+	fun:s_new
+	fun:type_call
+	fun:_PyObject_MakeTpCall
+	fun:_PyObject_Vectorcall
+	fun:_PyObject_FastCall
+	fun:object_vacall
+	fun:PyObject_CallFunctionObjArgs
+	fun:cache_struct_converter
+	fun:calcsize
+	fun:cfunction_vectorcall_O
+	fun:_PyObject_Vectorcall
+	fun:call_function
+	fun:_PyEval_EvalFrameDefault
+	fun:_PyEval_EvalCodeWithName
+	fun:PyEval_EvalCodeEx
+}
+{
+	Pytest at shutdown?
+	Memcheck:Leak
+	match-leak-kinds: possible
+	fun:malloc
+	fun:prepare_s
+	fun:Struct___init___impl
+	fun:Struct___init__
+	fun:type_call
+	fun:_PyObject_MakeTpCall
+	fun:_PyObject_Vectorcall
+	fun:_PyObject_FastCall
+	fun:object_vacall
+	fun:PyObject_CallFunctionObjArgs
+	fun:cache_struct_converter
+	fun:calcsize
+	fun:cfunction_vectorcall_O
+	fun:_PyObject_Vectorcall
+	fun:call_function
+	fun:_PyEval_EvalFrameDefault
+	fun:_PyEval_EvalCodeWithName
+	fun:PyEval_EvalCodeEx
+	fun:PyEval_EvalCode
+}
+{
+	Pytest at shutdown
+	Memcheck:Leak
+	match-leak-kinds: definite
+	fun:malloc
+	fun:_dl_map_object_deps
+	fun:dl_open_worker
+	fun:_dl_catch_error
+	fun:_dl_open
+	fun:dlopen_doit
+	fun:_dl_catch_error
+	fun:_dlerror_run
+	fun:dlopen@@GLIBC_2.2.5
+	fun:_PyImport_FindSharedFuncptr
+	fun:_PyImport_LoadDynamicModuleWithSpec
+	fun:_imp_create_dynamic_impl
+	fun:_imp_create_dynamic
+}
+{
+	Pytest at shutdown
+	Memcheck:Leak
+	match-leak-kinds: possible
+	fun:realloc
+	fun:_PyBytes_Resize
+	fun:_PyBytesWriter_Finish
+	fun:PyBytes_FromFormatV
+	fun:PyBytes_FromFormat
+	fun:os_putenv_impl
+	fun:os_putenv
+	fun:cfunction_vectorcall_FASTCALL
+	fun:_PyObject_Vectorcall
+	fun:call_function
+	fun:_PyEval_EvalFrameDefault
+	fun:function_code_fastcall
+	fun:_PyObject_Vectorcall
+	fun:_PyObject_FastCall
+	fun:_PyObject_FastCall_Prepend
+	fun:call_unbound
+	fun:call_method
+	fun:slot_mp_ass_subscript
+	fun:_PyEval_EvalFrameDefault
+}

--- a/ycmd/tests/shutdown_test.py
+++ b/ycmd/tests/shutdown_test.py
@@ -19,6 +19,7 @@ from hamcrest import assert_that, equal_to
 from threading import Event
 import time
 import requests
+import pytest
 
 from ycmd.tests.client_test import Client_test
 from ycmd.utils import StartThread
@@ -46,6 +47,7 @@ class Shutdown_test( Client_test ):
     self.AssertLogfilesAreRemoved()
 
 
+  @pytest.mark.valgrind_skip
   @Client_test.CaptureLogfiles
   def FromHandlerWithSubservers_test( self ):
     self.Start()
@@ -76,6 +78,7 @@ class Shutdown_test( Client_test ):
     self.AssertLogfilesAreRemoved()
 
 
+  @pytest.mark.valgrind_skip
   @Client_test.CaptureLogfiles
   def FromWatchdogWithSubservers_test( self ):
     all_servers_are_running = Event()


### PR DESCRIPTION
Python 3.8 is finally nice enough to not get in the way of running valgrind with `PYMALLOC=malloc`. The question is what should we run through valgrind? Here are the options:

- `ycm_core_tests`, which embeds the python interpreter. Currently valgrind detects [a leak in pybind](https://github.com/pybind/pybind11/pull/2020)
- `ycm_benchmarks`, same comment as the above.
- nose tests? I haven't tried this, but valgrind will detect [another leak in pybind](https://github.com/pybind/pybind11/pull/2024)
- Some combination of the above?

Currently the CI is running only a single benchmark, from `ycm_benchmarks` binary.

CI is also complaining about a missing `libsqlite3-dev` package. We probably should fix it, even though the tests aren't broken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1383)
<!-- Reviewable:end -->
