### PR TITLE
[READY] Fix disable signature help

### DIFF
--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -172,7 +172,7 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
 
   If your completer supports signature help, then you need to implemment:
     - SignatureHelpAvailable
-    - something which calls self._signature_triggers.SetServerTriggerCharacters
+    - something which calls self.SetSignatureHelpTriggers()
     - ComputeSignaturesInner
   See the language_server_completer or Python completers for examples.
 
@@ -191,7 +191,7 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
             filetype_set = set( self.SupportedFiletypes() ) )
         if user_options[ 'auto_trigger' ] else None )
 
-    self.signature_triggers = (
+    self._signature_triggers = (
       completer_utils.PreparedTriggers(
         user_trigger_map = {}, # user triggers not supported for signature help
         filetype_set = set( self.SupportedFiletypes() ),
@@ -257,10 +257,17 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
       # the menu and returns state 'INACTIVE').
       return True
 
-    return self.signature_triggers.MatchesForFiletype( current_line,
-                                                       column_codepoint,
-                                                       column_codepoint,
-                                                       filetype )
+    return self._signature_triggers.MatchesForFiletype( current_line,
+                                                        column_codepoint,
+                                                        column_codepoint,
+                                                        filetype )
+
+
+  def SetSignatureHelpTriggers( self, trigger_characters ):
+    if self._signature_triggers is None:
+      return
+
+    self._signature_triggers.SetServerSemanticTriggers( trigger_characters )
 
 
   def QueryLengthAboveMinThreshold( self, request_data ):

--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -69,7 +69,7 @@ class CsharpCompleter( Completer ):
     self._completer_per_solution = {}
     self._diagnostic_store = None
     self._solution_state_lock = threading.Lock()
-    self.signature_triggers.SetServerSemanticTriggers( [ '(', ',' ] )
+    self.SetSignatureHelpTriggers( [ '(', ',' ] )
 
     if not os.path.isfile( PATH_TO_ROSLYN_OMNISHARP_BINARY ):
       raise RuntimeError(

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1781,7 +1781,7 @@ class LanguageServerCompleter( Completer ):
           self.completion_triggers.SetServerSemanticTriggers(
             trigger_characters )
 
-      if self.signature_triggers is not None:
+      if self._signature_triggers is not None:
         server_trigger_characters = (
           ( self._server_capabilities.get( 'signatureHelpProvider' ) or {} )
                                      .get( 'triggerCharacters' ) or []
@@ -1797,9 +1797,7 @@ class LanguageServerCompleter( Completer ):
           LOGGER.info( '%s: Using characters for signature triggers: %s',
                        self.Language(),
                        ','.join( trigger_characters ) )
-
-          self.signature_triggers.SetServerSemanticTriggers(
-            trigger_characters )
+          self.SetSignatureHelpTriggers( trigger_characters )
 
       # We must notify the server that we received the initialize response (for
       # no apparent reason, other than that's what the protocol says).

--- a/ycmd/completers/python/python_completer.py
+++ b/ycmd/completers/python/python_completer.py
@@ -48,7 +48,7 @@ class PythonCompleter( Completer ):
     self._environment_for_file = {}
     self._environment_for_interpreter_path = {}
     self._sys_path_for_file = {}
-    self.signature_triggers.SetServerSemanticTriggers( [ '(', ',' ] )
+    self.SetSignatureHelpTriggers( [ '(', ',' ] )
 
 
   def SupportedFiletypes( self ):

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -179,7 +179,7 @@ class TypeScriptCompleter( Completer ):
     # There's someting in the API that lists the trigger characters, but
     # there is no way to request that from the server, so we just hard-code
     # the signature triggers.
-    self.signature_triggers.SetServerSemanticTriggers( [ '(', ',', '<' ] )
+    self.SetSignatureHelpTriggers( [ '(', ',', '<' ] )
 
     LOGGER.info( 'Enabling TypeScript completion' )
 

--- a/ycmd/tests/python/get_completions_test.py
+++ b/ycmd/tests/python/get_completions_test.py
@@ -254,6 +254,33 @@ def GetCompletions_SysPath_SettingsFunctionInExtraConf_test( app ):
   } )
 
 
+@IsolatedYcmd( {
+  'global_ycm_extra_conf': PathToTestFile( 'project',
+                                           'settings_extra_conf.py' ),
+  'disable_signature_help': True
+} )
+def GetCompletions_SysPath_SettingsFunctionInExtraConf_DisableSig_test( app ):
+  RunTest( app, {
+    'description': 'Module is added to sys.path through the Settings '
+                   'function in extra conf file',
+    'request': {
+      'filetype'  : 'python',
+      'filepath'  : PathToTestFile( 'project', '__main__.py' ),
+      'line_num'  : 3,
+      'column_num': 8
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completions': has_item(
+          CompletionEntryMatcher( 'SOME_CONSTANT', 'SOME_CONSTANT = 1' )
+        ),
+        'errors': empty()
+      } )
+    }
+  } )
+
+
 @IsolatedYcmd( { 'global_ycm_extra_conf':
                  PathToTestFile( 'project', 'settings_empty_extra_conf.py' ) } )
 def GetCompletions_SysPath_SettingsEmptyInExtraConf_test( app ):

--- a/ycmd/tests/python/signature_help_test.py
+++ b/ycmd/tests/python/signature_help_test.py
@@ -32,7 +32,7 @@ from hamcrest import ( assert_that,
 import requests
 
 from ycmd.utils import ReadFile
-from ycmd.tests.python import PathToTestFile, SharedYcmd
+from ycmd.tests.python import PathToTestFile, IsolatedYcmd, SharedYcmd
 from ycmd.tests.test_utils import ( CombineRequest,
                                     ParameterMatcher,
                                     SignatureMatcher,
@@ -101,6 +101,31 @@ def SignatureHelp_MethodTrigger_test( app ):
             SignatureMatcher( 'def hack( obj )',
                               [ ParameterMatcher( 10, 13 ) ] )
           ),
+        } ),
+      } )
+    }
+  } )
+
+
+@IsolatedYcmd( { 'disable_signature_help': True } )
+def SignatureHelp_MethodTrigger_Disabled_test( app ):
+  RunTest( app, {
+    'description': 'do not Trigger after (',
+    'request': {
+      'filetype'  : 'python',
+      'filepath'  : PathToTestFile( 'general_fallback',
+                                    'lang_python.py' ),
+      'line_num'  : 6,
+      'column_num': 10,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'errors': empty(),
+        'signature_help': has_entries( {
+          'activeSignature': 0,
+          'activeParameter': 0,
+          'signatures': empty(),
         } ),
       } )
     }

--- a/ycmd/tests/typescript/get_completions_test.py
+++ b/ycmd/tests/typescript/get_completions_test.py
@@ -147,6 +147,53 @@ def GetCompletions_Basic_test( app ):
   } )
 
 
+@IsolatedYcmd( { 'disable_signature_help': True } )
+def GetCompletions_Basic_NoSigHelp_test( app ):
+  RunTest( app, {
+    'description': 'Extra and detailed info when completions are methods',
+    'request': {
+      'line_num': 17,
+      'column_num': 6,
+      'filepath': PathToTestFile( 'test.ts' )
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'completions': contains_inanyorder(
+          CompletionEntryMatcher(
+            'methodA',
+            '(method) Foo.methodA(): void',
+            extra_params = {
+              'kind': 'method',
+              'detailed_info': '(method) Foo.methodA(): void\n\n'
+                               'Unicode string: 说话'
+            }
+          ),
+          CompletionEntryMatcher(
+            'methodB',
+            '(method) Foo.methodB(): void',
+            extra_params = {
+              'kind': 'method',
+              'detailed_info': '(method) Foo.methodB(): void'
+            }
+          ),
+          CompletionEntryMatcher(
+            'methodC',
+            '(method) Foo.methodC(a: { foo: string; bar: number; }): void',
+            extra_params = {
+              'kind': 'method',
+              'detailed_info': '(method) Foo.methodC(a: {\n'
+                               '    foo: string;\n'
+                               '    bar: number;\n'
+                               '}): void'
+            }
+          )
+        )
+      } )
+    }
+  } )
+
+
 @SharedYcmd
 def GetCompletions_Keyword_test( app ):
   RunTest( app, {

--- a/ycmd/tests/typescript/signature_help_test.py
+++ b/ycmd/tests/typescript/signature_help_test.py
@@ -28,7 +28,7 @@ from hamcrest import ( assert_that, contains, empty, has_entries )
 import requests
 
 from nose.tools import eq_
-from ycmd.tests.typescript import PathToTestFile, SharedYcmd
+from ycmd.tests.typescript import PathToTestFile, IsolatedYcmd, SharedYcmd
 from ycmd.tests.test_utils import ( CombineRequest,
                                     ParameterMatcher,
                                     SignatureMatcher,
@@ -103,6 +103,30 @@ def Signature_Help_Trigger_Paren_test( app ):
             SignatureMatcher( 'single_argument_with_return(a: string): string',
                               [ ParameterMatcher( 28, 37 ) ] )
           ),
+        } ),
+      } )
+    }
+  } )
+
+
+@IsolatedYcmd( { 'disable_signature_help': True } )
+def Signature_Help_Trigger_Paren_Disabled_test( app ):
+  RunTest( app, {
+    'description': 'Trigger after (',
+    'request': {
+      'filetype'  : 'typescript',
+      'filepath'  : PathToTestFile( 'signatures.ts' ),
+      'line_num'  : 27,
+      'column_num': 29,
+    },
+    'expect': {
+      'response': requests.codes.ok,
+      'data': has_entries( {
+        'errors': empty(),
+        'signature_help': has_entries( {
+          'activeSignature': 0,
+          'activeParameter': 0,
+          'signatures': empty()
         } ),
       } )
     }


### PR DESCRIPTION
Fixes https://github.com/ycm-core/YouCompleteMe/issues/3570

    During the review of signature help we changed so that
    signature_triggers was None when disabled. This was fixed for LSP, but
    this broke all other implementations which assume they can just set the
    triggers manually.
    
    Fixed by making signature_triggers private (_signature_triggers) and
    adding a public method to set them. This keeps the logic in individual
    completers simple.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1384)
<!-- Reviewable:end -->
