### PR TITLE
[READY] Raise exception on empty C# /typelookup

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -602,6 +602,8 @@ class CsharpSolutionCompleter( object ):
     result = self._GetResponse( '/typelookup', request )
     message = result[ "Type" ]
 
+    if not message:
+      raise RuntimeError( 'No type info available.' )
     return responses.BuildDisplayMessageResponse( message )
 
 
@@ -698,11 +700,14 @@ class CsharpSolutionCompleter( object ):
     request[ "IncludeDocumentation" ] = True
 
     result = self._GetResponse( '/typelookup', request )
-    message = result[ "Type" ]
+    message = result.get( 'Type' ) or ''
+
     if ( result[ "Documentation" ] ):
       message += "\n" + result[ "Documentation" ]
 
-    return responses.BuildDetailedInfoResponse( message )
+    if not message:
+      raise RuntimeError( 'No documentation available.' )
+    return responses.BuildDetailedInfoResponse( message.strip() )
 
 
   def _DefaultParameters( self, request_data ):

--- a/ycmd/tests/cs/subcommands_test.py
+++ b/ycmd/tests/cs/subcommands_test.py
@@ -540,8 +540,11 @@ def Subcommands_GetType_EmptyMessage_test( app ):
                                  filetype = 'cs',
                                  filepath = filepath )
 
-    response = app.post_json( '/run_completer_command', gettype_data ).json
-    assert_that( response, has_entry( 'message', None ) )
+    response = app.post_json( '/run_completer_command',
+                              gettype_data,
+                              expect_errors = True ).json
+    assert_that( response, ErrorMatcher( RuntimeError,
+                                         'No type info available.' ) )
 
 
 @SharedYcmd
@@ -597,6 +600,27 @@ def Subcommands_GetType_DocsIgnored_test( app ):
     response = app.post_json( '/run_completer_command', gettype_data ).json
     assert_that( response, has_entry(
       'message', 'int GetTypeTestCase.an_int_with_docs' ) )
+
+
+@SharedYcmd
+def Subcommands_GetDoc_Invalid_test( app ):
+  filepath = PathToTestFile( 'testy', 'GetDocTestCase.cs' )
+  with WrapOmniSharpServer( app, filepath ):
+    contents = ReadFile( filepath )
+
+    getdoc_data = BuildRequest( completer_target = 'filetype_default',
+                                command_arguments = [ 'GetDoc' ],
+                                line_num = 1,
+                                column_num = 1,
+                                contents = contents,
+                                filetype = 'cs',
+                                filepath = filepath )
+
+    response = app.post_json( '/run_completer_command',
+                              getdoc_data,
+                              expect_errors = True ).json
+    assert_that( response, ErrorMatcher( RuntimeError,
+                                         'No documentation available.' ) )
 
 
 @SharedYcmd


### PR DESCRIPTION
Fixes #1385 
Returning `{ 'detailed_info': None }` and `{ 'message': None }` causes problems for clients, including YCM. Instead, we should raise an exception and tell the user that there's no type info/docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1386)
<!-- Reviewable:end -->
