### PR TITLE
[READY] Drop `ToCppStringCompatible()`

### DIFF
--- a/ycmd/completers/all/identifier_completer.py
+++ b/ycmd/completers/all/identifier_completer.py
@@ -20,7 +20,7 @@ import ycm_core
 from collections import defaultdict
 from ycmd.completers.general_completer import GeneralCompleter
 from ycmd import identifier_utils
-from ycmd.utils import LOGGER, ToCppStringCompatible, SplitLines
+from ycmd.utils import LOGGER, SplitLines
 from ycmd import responses
 
 SYNTAX_FILENAME = 'YCM_PLACEHOLDER_FOR_SYNTAX'
@@ -43,8 +43,8 @@ class IdentifierCompleter( GeneralCompleter ):
       return []
 
     completions = self._completer.CandidatesForQueryAndType(
-      ToCppStringCompatible( _SanitizeQuery( request_data[ 'query' ] ) ),
-      ToCppStringCompatible( request_data[ 'first_filetype' ] ),
+      _SanitizeQuery( request_data[ 'query' ] ),
+      request_data[ 'first_filetype' ],
       self._max_candidates )
 
     completions = _RemoveSmallCandidates(
@@ -66,12 +66,12 @@ class IdentifierCompleter( GeneralCompleter ):
       return
 
     vector = ycm_core.StringVector()
-    vector.append( ToCppStringCompatible( identifier ) )
+    vector.append( identifier )
     LOGGER.info( 'Adding ONE buffer identifier for file: %s', filepath )
     self._completer.AddIdentifiersToDatabase(
       vector,
-      ToCppStringCompatible( filetype ),
-      ToCppStringCompatible( filepath ) )
+      filetype,
+      filepath )
 
 
   def _AddPreviousIdentifier( self, request_data ):
@@ -106,8 +106,8 @@ class IdentifierCompleter( GeneralCompleter ):
         _IdentifiersFromBuffer( text,
                                 filetype,
                                 collect_from_comments_and_strings ),
-        ToCppStringCompatible( filetype ),
-        ToCppStringCompatible( filepath ) )
+        filetype,
+        filepath )
 
 
   def _FilterUnchangedTagFiles( self, tag_files ):
@@ -132,7 +132,7 @@ class IdentifierCompleter( GeneralCompleter ):
   def _AddIdentifiersFromTagFiles( self, tag_files ):
     absolute_paths_to_tag_files = ycm_core.StringVector()
     for tag_file in self._FilterUnchangedTagFiles( tag_files ):
-      absolute_paths_to_tag_files.append( ToCppStringCompatible( tag_file ) )
+      absolute_paths_to_tag_files.append( tag_file )
 
     if not absolute_paths_to_tag_files:
       return
@@ -144,13 +144,13 @@ class IdentifierCompleter( GeneralCompleter ):
   def _AddIdentifiersFromSyntax( self, keyword_list, filetype ):
     keyword_vector = ycm_core.StringVector()
     for keyword in keyword_list:
-      keyword_vector.append( ToCppStringCompatible( keyword ) )
+      keyword_vector.append( keyword )
 
     filepath = SYNTAX_FILENAME + filetype
     self._completer.AddIdentifiersToDatabase(
       keyword_vector,
-      ToCppStringCompatible( filetype ),
-      ToCppStringCompatible( filepath ) )
+      filetype,
+      filepath )
 
 
   def OnFileReadyToParse( self, request_data ):
@@ -243,7 +243,7 @@ def _IdentifiersFromBuffer( text,
   idents = identifier_utils.ExtractIdentifiersFromText( text, filetype )
   vector = ycm_core.StringVector()
   for ident in idents:
-    vector.append( ToCppStringCompatible( ident ) )
+    vector.append( ident )
   return vector
 
 

--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -18,8 +18,7 @@
 # Must not import ycm_core here! Vim imports completer, which imports this file.
 # We don't want ycm_core inside Vim.
 from collections import defaultdict
-from ycmd.utils import ( LOGGER, ToCppStringCompatible, ToUnicode, re, ReadFile,
-                         SplitLines )
+from ycmd.utils import LOGGER, ToUnicode, re, ReadFile, SplitLines
 
 
 class PreparedTriggers:
@@ -178,16 +177,9 @@ def FilterAndSortCandidatesWrap( candidates, sort_property, query,
                                  max_candidates ):
   from ycm_core import FilterAndSortCandidates
 
-  # The c++ interface we use only understands the 'str' type. If we pass it a
-  # 'unicode' or 'bytes' instance then various things blow up, such as
-  # converting to std::string. Therefore all strings passed into the c++ API
-  # must pass through ToCppStringCompatible (or more strictly all strings which
-  # the C++ code needs to use and convert. In this case, just the insertion
-  # text property) For efficiency, the conversion of the insertion text
-  # property is done in the C++ layer.
   return FilterAndSortCandidates( candidates,
-                                  ToCppStringCompatible( sort_property ),
-                                  ToCppStringCompatible( query ),
+                                  sort_property,
+                                  query,
                                   max_candidates )
 
 

--- a/ycmd/completers/cpp/clang_completer.py
+++ b/ycmd/completers/cpp/clang_completer.py
@@ -23,10 +23,7 @@ from xml.etree.ElementTree import ParseError as XmlParseError
 
 import ycm_core
 from ycmd import responses
-from ycmd.utils import ( PathLeftSplit,
-                         re,
-                         ToCppStringCompatible,
-                         ToUnicode )
+from ycmd.utils import PathLeftSplit, re, ToBytes, ToUnicode
 from ycmd.completers.completer import Completer
 from ycmd.completers.cpp.flags import ( Flags, PrepareFlagsForClang,
                                         UserIncludePaths )
@@ -70,10 +67,10 @@ class ClangCompleter( Completer ):
         continue
 
       unsaved_file = ycm_core.UnsavedFile()
-      utf8_contents = ToCppStringCompatible( contents )
+      utf8_contents = ToBytes( contents )
       unsaved_file.contents_ = utf8_contents
       unsaved_file.length_ = len( utf8_contents )
-      unsaved_file.filename_ = ToCppStringCompatible( filename )
+      unsaved_file.filename_ = filename
 
       files.append( unsaved_file )
     return files
@@ -138,8 +135,7 @@ class ClangCompleter( Completer ):
     if includes is not None:
       return includes
 
-    if self._completer.UpdatingTranslationUnit(
-        ToCppStringCompatible( filename ) ):
+    if self._completer.UpdatingTranslationUnit( filename ):
       raise RuntimeError( PARSING_FILE_MESSAGE )
 
     files = self.GetUnsavedFilesVector( request_data )
@@ -147,8 +143,8 @@ class ClangCompleter( Completer ):
     column = request_data[ 'start_column' ]
     with self._files_being_compiled.GetExclusive( filename ):
       results = self._completer.CandidatesForLocationInFile(
-          ToCppStringCompatible( filename ),
-          ToCppStringCompatible( request_data[ 'filepath' ] ),
+          filename,
+          request_data[ 'filepath' ],
           line,
           column,
           files,
@@ -203,16 +199,15 @@ class ClangCompleter( Completer ):
     if not flags:
       raise ValueError( NO_COMPILE_FLAGS_MESSAGE )
 
-    if self._completer.UpdatingTranslationUnit(
-        ToCppStringCompatible( filename ) ):
+    if self._completer.UpdatingTranslationUnit( filename ):
       raise RuntimeError( PARSING_FILE_MESSAGE )
 
     files = self.GetUnsavedFilesVector( request_data )
     line = request_data[ 'line_num' ]
     column = request_data[ 'column_num' ]
     return getattr( self._completer, goto_function )(
-        ToCppStringCompatible( filename ),
-        ToCppStringCompatible( request_data[ 'filepath' ] ),
+        filename,
+        request_data[ 'filepath' ],
         line,
         column,
         files,
@@ -312,8 +307,7 @@ class ClangCompleter( Completer ):
     if not flags:
       raise ValueError( NO_COMPILE_FLAGS_MESSAGE )
 
-    if self._completer.UpdatingTranslationUnit(
-        ToCppStringCompatible( filename ) ):
+    if self._completer.UpdatingTranslationUnit( filename ):
       raise RuntimeError( PARSING_FILE_MESSAGE )
 
     files = self.GetUnsavedFilesVector( request_data )
@@ -321,8 +315,8 @@ class ClangCompleter( Completer ):
     column = request_data[ 'column_num' ]
 
     message = getattr( self._completer, func )(
-        ToCppStringCompatible( filename ),
-        ToCppStringCompatible( request_data[ 'filepath' ] ),
+        filename,
+        request_data[ 'filepath' ],
         line,
         column,
         files,
@@ -344,8 +338,7 @@ class ClangCompleter( Completer ):
     if not flags:
       raise ValueError( NO_COMPILE_FLAGS_MESSAGE )
 
-    if self._completer.UpdatingTranslationUnit(
-        ToCppStringCompatible( filename ) ):
+    if self._completer.UpdatingTranslationUnit( filename ):
       raise RuntimeError( PARSING_FILE_MESSAGE )
 
     files = self.GetUnsavedFilesVector( request_data )
@@ -353,8 +346,8 @@ class ClangCompleter( Completer ):
     column = request_data[ 'column_num' ]
 
     fixits = getattr( self._completer, "GetFixItsForLocationInFile" )(
-        ToCppStringCompatible( filename ),
-        ToCppStringCompatible( request_data[ 'filepath' ] ),
+        filename,
+        request_data[ 'filepath' ],
         line,
         column,
         files,
@@ -374,7 +367,7 @@ class ClangCompleter( Completer ):
 
     with self._files_being_compiled.GetExclusive( filename ):
       diagnostics = self._completer.UpdateTranslationUnit(
-        ToCppStringCompatible( filename ),
+        filename,
         self.GetUnsavedFilesVector( request_data ),
         flags )
 
@@ -395,8 +388,7 @@ class ClangCompleter( Completer ):
     #
     # Solving this would require remembering the graph of files to translation
     # units and only closing a unit when there are no files open which use it.
-    self._completer.DeleteCachesForFile(
-        ToCppStringCompatible( request_data[ 'filepath' ] ) )
+    self._completer.DeleteCachesForFile( request_data[ 'filepath' ] )
 
 
   def GetDetailedDiagnostic( self, request_data ):

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -23,7 +23,6 @@ from ycmd.utils import ( OnMac,
                          OnWindows,
                          PathsToAllParentFolders,
                          re,
-                         ToCppStringCompatible,
                          ToUnicode,
                          CLANG_RESOURCE_DIR )
 from ycmd.responses import NoExtraConfDetected
@@ -303,7 +302,7 @@ def PrepareFlagsForClang( flags,
 
   vector = ycm_core.StringVector()
   for flag in flags:
-    vector.append( ToCppStringCompatible( flag ) )
+    vector.append( flag )
   return vector
 
 

--- a/ycmd/tests/bindings/cpp_bindings_general_test.py
+++ b/ycmd/tests/bindings/cpp_bindings_general_test.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-from ycmd.utils import ToCppStringCompatible as ToCppStr
 from ycmd.completers.cpp.clang_completer import ConvertCompletionData
 from ycmd.responses import BuildDiagnosticData
 from ycmd.tests.bindings import PathToTestFile
@@ -35,8 +34,8 @@ import os
 
 def CppBindings_FilterAndSortCandidates_test():
   candidates = [ 'foo1', 'foo2', 'foo3' ]
-  query = ToCppStr( 'oo' )
-  candidate_property = ToCppStr( '' )
+  query = 'oo'
+  candidate_property = ''
 
   result_full = ycm_core.FilterAndSortCandidates( candidates,
                                                   candidate_property,
@@ -57,38 +56,33 @@ def CppBindings_FilterAndSortCandidates_test():
 def CppBindings_IdentifierCompleter_test():
   identifier_completer = ycm_core.IdentifierCompleter()
   identifiers = ycm_core.StringVector()
-  identifiers.append( ToCppStr( 'foo' ) )
-  identifiers.append( ToCppStr( 'bar' ) )
-  identifiers.append( ToCppStr( 'baz' ) )
-  identifier_completer.AddIdentifiersToDatabase( identifiers,
-                                                 ToCppStr( 'foo' ),
-                                                 ToCppStr( 'file' ) )
+  identifiers.append( 'foo' )
+  identifiers.append( 'bar' )
+  identifiers.append( 'baz' )
+  identifier_completer.AddIdentifiersToDatabase( identifiers, 'foo', 'file' )
   del identifiers
   query_fo_10 = identifier_completer.CandidatesForQueryAndType(
-                                       ToCppStr( 'fo' ), ToCppStr( 'foo' ), 10 )
-  query_fo = identifier_completer.CandidatesForQueryAndType(
-                                    ToCppStr( 'fo' ), ToCppStr( 'foo' ) )
-  query_a = identifier_completer.CandidatesForQueryAndType(
-                                   ToCppStr( 'a' ), ToCppStr( 'foo' ) )
+                                       'fo', 'foo', 10 )
+  query_fo = identifier_completer.CandidatesForQueryAndType( 'fo', 'foo' )
+  query_a = identifier_completer.CandidatesForQueryAndType( 'a', 'foo' )
   assert_that( query_fo_10, contains( 'foo' ) )
   assert_that( query_fo, contains( 'foo' ) )
   assert_that( query_a, contains( 'bar', 'baz' ) )
   identifiers = ycm_core.StringVector()
-  identifiers.append( ToCppStr( 'oof' ) )
-  identifiers.append( ToCppStr( 'rab' ) )
-  identifiers.append( ToCppStr( 'zab' ) )
+  identifiers.append( 'oof' )
+  identifiers.append( 'rab' )
+  identifiers.append( 'zab' )
   identifier_completer.ClearForFileAndAddIdentifiersToDatabase(
-                         identifiers, ToCppStr( 'foo' ), ToCppStr( 'file' ) )
-  query_a_10 = identifier_completer.CandidatesForQueryAndType(
-                                      ToCppStr( 'a' ), ToCppStr( 'foo' ) )
+                         identifiers, 'foo', 'file' )
+  query_a_10 = identifier_completer.CandidatesForQueryAndType( 'a', 'foo' )
   assert_that( query_a_10, contains( 'rab', 'zab' ) )
 
 
 @ClangOnly
 def CppBindings_UnsavedFile_test():
   unsaved_file = ycm_core.UnsavedFile()
-  filename = ToCppStr( 'foo' )
-  contents = ToCppStr( 'bar\\n' )
+  filename = 'foo'
+  contents = 'bar\\n'
   length = len( contents )
   unsaved_file.filename_ = filename
   unsaved_file.contents_ = contents
@@ -105,13 +99,13 @@ def CppBindings_UnsavedFile_test():
 
 @ClangOnly
 def CppBindings_DeclarationLocation_test():
-  translation_unit = ToCppStr( PathToTestFile( 'foo.c' ) )
-  filename = ToCppStr( PathToTestFile( 'foo.c' ) )
+  translation_unit = PathToTestFile( 'foo.c' )
+  filename = PathToTestFile( 'foo.c' )
   line = 9
   column = 17
   unsaved_file_vector = ycm_core.UnsavedFileVector()
   flags = ycm_core.StringVector()
-  flags.append( ToCppStr( '-xc++' ) )
+  flags.append( '-xc++' )
   reparse = True
   clang_completer = ycm_core.ClangCompleter()
 
@@ -139,13 +133,13 @@ def CppBindings_DeclarationLocation_test():
 
 @ClangOnly
 def CppBindings_DefinitionOrDeclarationLocation_test():
-  translation_unit = ToCppStr( PathToTestFile( 'foo.c' ) )
-  filename = ToCppStr( PathToTestFile( 'foo.c' ) )
+  translation_unit = PathToTestFile( 'foo.c' )
+  filename = PathToTestFile( 'foo.c' )
   line = 9
   column = 17
   unsaved_file_vector = ycm_core.UnsavedFileVector()
   flags = ycm_core.StringVector()
-  flags.append( ToCppStr( '-xc++' ) )
+  flags.append( '-xc++' )
   reparse = True
   clang_completer = ycm_core.ClangCompleter()
 
@@ -174,13 +168,13 @@ def CppBindings_DefinitionOrDeclarationLocation_test():
 
 @ClangOnly
 def CppBindings_DefinitionLocation_test():
-  translation_unit = ToCppStr( PathToTestFile( 'foo.c' ) )
-  filename = ToCppStr( PathToTestFile( 'foo.c' ) )
+  translation_unit = PathToTestFile( 'foo.c' )
+  filename = PathToTestFile( 'foo.c' )
   line = 9
   column = 17
   unsaved_file_vector = ycm_core.UnsavedFileVector()
   flags = ycm_core.StringVector()
-  flags.append( ToCppStr( '-xc++' ) )
+  flags.append( '-xc++' )
   reparse = True
   clang_completer = ycm_core.ClangCompleter()
 
@@ -208,13 +202,13 @@ def CppBindings_DefinitionLocation_test():
 
 @ClangOnly
 def CppBindings_Candidates_test():
-  translation_unit = ToCppStr( PathToTestFile( 'foo.c' ) )
-  filename = ToCppStr( PathToTestFile( 'foo.c' ) )
+  translation_unit = PathToTestFile( 'foo.c' )
+  filename = PathToTestFile( 'foo.c' )
   line = 11
   column = 6
   unsaved_file_vector = ycm_core.UnsavedFileVector()
   flags = ycm_core.StringVector()
-  flags.append( ToCppStr( '-xc' ) )
+  flags.append( '-xc' )
   reparse = True
   clang_completer = ycm_core.ClangCompleter()
 
@@ -255,13 +249,13 @@ def CppBindings_Candidates_test():
 
 @ClangOnly
 def CppBindings_GetType_test():
-  translation_unit = ToCppStr( PathToTestFile( 'foo.c' ) )
-  filename = ToCppStr( PathToTestFile( 'foo.c' ) )
+  translation_unit = PathToTestFile( 'foo.c' )
+  filename = PathToTestFile( 'foo.c' )
   line = 9
   column = 17
   unsaved_file_vector = ycm_core.UnsavedFileVector()
   flags = ycm_core.StringVector()
-  flags.append( ToCppStr( '-xc++' ) )
+  flags.append( '-xc++' )
   reparse = True
   clang_completer = ycm_core.ClangCompleter()
 
@@ -286,13 +280,13 @@ def CppBindings_GetType_test():
 
 @ClangOnly
 def CppBindings_GetParent_test():
-  translation_unit = ToCppStr( PathToTestFile( 'foo.c' ) )
-  filename = ToCppStr( PathToTestFile( 'foo.c' ) )
+  translation_unit = PathToTestFile( 'foo.c' )
+  filename = PathToTestFile( 'foo.c' )
   line = 9
   column = 17
   unsaved_file_vector = ycm_core.UnsavedFileVector()
   flags = ycm_core.StringVector()
-  flags.append( ToCppStr( '-xc++' ) )
+  flags.append( '-xc++' )
   reparse = True
   clang_completer = ycm_core.ClangCompleter()
 
@@ -319,13 +313,13 @@ def CppBindings_GetParent_test():
 
 @ClangOnly
 def CppBindings_FixIt_test():
-  translation_unit = ToCppStr( PathToTestFile( 'foo.c' ) )
-  filename = ToCppStr( PathToTestFile( 'foo.c' ) )
+  translation_unit = PathToTestFile( 'foo.c' )
+  filename = PathToTestFile( 'foo.c' )
   line = 3
   column = 5
   unsaved_file_vector = ycm_core.UnsavedFileVector()
   flags = ycm_core.StringVector()
-  flags.append( ToCppStr( '-xc++' ) )
+  flags.append( '-xc++' )
   reparse = True
   clang_completer = ycm_core.ClangCompleter()
 
@@ -373,13 +367,13 @@ def CppBindings_FixIt_test():
 
 @ClangOnly
 def CppBindings_Docs_test():
-  translation_unit = ToCppStr( PathToTestFile( 'foo.c' ) )
-  filename = ToCppStr( PathToTestFile( 'foo.c' ) )
+  translation_unit = PathToTestFile( 'foo.c' )
+  filename = PathToTestFile( 'foo.c' )
   line = 9
   column = 16
   unsaved_file_vector = ycm_core.UnsavedFileVector()
   flags = ycm_core.StringVector()
-  flags.append( ToCppStr( '-xc++' ) )
+  flags.append( '-xc++' )
   reparse = True
   clang_completer = ycm_core.ClangCompleter()
 
@@ -413,10 +407,10 @@ def CppBindings_Docs_test():
 
 @ClangOnly
 def CppBindings_Diags_test():
-  filename = ToCppStr( PathToTestFile( 'foo.c' ) )
+  filename = PathToTestFile( 'foo.c' )
   unsaved_file_vector = ycm_core.UnsavedFileVector()
   flags = ycm_core.StringVector()
-  flags.append( ToCppStr( '-xc++' ) )
+  flags.append( '-xc++' )
   reparse = True
   clang_completer = ycm_core.ClangCompleter()
 

--- a/ycmd/tests/bindings/cpp_bindings_vectors_test.py
+++ b/ycmd/tests/bindings/cpp_bindings_vectors_test.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-from ycmd.utils import ToCppStringCompatible as ToCppStr
 from ycmd.completers.cpp.clang_completer import ConvertCompletionData
 from ycmd.responses import BuildDiagnosticData
 from ycmd.tests.bindings import PathToTestFile
@@ -39,9 +38,9 @@ def CppBindings_StringVector_test():
   str2 = 'bar'
   str3 = 'baz'
   string_vector = ycm_core.StringVector()
-  string_vector.append( ToCppStr( str1 ) )
-  EmplaceBack( string_vector, ToCppStr( str2 ) )
-  string_vector.append( ToCppStr( str3 ) )
+  string_vector.append( str1 )
+  EmplaceBack( string_vector, str2 )
+  string_vector.append( str3 )
   del str1
   del str2
   del str3
@@ -52,8 +51,8 @@ def CppBindings_StringVector_test():
 def CppBindings_UnsavedFileVector_test():
   unsaved_file_vector = ycm_core.UnsavedFileVector()
   unsaved_file = ycm_core.UnsavedFile()
-  unsaved_file.filename_ = ToCppStr( 'foo' )
-  unsaved_file.contents_ = ToCppStr( 'bar' )
+  unsaved_file.filename_ = 'foo'
+  unsaved_file.contents_ = 'bar'
   unsaved_file.length_ = 3
   unsaved_file_vector.append( unsaved_file )
   EmplaceBack( unsaved_file_vector, unsaved_file )
@@ -76,13 +75,13 @@ def CppBindings_UnsavedFileVector_test():
 @ClangOnly
 def CppBindings_FixItVector_test():
   flags = ycm_core.StringVector()
-  flags.append( ToCppStr( '-xc++' ) )
+  flags.append( '-xc++' )
   clang_completer = ycm_core.ClangCompleter()
   translation_unit = PathToTestFile( 'foo.c' )
-  filename = ToCppStr( PathToTestFile( 'foo.c' ) )
+  filename = PathToTestFile( 'foo.c' )
   fixits = ( clang_completer
-               .GetFixItsForLocationInFile( ToCppStr( translation_unit ),
-                                            ToCppStr( filename ),
+               .GetFixItsForLocationInFile( translation_unit,
+                                            filename,
                                             3,
                                             5,
                                             ycm_core.UnsavedFileVector(),
@@ -147,13 +146,13 @@ def CppBindings_FixItVector_test():
 @ClangOnly
 def CppBindings_FixItChunkVector_test():
   flags = ycm_core.StringVector()
-  flags.append( ToCppStr( '-xc++' ) )
+  flags.append( '-xc++' )
   clang_completer = ycm_core.ClangCompleter()
   translation_unit = PathToTestFile( 'foo.c' )
   filename = PathToTestFile( 'foo.c' )
   fixits = ( clang_completer
-               .GetFixItsForLocationInFile( ToCppStr( translation_unit ),
-                                            ToCppStr( filename ),
+               .GetFixItsForLocationInFile( translation_unit,
+                                            filename,
                                             3,
                                             5,
                                             ycm_core.UnsavedFileVector(),
@@ -199,14 +198,14 @@ def CppBindings_FixItChunkVector_test():
 @ClangOnly
 def CppBindings_RangeVector_test():
   flags = ycm_core.StringVector()
-  flags.append( ToCppStr( '-xc++' ) )
+  flags.append( '-xc++' )
   clang_completer = ycm_core.ClangCompleter()
   translation_unit = PathToTestFile( 'foo.c' )
   filename = PathToTestFile( 'foo.c' )
 
   fixits = ( clang_completer
-               .GetFixItsForLocationInFile( ToCppStr( translation_unit ),
-                                            ToCppStr( filename ),
+               .GetFixItsForLocationInFile( translation_unit,
+                                            filename,
                                             3,
                                             5,
                                             ycm_core.UnsavedFileVector(),
@@ -251,10 +250,10 @@ def CppBindings_DiagnosticVector_test():
   filename = PathToTestFile( 'foo.c' )
   unsaved_file_vector = ycm_core.UnsavedFileVector()
   flags = ycm_core.StringVector()
-  flags.append( ToCppStr( '-xc++' ) )
+  flags.append( '-xc++' )
   clang_completer = ycm_core.ClangCompleter()
 
-  diag_vector = clang_completer.UpdateTranslationUnit( ToCppStr( filename ),
+  diag_vector = clang_completer.UpdateTranslationUnit( filename,
                                                        unsaved_file_vector,
                                                        flags )
 
@@ -316,13 +315,13 @@ def CppBindings_DiagnosticVector_test():
 
 @ClangOnly
 def CppBindings_CompletionDataVector_test():
-  translation_unit = ToCppStr( PathToTestFile( 'foo.c' ) )
-  filename = ToCppStr( PathToTestFile( 'foo.c' ) )
+  translation_unit = PathToTestFile( 'foo.c' )
+  filename = PathToTestFile( 'foo.c' )
   line = 11
   column = 6
   unsaved_file_vector = ycm_core.UnsavedFileVector()
   flags = ycm_core.StringVector()
-  flags.append( ToCppStr( '-xc' ) )
+  flags.append( '-xc' )
   clang_completer = ycm_core.ClangCompleter()
 
   candidates = ( clang_completer

--- a/ycmd/tests/utils_test.py
+++ b/ycmd/tests/utils_test.py
@@ -18,7 +18,6 @@
 import os
 import subprocess
 import tempfile
-import ycm_core
 from hamcrest import ( assert_that,
                        calling,
                        empty,
@@ -112,36 +111,6 @@ def JoinLinesAsUnicode_BadInput_test():
     calling( utils.JoinLinesAsUnicode ).with_args( [ 42 ] ),
     raises( ValueError, 'lines must contain either strings or bytes' )
   )
-
-
-def ToCppStringCompatible_Py3Bytes_test():
-  value = utils.ToCppStringCompatible( bytes( b'abc' ) )
-  eq_( value, bytes( b'abc' ) )
-  ok_( isinstance( value, bytes ) )
-
-  vector = ycm_core.StringVector()
-  vector.append( value )
-  eq_( vector[ 0 ], 'abc' )
-
-
-def ToCppStringCompatible_Py3Str_test():
-  value = utils.ToCppStringCompatible( 'abc' )
-  eq_( value, bytes( b'abc' ) )
-  ok_( isinstance( value, bytes ) )
-
-  vector = ycm_core.StringVector()
-  vector.append( value )
-  eq_( vector[ 0 ], 'abc' )
-
-
-def ToCppStringCompatible_Py3Int_test():
-  value = utils.ToCppStringCompatible( 123 )
-  eq_( value, bytes( b'123' ) )
-  ok_( isinstance( value, bytes ) )
-
-  vector = ycm_core.StringVector()
-  vector.append( value )
-  eq_( vector[ 0 ], '123' )
 
 
 def RemoveIfExists_Exists_test():

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -110,17 +110,6 @@ def CreateLogfile( prefix = '' ):
     return logfile.name
 
 
-# Given an object, returns a str object that's utf-8 encoded. This is meant to
-# be used exclusively when producing strings to be passed to the C++ Python
-# plugins. For other code, you likely want to use ToBytes below.
-def ToCppStringCompatible( value ):
-  if isinstance( value, str ):
-    return value.encode( 'utf-8' )
-  if isinstance( value, bytes ):
-    return value
-  return str( value ).encode( 'utf-8' )
-
-
 def ToUnicode( value ):
   if not value:
     return ''


### PR DESCRIPTION
Pybind can handle being passed either `bytes` or `str`, so we don't need to convert before calling a C++ API from python.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1387)
<!-- Reviewable:end -->
