### PR TITLE
[READY] Minor pre-C++17 cleanup

### DIFF
--- a/cpp/ycm/CandidateRepository.h
+++ b/cpp/ycm/CandidateRepository.h
@@ -59,9 +59,6 @@ private:
   CandidateRepository() = default;
   ~CandidateRepository() = default;
 
-  const std::string &ValidatedCandidateText(
-      const std::string &candidate_text );
-
   // This data structure owns all the Candidate pointers
   CandidateHolder candidate_holder_;
   std::mutex candidate_holder_mutex_;

--- a/cpp/ycm/Character.h
+++ b/cpp/ycm/Character.h
@@ -73,7 +73,7 @@ public:
 
   inline bool operator== ( const Character &other ) const {
     return normal_ == other.normal_;
-  };
+  }
 
   inline bool EqualsBase( const Character &other ) const {
     return base_ == other.base_;
@@ -81,7 +81,7 @@ public:
 
   inline bool EqualsIgnoreCase( const Character &other ) const {
     return folded_case_ == other.folded_case_;
-  };
+  }
 
   // Smart base matching on top of smart case matching, e.g.:
   //  - e matches e, é, E, É;
@@ -93,7 +93,7 @@ public:
              ( !is_uppercase_ || other.is_uppercase_ ) ) ||
            ( !is_uppercase_ && EqualsIgnoreCase( other ) ) ||
            normal_ == other.normal_;
-  };
+  }
 
 private:
   std::string normal_;

--- a/cpp/ycm/CodePoint.cpp
+++ b/cpp/ycm/CodePoint.cpp
@@ -62,7 +62,7 @@ RawCodePoint FindCodePoint( const char *text ) {
     auto it = first + step;
     int cmp = std::strcmp( *it, text );
     if ( cmp == 0 ) {
-      size_t index = std::distance( start, it );
+      auto index = static_cast< size_t >( std::distance( start, it ) );
       return { *it,
                code_points.normal[ index ],
                code_points.folded_case[ index ],
@@ -109,7 +109,7 @@ CodePointSequence BreakIntoCodePoints( const std::string &text ) {
   // and the bytes themselves are valid (they must start with bits '10').
   std::vector< std::string > code_points;
   for ( auto iter = text.begin(); iter != text.end(); ) {
-    int length = GetCodePointLength( *iter );
+    int length = GetCodePointLength( static_cast< uint8_t >( *iter ) );
     if ( text.end() - iter < length ) {
       throw UnicodeDecodeError( "Invalid code point length." );
     }
@@ -119,5 +119,10 @@ CodePointSequence BreakIntoCodePoints( const std::string &text ) {
 
   return CodePointRepository::Instance().GetCodePoints( code_points );
 }
+
+
+const char* UnicodeDecodeError::what() const noexcept {
+  return std::runtime_error::what();
+};
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/CodePoint.h
+++ b/cpp/ycm/CodePoint.h
@@ -124,7 +124,7 @@ public:
 
   inline bool operator< ( const CodePoint &other ) const {
     return combining_class_ < other.combining_class_;
-  };
+  }
 
 private:
   explicit CodePoint( RawCodePoint&& code_point );
@@ -149,9 +149,8 @@ YCM_EXPORT CodePointSequence BreakIntoCodePoints( const std::string &text );
 
 // Thrown when an error occurs while decoding a UTF-8 string.
 struct YCM_EXPORT UnicodeDecodeError : std::runtime_error {
-  explicit UnicodeDecodeError( const char *what_arg )
-    : std::runtime_error( what_arg ) {
-  }
+  using std::runtime_error::runtime_error;
+  const char* what() const noexcept override;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/IdentifierCompleter.cpp
+++ b/cpp/ycm/IdentifierCompleter.cpp
@@ -81,11 +81,10 @@ std::vector< std::string > IdentifierCompleter::CandidatesForQueryAndType(
   const std::string &filetype,
   const size_t max_candidates ) const {
 
-  std::vector< Result > results;
-  identifier_database_.ResultsForQueryAndType( std::move( query ),
-                                               filetype,
-                                               results,
-                                               max_candidates );
+  std::vector< Result > results =
+    identifier_database_.ResultsForQueryAndType( std::move( query ),
+                                                 filetype,
+                                                 max_candidates );
 
   std::vector< std::string > candidates;
   candidates.reserve( results.size() );

--- a/cpp/ycm/IdentifierDatabase.cpp
+++ b/cpp/ycm/IdentifierDatabase.cpp
@@ -63,10 +63,9 @@ void IdentifierDatabase::ClearCandidatesStoredForFile(
 }
 
 
-void IdentifierDatabase::ResultsForQueryAndType(
+std::vector< Result > IdentifierDatabase::ResultsForQueryAndType(
   std::string&& query,
   const std::string &filetype,
-  std::vector< Result > &results,
   const size_t max_results ) const {
   FiletypeCandidateMap::const_iterator it;
   {
@@ -74,13 +73,14 @@ void IdentifierDatabase::ResultsForQueryAndType(
     it = filetype_candidate_map_.find( filetype );
 
     if ( it == filetype_candidate_map_.end() ) {
-      return;
+      return {};
     }
   }
   Word query_object( std::move( query ) );
 
   std::unordered_set< const Candidate * > seen_candidates;
   seen_candidates.reserve( candidate_repository_.NumStoredCandidates() );
+  std::vector< Result > results;
 
   {
     std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
@@ -106,6 +106,7 @@ void IdentifierDatabase::ResultsForQueryAndType(
   }
 
   PartialSort( results, max_results );
+  return results;
 }
 
 

--- a/cpp/ycm/IdentifierDatabase.h
+++ b/cpp/ycm/IdentifierDatabase.h
@@ -66,10 +66,10 @@ public:
   void ClearCandidatesStoredForFile( const std::string &filetype,
                                      const std::string &filepath );
 
-  void ResultsForQueryAndType( std::string&& query,
-                               const std::string &filetype,
-                               std::vector< Result >& results,
-                               const size_t max_results ) const;
+  std::vector< Result > ResultsForQueryAndType(
+    std::string&& query,
+    const std::string &filetype,
+    const size_t max_results ) const;
 
 private:
   std::set< const Candidate * > &GetCandidateSet(

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -45,8 +45,7 @@ const char *const TAG_REGEX =
 // values and not pointer values.
 // When passed a const char* this will create a temporary std::string for
 // comparison, but it's fast enough for our use case.
-struct StringEqualityComparer :
-    std::binary_function< std::string, std::string, bool > {
+struct StringEqualityComparer {
   bool operator()( const std::string &a, const std::string &b ) const {
     return a == b;
   }

--- a/cpp/ycm/Result.cpp
+++ b/cpp/ycm/Result.cpp
@@ -53,17 +53,6 @@ size_t LongestCommonSubsequenceLength( const CharacterSequence &first,
 
 } // unnamed namespace
 
-Result::Result()
-  : is_subsequence_( false ),
-    first_char_same_in_query_and_text_( false ),
-    query_is_candidate_prefix_( false ),
-    char_match_index_sum_( 0 ),
-    num_wb_matches_( 0 ),
-    candidate_( nullptr ),
-    query_( nullptr ) {
-}
-
-
 Result::Result( const Candidate *candidate,
                 const Word *query,
                 size_t char_match_index_sum,

--- a/cpp/ycm/Result.h
+++ b/cpp/ycm/Result.h
@@ -26,8 +26,14 @@ namespace YouCompleteMe {
 
 class Result {
 public:
-  Result();
-  ~Result() = default;
+  Result()
+  : is_subsequence_( false ),
+    first_char_same_in_query_and_text_( false ),
+    query_is_candidate_prefix_( false ),
+    char_match_index_sum_( 0 ),
+    num_wb_matches_( 0 ),
+    candidate_( nullptr ),
+    query_( nullptr ) {}
 
   Result( const Candidate *candidate,
           const Word *query,
@@ -104,21 +110,6 @@ struct ResultAnd {
   }
 
   T extra_object_;
-  Result result_;
-};
-
-template< class T >
-struct ResultAnd<T * > {
-  ResultAnd( const Result &result, const T *extra_object )
-    : extra_object_( extra_object ),
-      result_( result ) {
-  }
-
-  bool operator< ( const ResultAnd &other ) const {
-    return result_ < other.result_;
-  }
-
-  const T *extra_object_;
   Result result_;
 };
 

--- a/cpp/ycm/Utils.cpp
+++ b/cpp/ycm/Utils.cpp
@@ -32,13 +32,17 @@ std::string ReadUtf8File( const fs::path &filepath ) {
   // in case filepath's file_status is "other".
   // "other" in this case means everything that is not a regular file,
   // directory or a symlink.
+  // For the algorithm check:
+  // https://insanecoding.blogspot.com/2011/11/how-to-read-in-file-in-c.html
+  std::string contents;
   if ( !fs::is_empty( filepath ) && fs::is_regular_file( filepath ) ) {
-    fs::ifstream file( filepath, std::ios::in | std::ios::binary );
-    std::vector< char > contents( ( std::istreambuf_iterator< char >( file ) ),
-                                  std::istreambuf_iterator< char >() );
-    return std::string( contents.begin(), contents.end() );
+    fs::ifstream file( filepath, std::ios::in | std::ios::binary | std::ios::ate );
+    const size_t size = static_cast< std::string::size_type >( file.tellg() );
+    contents.resize( size );
+    file.seekg( 0, std::ios::beg );
+    file.read( &contents[ 0 ], static_cast< std::streamsize >( size ) );
   }
-  return std::string();
+  return contents;
 }
 
 

--- a/cpp/ycm/Utils.h
+++ b/cpp/ycm/Utils.h
@@ -35,18 +35,18 @@ YCM_EXPORT inline bool IsUppercase( uint8_t ascii_character ) {
 
 // An uppercase ASCII character can be converted to lowercase and vice versa by
 // flipping its third most significant bit.
-YCM_EXPORT inline uint8_t Lowercase( uint8_t ascii_character ) {
+YCM_EXPORT inline char Lowercase( uint8_t ascii_character ) {
   if ( IsUppercase( ascii_character ) ) {
-    return ascii_character ^ 0x20;
+    return static_cast< char >( ascii_character ^ 0x20 );
   }
-  return ascii_character;
+  return static_cast< char >( ascii_character );
 }
 
 
 YCM_EXPORT inline std::string Lowercase( const std::string &text ) {
   std::string result;
-  for ( uint8_t ascii_character : text ) {
-    result.push_back( Lowercase( ascii_character ) );
+  for ( auto ascii_character : text ) {
+    result.push_back( Lowercase( static_cast< uint8_t >( ascii_character ) ) );
   }
   return result;
 }
@@ -111,6 +111,7 @@ template <typename Element>
 void PartialSort( std::vector< Element > &elements,
                   const size_t num_sorted_elements ) {
 
+  using diff = typename std::vector< Element >::iterator::difference_type;
   size_t nb_elements = elements.size();
   size_t max_elements = num_sorted_elements > 0 &&
                         nb_elements >= num_sorted_elements ?
@@ -126,18 +127,19 @@ void PartialSort( std::vector< Element > &elements,
   if ( max_elements <= std::max( static_cast< size_t >( 1024 ),
                                  nb_elements / 64 ) ) {
     std::partial_sort( elements.begin(),
-                       elements.begin() + max_elements,
+                       elements.begin() + static_cast< diff >( max_elements ),
                        elements.end() );
   } else {
     std::nth_element( elements.begin(),
-                      elements.begin() + max_elements,
+                      elements.begin() + static_cast< diff >( max_elements ),
                       elements.end() );
-    std::sort( elements.begin(), elements.begin() + max_elements );
+    std::sort( elements.begin(), elements.begin() + static_cast< diff >( max_elements ) );
   }
 
   // Remove the unsorted elements. Use erase instead of resize as it doesn't
   // require a default constructor on Element.
-  elements.erase( elements.begin() + max_elements, elements.end() );
+  elements.erase( elements.begin() + static_cast< diff >( max_elements ),
+                  elements.end() );
 }
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/Word.cpp
+++ b/cpp/ycm/Word.cpp
@@ -279,8 +279,8 @@ void Word::BreakIntoCharacters() {
 
 void Word::ComputeBytesPresent() {
   for ( const auto &character : characters_ ) {
-    for ( uint8_t byte : character->Base() ) {
-      bytes_present_.set( byte );
+    for ( auto byte : character->Base() ) {
+      bytes_present_.set( static_cast< uint8_t >( byte ) );
     }
   }
 }

--- a/cpp/ycm/benchmarks/IdentifierCompleter_bench.cpp
+++ b/cpp/ycm/benchmarks/IdentifierCompleter_bench.cpp
@@ -38,9 +38,8 @@ public:
 BENCHMARK_DEFINE_F( IdentifierCompleterFixture, CandidatesWithCommonPrefix )(
     benchmark::State& state ) {
 
-  std::vector< std::string > candidates;
-  candidates = GenerateCandidatesWithCommonPrefix( "a_A_a_",
-                                                   state.range( 0 ) );
+  std::vector< std::string > candidates =
+    GenerateCandidatesWithCommonPrefix( "a_A_a_", state.range( 0 ) );
   IdentifierCompleter completer( std::move( candidates ) );
 
   while ( state.KeepRunning() ) {

--- a/cpp/ycm/tests/IdentifierUtils_test.cpp
+++ b/cpp/ycm/tests/IdentifierUtils_test.cpp
@@ -28,6 +28,7 @@ namespace YouCompleteMe {
 namespace fs = boost::filesystem;
 using ::testing::ElementsAre;
 using ::testing::ContainerEq;
+using ::testing::IsEmpty;
 using ::testing::WhenSorted;
 using ::testing::Pair;
 using ::testing::UnorderedElementsAre;
@@ -65,32 +66,28 @@ TEST( IdentifierUtilsTest, ExtractIdentifiersFromTagsFileWorks ) {
 TEST( IdentifierUtilsTest, TagFileIsDirectory ) {
   fs::path testfile = PathToTestFile( "directory.tags" );
 
-  EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ),
-               ContainerEq( FiletypeIdentifierMap() ) );
+  EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ), IsEmpty() );
 }
 
 
 TEST( IdentifierUtilsTest, TagFileIsEmpty ) {
   fs::path testfile = PathToTestFile( "empty.tags" );
 
-  EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ),
-               ContainerEq( FiletypeIdentifierMap() ) );
+  EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ), IsEmpty() );
 }
 
 
 TEST( IdentifierUtilsTest, TagLanguageMissing ) {
   fs::path testfile = PathToTestFile( "invalid_tag_file_format.tags" );
 
-  EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ),
-               ContainerEq( FiletypeIdentifierMap() ) );
+  EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ), IsEmpty() );
 }
 
 
 TEST( IdentifierUtilsTest, TagFileInvalidPath ) {
   fs::path testfile = PathToTestFile( "invalid_path_to_tag_file.tags" );
 
-  EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ),
-               ContainerEq( FiletypeIdentifierMap() ) );
+  EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ), IsEmpty() );
 }
 
 } // namespace YouCompleteMe


### PR DESCRIPTION
- Gets rid of a few warnings, like:
  - `-Wdeprecated`
  - `-Wweak-vtables`
  - `-Wsign-conversion`
  - `-Wextra-semi`
- Removes unused code
- Avoids `operator==` on hash maps, since not all implementaitons have
  the operator defined. This brings us a little closer to using flat
  hash maps.
- Removes the deprecated (C++11) and removed (C++17)
  `std::binary_function`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1388)
<!-- Reviewable:end -->
