### PR TITLE
[READY] Clean up python's sys path

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -189,13 +189,6 @@ def Settings( **kwargs ):
   return {}
 
 
-def GetStandardLibraryIndexInSysPath( sys_path ):
-  for index, path in enumerate( sys_path ):
-    if p.isfile( p.join( path, 'os.py' ) ):
-      return index
-  raise RuntimeError( 'Could not find standard library path in Python path.' )
-
-
 def PythonSysPath( **kwargs ):
   sys_path = kwargs[ 'sys_path' ]
 
@@ -204,15 +197,12 @@ def PythonSysPath( **kwargs ):
     interpreter_path, '-c', 'import sys; print( sys.version_info[ 0 ] )' ]
   ).rstrip().decode( 'utf8' )
 
-  sys_path.insert( GetStandardLibraryIndexInSysPath( sys_path ) + 1,
-                   p.join( DIR_OF_THIRD_PARTY, 'python-future', 'src' ) )
   sys_path[ 0:0 ] = [ p.join( DIR_OF_THIS_SCRIPT ),
                       p.join( DIR_OF_THIRD_PARTY, 'bottle' ),
                       p.join( DIR_OF_THIRD_PARTY, 'cregex',
                               'regex_{}'.format( major_version ) ),
                       p.join( DIR_OF_THIRD_PARTY, 'frozendict' ),
                       p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'jedi' ),
-                      p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'numpydoc' ),
                       p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'parso' ),
                       p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'requests' ),
                       p.join( DIR_OF_THIRD_PARTY, 'requests_deps',
@@ -226,4 +216,5 @@ def PythonSysPath( **kwargs ):
                                                   'idna' ),
                       p.join( DIR_OF_THIRD_PARTY, 'waitress' ) ]
 
+  sys_path.append( p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'numpydoc' ) )
   return sys_path

--- a/run_tests.py
+++ b/run_tests.py
@@ -17,7 +17,6 @@ python_path = [
   p.join( DIR_OF_THIRD_PARTY, 'cregex', 'regex_3' ),
   p.join( DIR_OF_THIRD_PARTY, 'frozendict' ),
   p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'jedi' ),
-  p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'numpydoc' ),
   p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'parso' ),
   p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'certifi' ),
   p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'chardet' ),
@@ -28,7 +27,10 @@ python_path = [
 ]
 if os.environ.get( 'PYTHONPATH' ) is not None:
   python_path.append( os.environ[ 'PYTHONPATH' ] )
-os.environ[ 'PYTHONPATH' ] = os.pathsep.join( python_path )
+os.environ[ 'PYTHONPATH' ] = (
+    os.pathsep.join( python_path ) +
+    os.pathsep +
+    p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'numpydoc' ) )
 
 
 def OnWindows():

--- a/ycmd/server_utils.py
+++ b/ycmd/server_utils.py
@@ -37,7 +37,6 @@ def SetUpPythonPath():
                       p.join( DIR_OF_THIRD_PARTY, 'cregex', 'regex_3' ),
                       p.join( DIR_OF_THIRD_PARTY, 'frozendict' ),
                       p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'jedi' ),
-                      p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'numpydoc' ),
                       p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'parso' ),
                       p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'requests' ),
                       p.join( DIR_OF_THIRD_PARTY, 'requests_deps', 'chardet' ),
@@ -48,3 +47,4 @@ def SetUpPythonPath():
                               'urllib3',
                               'src' ),
                       p.join( DIR_OF_THIRD_PARTY, 'waitress' ) ]
+  sys.path.append( p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'numpydoc' ) )


### PR DESCRIPTION
Removing python-future from the extra conf was missed in the python2
support drop pull request.

Numpydoc is now appended to the sys.path to allow python to find the
system-wide numpydoc instead. This is because we're unlikely to update
numpydoc as the v0.9.0+ depend on sphinx and that would be rather insane
to keep around as a submodule.

This way, for users that have a newer numpydoc and use the new features of it, we allow jedi to use that new numpydoc, but for other users the bundled version still works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1396)
<!-- Reviewable:end -->
