### PR TITLE
[READY] Make LoadPythonModule self-contained

### DIFF
--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -359,7 +359,7 @@ def SafePopen( args, **kwargs ):
 # Shim for importlib.machinery.SourceFileLoader.
 # See upstream Python docs for info on what this does.
 def LoadPythonSource( name, pathname ):
-  import importlib
+  import importlib.machinery
   return importlib.machinery.SourceFileLoader( name, pathname ).load_module()
 
 


### PR DESCRIPTION
Currently this utility only works because of side-effects. During tests,
pytest does its magic and loads `importlib.machinery`. During the normal
use, there's no pytest, but jedi creates the same side-effect.

As a result, `LoadPythonModule()` only needs to get a reference to
`importlib` to work.

    import ycmd
    ycmd.utils

The above snippet raises an `AttributeError` and looks just like
`LoadPythonModule`. Instead the correct snippet would be

    import ycmd.utils
    ycmd.utils

The tests are missing because, considering the side-effects, it is
impossible to write one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1398)
<!-- Reviewable:end -->
