### PR TITLE
[READY] Update CI images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ jobs:
   pool:
     # List of available software on this image:
     # https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/linux/Ubuntu1604-README.md
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   strategy:
     matrix:
       'Python 3.6 without libclang completer':
@@ -51,7 +51,7 @@ jobs:
   pool:
     # List of available software on this image:
     # https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/macos/macos-10.13-Readme.md
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.15'
   strategy:
     matrix:
       'Python 3.6':
@@ -76,31 +76,6 @@ jobs:
   - script: ./azure/send_coverage.sh
     displayName: Send coverage
     condition: and(succeeded(), eq(variables['COVERAGE'], 'true'))
-    env:
-      CODECOV_TOKEN: $(CODECOV_TOKEN)
-      CODECOV_JOB_NAME: '$(Agent.JobName)'
-- job: windows_msvc14
-  displayName: 'Windows Visual Studio 2015'
-  pool:
-    # List of available software on this image:
-    # https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/win/Vs2015-Server2012R2-Readme.md
-    vmImage: 'vs2015-win2012r2'
-  strategy:
-    matrix:
-      'Python 3.8 64-bit':
-        YCM_PYTHON_INSTALLER_URL: 'https://www.python.org/ftp/python/3.8.1/python-3.8.1-amd64.exe'
-  variables:
-    MSVC: 14
-    MSBUILD_PATH: 'C:\Program Files (x86)\MSBuild\14.0\Bin'
-  steps:
-  - checkout: self
-    submodules: recursive
-  - script: azure\windows\install_dependencies.bat
-    displayName: Install dependencies
-  - script: azure\windows\run_tests.bat
-    displayName: Run tests
-  - script: azure\windows\send_coverage.bat
-    displayName: Send coverage
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)
       CODECOV_JOB_NAME: '$(Agent.JobName)'

--- a/azure/linux/install_dependencies.sh
+++ b/azure/linux/install_dependencies.sh
@@ -7,9 +7,9 @@ set -e
 
 sudo apt-get install libsqlite3-dev
 if [ "${YCM_COMPILER}" == "clang" ]; then
-  sudo apt-get install clang-3.5
-  sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-3.5 100
-  sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-3.5 100
+  sudo apt-get install clang-3.9
+  sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-3.9 100
+  sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-3.9 100
 else
   sudo apt-get install gcc-4.8 g++-4.8
   sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-4.8 100
@@ -18,10 +18,10 @@ fi
 
 if [ "${YCM_CLANG_TIDY}" ]; then
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-  sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
+  sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main"
   sudo apt-get update
-  sudo apt-get install -y clang-tidy-8 valgrind
-  sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-8 100
+  sudo apt-get install -y clang-tidy-9 valgrind
+  sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 100
 fi
 
 #

--- a/valgrind.suppressions
+++ b/valgrind.suppressions
@@ -315,16 +315,15 @@
 	fun:malloc
 	fun:_dl_map_object_deps
 	fun:dl_open_worker
-	fun:_dl_catch_error
+	fun:_dl_catch_exception
 	fun:_dl_open
 	fun:dlopen_doit
+	fun:_dl_catch_exception
 	fun:_dl_catch_error
 	fun:_dlerror_run
 	fun:dlopen@@GLIBC_2.2.5
 	fun:_PyImport_FindSharedFuncptr
 	fun:_PyImport_LoadDynamicModuleWithSpec
-	fun:_imp_create_dynamic_impl
-	fun:_imp_create_dynamic
 }
 {
 	Pytest at shutdown
@@ -349,4 +348,25 @@
 	fun:call_method
 	fun:slot_mp_ass_subscript
 	fun:_PyEval_EvalFrameDefault
+}
+{
+	Magically appeared when upgrading to Ubuntu 18.04
+	Memcheck:Cond
+	fun:__wcsnlen_avx2
+	fun:wcsrtombs
+	fun:wcstombs
+	fun:wcstombs
+	fun:encode_current_locale
+	fun:encode_locale_ex
+}
+{
+	Magically appeared when upgrading to Ubuntu 18.04
+	Memcheck:Cond
+	fun:internal_utf8_loop
+	fun:__gconv_transform_internal_utf8
+	fun:wcsrtombs
+	fun:wcstombs
+	fun:wcstombs
+	fun:encode_current_locale
+	fun:encode_locale_ex
 }


### PR DESCRIPTION
Use latest macOS and linux images and drop testing on VS2015.

The macOS and Windows changes are made because azure is dropping VS2015 and macos 10.13 images. Linux was just convenient.

There's also a bump to clang 3.9 and that's because Ubuntu 18.04 doesn't ship clang older than that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1406)
<!-- Reviewable:end -->
