### PR TITLE
[READY] Use non-reentrant locks everywhere

### DIFF
--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -475,24 +475,36 @@ class CompletionsCache:
   """Cache of computed completions for a particular request."""
 
   def __init__( self ):
-    self._access_lock = threading.RLock()
+    self._access_lock = threading.Lock()
     self.Invalidate()
 
 
   def Invalidate( self ):
     with self._access_lock:
-      self._request_data = None
-      self._completions = None
+      self.InvalidateNoLock()
+
+
+  def InvalidateNoLock( self ):
+    self._request_data = None
+    self._completions = None
 
 
   def Update( self, request_data, completions ):
     with self._access_lock:
-      self._request_data = request_data
-      self._completions = completions
+      self.UpdateNoLock( request_data, completions )
+
+
+  def UpdateNoLock( self, request_data, completions ):
+    self._request_data = request_data
+    self._completions = completions
 
 
   def GetCompletionsIfCacheValid( self, request_data ):
     with self._access_lock:
-      if self._request_data and self._request_data == request_data:
-        return self._completions
-      return None
+      return self.GetCompletionsIfCacheValidNoLock( request_data )
+
+
+  def GetCompletionsIfCacheValidNoLock( self, request_data ):
+    if self._request_data and self._request_data == request_data:
+      return self._completions
+    return None

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -2822,14 +2822,14 @@ class LanguageServerCompletionsCache( CompletionsCache ):
 
   def Invalidate( self ):
     with self._access_lock:
-      super().Invalidate()
+      super().InvalidateNoLock()
       self._is_incomplete = False
       self._use_start_column = True
 
 
   def Update( self, request_data, completions, is_incomplete ):
     with self._access_lock:
-      super().Update( request_data, completions )
+      super().UpdateNoLock( request_data, completions )
       self._is_incomplete = is_incomplete
       if is_incomplete:
         self._use_start_column = False
@@ -2851,7 +2851,7 @@ class LanguageServerCompletionsCache( CompletionsCache ):
     with self._access_lock:
       if ( not self._is_incomplete and
            ( self._use_start_column or self._IsQueryPrefix( request_data ) ) ):
-        return super().GetCompletionsIfCacheValid( request_data )
+        return super().GetCompletionsIfCacheValidNoLock( request_data )
       return None
 
 

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -138,7 +138,7 @@ class TypeScriptCompleter( Completer ):
 
     self._logfile = None
 
-    self._tsserver_lock = threading.RLock()
+    self._tsserver_lock = threading.Lock()
     self._tsserver_handle = None
     self._tsserver_version = None
     self._tsserver_executable = FindTSServer(
@@ -189,31 +189,35 @@ class TypeScriptCompleter( Completer ):
 
   def _StartServer( self ):
     with self._tsserver_lock:
-      if self._ServerIsRunning():
-        return
+      self._StartServerNoLock()
 
-      self._logfile = utils.CreateLogfile( LOGFILE_FORMAT )
-      tsserver_log = '-file {path} -level {level}'.format( path = self._logfile,
-                                                           level = _LogLevel() )
-      # TSServer gets the configuration for the log file through the
-      # environment variable 'TSS_LOG'. This seems to be undocumented but
-      # looking at the source code it seems like this is the way:
-      # https://github.com/Microsoft/TypeScript/blob/8a93b489454fdcbdf544edef05f73a913449be1d/src/server/server.ts#L136
-      environ = os.environ.copy()
-      environ[ 'TSS_LOG' ] = tsserver_log
 
-      LOGGER.info( 'TSServer log file: %s', self._logfile )
+  def _StartServerNoLock( self ):
+    if self._ServerIsRunning():
+      return
 
-      # We need to redirect the error stream to the output one on Windows.
-      self._tsserver_handle = utils.SafePopen( self._tsserver_executable,
-                                               stdin = subprocess.PIPE,
-                                               stdout = subprocess.PIPE,
-                                               stderr = subprocess.STDOUT,
-                                               env = environ )
+    self._logfile = utils.CreateLogfile( LOGFILE_FORMAT )
+    tsserver_log = '-file {path} -level {level}'.format( path = self._logfile,
+                                                         level = _LogLevel() )
+    # TSServer gets the configuration for the log file through the
+    # environment variable 'TSS_LOG'. This seems to be undocumented but
+    # looking at the source code it seems like this is the way:
+    # https://github.com/Microsoft/TypeScript/blob/8a93b489454fdcbdf544edef05f73a913449be1d/src/server/server.ts#L136
+    environ = os.environ.copy()
+    environ[ 'TSS_LOG' ] = tsserver_log
 
-      self._tsserver_is_running.set()
+    LOGGER.info( 'TSServer log file: %s', self._logfile )
 
-      utils.StartThread( self._SetServerVersion )
+    # We need to redirect the error stream to the output one on Windows.
+    self._tsserver_handle = utils.SafePopen( self._tsserver_executable,
+                                             stdin = subprocess.PIPE,
+                                             stdout = subprocess.PIPE,
+                                             stderr = subprocess.STDOUT,
+                                             env = environ )
+
+    self._tsserver_is_running.set()
+
+    utils.StartThread( self._SetServerVersion )
 
 
   def _ReaderLoop( self ):
@@ -354,8 +358,7 @@ class TypeScriptCompleter( Completer ):
 
 
   def _ServerIsRunning( self ):
-    with self._tsserver_lock:
-      return utils.ProcessIsRunning( self._tsserver_handle )
+    return utils.ProcessIsRunning( self._tsserver_handle )
 
 
   def ServerIsHealthy( self ):
@@ -895,8 +898,8 @@ class TypeScriptCompleter( Completer ):
 
   def _RestartServer( self, request_data ):
     with self._tsserver_lock:
-      self._StopServer()
-      self._StartServer()
+      self._StopServerNoLock()
+      self._StartServerNoLock()
       # This is needed because after we restart the TSServer it would lose all
       # the information about the files we were working on. This means that the
       # newly started TSServer will know nothing about the buffer we're working
@@ -908,18 +911,22 @@ class TypeScriptCompleter( Completer ):
 
   def _StopServer( self ):
     with self._tsserver_lock:
-      if self._ServerIsRunning():
-        LOGGER.info( 'Stopping TSServer with PID %s',
-                     self._tsserver_handle.pid )
-        try:
-          self._SendCommand( 'exit' )
-          utils.WaitUntilProcessIsTerminated( self._tsserver_handle,
-                                              timeout = 5 )
-          LOGGER.info( 'TSServer stopped' )
-        except Exception:
-          LOGGER.exception( 'Error while stopping TSServer' )
+      self._StopServerNoLock()
 
-      self._CleanUp()
+
+  def _StopServerNoLock( self ):
+    if self._ServerIsRunning():
+      LOGGER.info( 'Stopping TSServer with PID %s',
+                   self._tsserver_handle.pid )
+      try:
+        self._SendCommand( 'exit' )
+        utils.WaitUntilProcessIsTerminated( self._tsserver_handle,
+                                            timeout = 5 )
+        LOGGER.info( 'TSServer stopped' )
+      except Exception:
+        LOGGER.exception( 'Error while stopping TSServer' )
+
+    self._CleanUp()
 
 
   def _CleanUp( self ):


### PR DESCRIPTION
We can actually use `threading.Lock` everywhere.

Where possible, we avoid taking and releasing the lock multiple times, by introducing `Foo()` and `FooNoLock()`, where the former takes a lock and calls the latter. The `LanguageServerCompleter` shutdown procedure is complex enough that we can't avoid multiple locks, so two places where this `FooNoLock()` thing isn't possible are:

- `_RestartServer()` in `LanguageServerCompleter`.
- `StartServer()` in `JavaCompleter` when it throws a `LanguageServerConnectionTimeout`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1411)
<!-- Reviewable:end -->
