### PR TITLE
[READY] Improve hover formatting for the GenericLSPCompleter

### DIFF
--- a/ycmd/completers/language_server/generic_lsp_completer.py
+++ b/ycmd/completers/language_server/generic_lsp_completer.py
@@ -47,8 +47,26 @@ class GenericLSPCompleter( language_server_completer.LanguageServerCompleter ):
 
   def GetCustomSubcommands( self ):
     return { 'GetHover': lambda self, request_data, args:
-      responses.BuildDisplayMessageResponse(
-        self.GetHoverResponse( request_data ) ) }
+      self._GetHover( request_data ) }
+
+
+  def _GetHover( self, request_data ):
+    raw_hover = self.GetHoverResponse( request_data )
+    if isinstance( raw_hover, dict ):
+      # Both MarkedString and MarkupContent contain 'value' key.
+      # MarkupContent is the only one not deprecated.
+      return responses.BuildDetailedInfoResponse( raw_hover[ 'value' ] )
+    if isinstance( raw_hover, str ):
+      # MarkedString might be just a string.
+      return responses.BuildDetailedInfoResponse( raw_hover )
+    # If we got this far, this is a list of MarkedString objects.
+    lines = []
+    for marked_string in raw_hover:
+      if isinstance( marked_string, str ):
+        lines.append( marked_string )
+      else:
+        lines.append( marked_string[ 'value' ] )
+    return responses.BuildDetailedInfoResponse( '\n'.join( lines ) )
 
 
   def GetCodepointForCompletionRequest( self, request_data ):


### PR DESCRIPTION
Since people seem to be actually using the generic LSP completer, it is high time we fixed the way we format the hover response. It would be nice if we could just forget about the deprecated MarkedString, but even among the 4 officially supported LSP servers, we're exercising every possible hover response. Hints of what I think of `interface Hover` is perhaps visible in one of the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1414)
<!-- Reviewable:end -->
