### PR TITLE
[READY] Do not assume that users have setuptools available

### DIFF
--- a/build.py
+++ b/build.py
@@ -1125,14 +1125,25 @@ def CompileWatchdog( script_args ):
     RemoveDirectoryIfExists( build_dir )
     RemoveDirectoryIfExists( lib_dir )
 
-    CheckCall( [ sys.executable,
-                 'setup.py',
-                 'build',
-                 '--build-base=' + build_dir,
-                 '--build-lib=' + lib_dir ],
-               exit_message = 'Failed to build watchdog module.',
-               quiet = script_args.quiet,
-               status_message = 'Building watchdog module' )
+    try:
+      import setuptools # noqa
+      CheckCall( [ sys.executable,
+                   'setup.py',
+                   'build',
+                   '--build-base=' + build_dir,
+                   '--build-lib=' + lib_dir ],
+                 exit_message = 'Failed to build watchdog module.',
+                 quiet = script_args.quiet,
+                 status_message = 'Building watchdog module' )
+    except ImportError:
+      if OnMac():
+        print( 'WARNING: setuptools unavailable. Watchdog will fall back to '
+               'the slower kqueue filesystem event API.\n'
+               'To use the faster fsevents, install setuptools and '
+               'rerun this script.' )
+      os.makedirs( lib_dir )
+      shutil.copytree( p.join( 'src', 'watchdog' ),
+                       p.join( lib_dir, 'watchdog' ) )
   finally:
     os.chdir( DIR_OF_THIS_SCRIPT )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ regex    >= 2020.2.20
 jedi     >= 0.16.0
 requests >= 2.22.0
 waitress >= 1.4.3
+watchdog >= 0.10.2

--- a/valgrind.suppressions
+++ b/valgrind.suppressions
@@ -462,3 +462,27 @@
 	fun:start_thread
 	fun:clone
 }
+{
+	Watchdog update from 0.9.0 to 0.10.2
+	Memcheck:Leak
+	fun:malloc
+	fun:new_keys_object
+	fun:dictresize
+	fun:dict_merge
+	fun:dict_update_common
+	fun:dict_update
+	fun:method_vectorcall_VARARGS_KEYWORDS
+	fun:_PyObject_Vectorcall
+	fun:call_function
+	fun:_PyEval_EvalFrameDefault
+	fun:_PyEval_EvalCodeWithName
+	fun:_PyFunction_Vectorcall
+	fun:_PyObject_Vectorcall
+	fun:call_function
+	fun:_PyEval_EvalFrameDefault
+	fun:_PyEval_EvalCodeWithName
+	fun:_PyFunction_Vectorcall
+	fun:_PyObject_Vectorcall
+	fun:call_function
+	fun:_PyEval_EvalFrameDefault
+}


### PR DESCRIPTION
Because some users really don't. Seems like we can't even touch anything remotely related to pip without getting bug reports...

This means that we won't always be able to compile watchdog's fsevents extension module.

This won't affect Windows and Linux users, but on macOS, without fsevents, watchdog will fall back to the slower kqueue API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1422)
<!-- Reviewable:end -->
