### PR TITLE
Make sure gopls installed in bin folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,5 +92,5 @@ third_party/generic_server/package-lock.json
 # clangd index data
 .clangd/
 
-# installation directory for glpls
+# installation directory for gopls
 third_party/go

--- a/build.py
+++ b/build.py
@@ -845,6 +845,7 @@ def EnableGoCompleter( args ):
   new_env = os.environ.copy()
   new_env[ 'GO111MODULE' ] = 'on'
   new_env[ 'GOPATH' ] = p.join( DIR_OF_THIS_SCRIPT, 'third_party', 'go' )
+  new_env[ 'GOBIN' ] = p.join( new_env[ 'GOPATH' ], 'bin' )
   CheckCall( [ go, 'get', 'golang.org/x/tools/gopls@v0.4.0' ],
              env = new_env,
              quiet = args.quiet,


### PR DESCRIPTION
If `GOBIN` environment variable is not set, `build.py --go-completer` will not install `gopls` to `third_party/go/bin`.

Please help me to review this PR, thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1427)
<!-- Reviewable:end -->
