### PR TITLE
Various typo fixes

### DIFF
--- a/JAVA_SUPPORT.md
+++ b/JAVA_SUPPORT.md
@@ -35,7 +35,7 @@ card][design]. In short:
 
 * 2 classes implement the language server protocol in the
   `language_server_completer.py` module:
- * `LanguageServerConnection` - an abstraction of the comminication with the
+ * `LanguageServerConnection` - an abstraction of the communication with the
    server, which may be over stdio or any number of TCP/IP ports (or a domain
    socket, etc.). Only a single implementation is included (stdio), but
    [implementations for TCP/IP](https://github.com/puremourning/ycmd-1/commit/f3cd06245692b05031a64745054326273d52d12f)
@@ -52,11 +52,11 @@ the [trello board][trello] I used for development.
 
 ## Threads, and why we need them
 
-LSP is by its nature an asyncronous protocol. There are request-reply like
+LSP is by its nature an asynchronous protocol. There are request-reply like
 `requests` and unsolicited `notifications`. Receipt of the latter is mandatory,
 so we cannot rely on their being a `bottle` thread executing a client request.
 
-So we need a message pump and despatch thread. This is actually the
+So we need a message pump and dispatch thread. This is actually the
 `LanguageServerConnection`, which implements `thread`. It's main method simply
 listens on the socket/stream and despatches complete messages to the
 `LanguageServerCompleter`. It does this:
@@ -212,7 +212,7 @@ fiddly. 2 things are required:
 
 This isn't so bad, but jdt.ls is buggy and actually dies without responding to
 the `shutdown` request. So we have a bunch of code to handle that and to ensure
-that the server dies eventually, as it had a habbit of getting stuck running,
+that the server dies eventually, as it had a habit of getting stuck running,
 particularly if we threw an exception.
 
 [PR]: https://github.com/valloric/ycmd/pull/857

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -240,7 +240,7 @@ else()
 endif()
 
 set( Python_ADDITIONAL_VERSIONS 3.9 3.8 3.7 3.6 3.5 )
-find_package( PythonLibs 3.5 REQUIRED )  # 3.5 is ONLY the mininum
+find_package( PythonLibs 3.5 REQUIRED )  # 3.5 is ONLY the minimum
 
 #############################################################################
 

--- a/cpp/ycm/ClangCompleter/ClangCompleter.cpp
+++ b/cpp/ycm/ClangCompleter/ClangCompleter.cpp
@@ -49,7 +49,7 @@ ClangCompleter::~ClangCompleter() {
   // when we destroy the clang index, but since we're shutting down, we don't
   // really care.
   // In practice, this situation shouldn't happen because the server threads are
-  // Python deamon threads and will all be killed before the main thread exits.
+  // Python daemon threads and will all be killed before the main thread exits.
   translation_unit_store_.RemoveAll();
   clang_disposeIndex( clang_index_ );
 }

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -381,7 +381,7 @@ definitions:
       resolve:
         type: boolean
         description: |-
-          Indicates wether the fixit requires additional processing.
+          Indicates whether the fixit requires additional processing.
   FixIt:
     type: object
     required:
@@ -400,7 +400,7 @@ definitions:
       resolve:
         type: boolean
         description: |-
-          Indicates wether the fixit requires additional processing.
+          Indicates whether the fixit requires additional processing.
       chunks:
         type: array
         description: |-
@@ -596,7 +596,7 @@ definitions:
 
       - An object with a property `message` is a *simple display message* where
         the property value is the message.
-      - An object with a property `diagnostics` contains diagnotics for a
+      - An object with a property `diagnostics` contains diagnostics for a
         project file. The value of the property is described below.
     items:
       $ref: '#/definitions/Message'
@@ -635,7 +635,7 @@ definitions:
     properties:
       filpath:
         $ref: '#/definitions/FilePath'
-      diagnotics:
+      diagnostics:
         type: array
         items:
           $ref: "#/definitions/DiagnosticData"
@@ -659,7 +659,7 @@ paths:
             Call when the user closes a buffer that was previously known to be
             open. Closing buffers is important to limit resource usage.
           - `BufferVisit` (optional)
-            Call when the user focusses on a buffer that is already known.
+            Call when the user focuses on a buffer that is already known.
             *Note*: The `ultisnips_snippets` property is optional when firing
             calling this event. Otherwise it is ignored.
           - `InsertLeave` (optional)
@@ -669,7 +669,7 @@ paths:
             Call when the user finishes typing what appears to the client to be
             an identifier.
           - `FileSave`
-            Call whe the user writes to a file on disk. (optional)
+            Call when the user writes to a file on disk. (optional)
       produces:
         - application/json
       parameters:
@@ -1492,7 +1492,7 @@ paths:
               - message: 'Initializing: Done.'
               - diagonostics:
                   filepath: '/file'
-                  diagnotics:
+                  diagnostics:
                   - ranges:
                     - start: { line_num: 10, column_num: 11, filepath: '/file' }
                       end: { line_num: 10, column_num: 20, filepath: '/file' }
@@ -1567,6 +1567,6 @@ paths:
           schema:
             $ref: "#/definitions/SubcommandResponse"
         500:
-          description: An error occured
+          description: An error occurred
           schema:
             $ref: "#/definitions/ExceptionResponse"

--- a/update_omnisharp.py
+++ b/update_omnisharp.py
@@ -135,7 +135,7 @@ def Main():
     with TemporaryDirectory() as temp_dir:
       output = Process( temp_dir, version )
 
-  print( "Omnisharp configration for {} is:".format( version ) )
+  print( "Omnisharp configuration for {} is:".format( version ) )
   for os_name, os_data in output.items():
     print( "    {}: {{".format( repr( os_name ) ) )
     for key, value in os_data.items():

--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -138,7 +138,7 @@ class Completer( metaclass = abc.ABCMeta ):
   Do not override this function. Instead, you need to implement the
   GetSubcommandsMap method. It should return a map between the user commands
   and the methods of your completer. See the documentation of this method for
-  more informations on how to implement it.
+  more information on how to implement it.
 
   Override the Shutdown() member function if your Completer subclass needs to do
   custom cleanup logic on server shutdown.

--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -164,7 +164,7 @@ def GetClangdCommand( user_options ):
 def ShouldEnableClangdCompleter( user_options ):
   """Checks whether clangd should be enabled or not.
 
-  - Returns True iff an up-to-date binary exists either in `clangd_binary_path`
+  - Returns True if an up-to-date binary exists either in `clangd_binary_path`
     or in third party folder and `use_clangd` is not set to `0`.
   """
   # User disabled clangd explicitly.

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -18,7 +18,7 @@
 import os
 import inspect
 from ycmd import extra_conf_store
-from ycmd.utils import ( AbsoluatePath,
+from ycmd.utils import ( AbsolutePath,
                          ImportCore,
                          OnMac,
                          OnWindows,
@@ -215,7 +215,7 @@ class Flags:
     # compilation database already for that path, or if a compile_commands.json
     # file exists in that directory.
     for folder in PathsToAllParentFolders( file_dir ):
-      # Try/catch to syncronise access to cache
+      # Try/catch to synchronise access to cache
       try:
         return self.compilation_database_dir_map[ folder ]
       except KeyError:
@@ -346,7 +346,7 @@ def _AddLanguageFlagWhenAppropriate( flags, enable_windows_style_flags ):
   """When flags come from the compile_commands.json file, the flag preceding the
   first flag starting with a dash is usually the path to the compiler that
   should be invoked. Since LibClang does not deduce the language from the
-  compiler name, we explicitely set the language to C++ if the compiler is a C++
+  compiler name, we explicitly set the language to C++ if the compiler is a C++
   one (g++, clang++, etc.). We also set the language to CUDA if any of the
   source files has a .cu or .cuh extension. Otherwise, we let LibClang guess the
   language from the file extension. This handles the case where the .h extension
@@ -611,7 +611,7 @@ def _MakeRelativePathsInFlagsAbsolute( flags, working_directory ):
 
     if make_next_absolute:
       make_next_absolute = False
-      new_flag = AbsoluatePath( flag, working_directory )
+      new_flag = AbsolutePath( flag, working_directory )
     else:
       for path_flag in path_flags:
         # Single dash argument alone, e.g. -isysroot <path>
@@ -623,7 +623,7 @@ def _MakeRelativePathsInFlagsAbsolute( flags, working_directory ):
         # or double-dash argument, e.g. --isysroot=<path>
         if flag.startswith( path_flag ):
           path = flag[ len( path_flag ): ]
-          path = AbsoluatePath( path, working_directory )
+          path = AbsolutePath( path, working_directory )
           new_flag = '{0}{1}'.format( path_flag, path )
           break
 

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -438,7 +438,7 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
         if project_directory:
           self._java_project_dir = project_directory
         elif 'project_directory' in self._settings:
-          self._java_project_dir = utils.AbsoluatePath(
+          self._java_project_dir = utils.AbsolutePath(
             self._settings[ 'project_directory' ],
             self._extra_conf_dir )
         else:

--- a/ycmd/completers/javascript/tern_completer.py
+++ b/ycmd/completers/javascript/tern_completer.py
@@ -514,7 +514,7 @@ class TernCompleter( Completer ):
   def _GetDoc( self, request_data ):
     # Note: we use the 'type' request because this is the best
     # way to get the name, type and doc string. The 'documentation' request
-    # doesn't return the 'name' (strangely), wheras the 'type' request returns
+    # doesn't return the 'name' (strangely), whereas the 'type' request returns
     # the same docs with extra info.
     query = {
       'type':      'type',

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -819,7 +819,7 @@ class LanguageServerCompleter( Completer ):
     #     server file state, and stored data about the server itself) when we
     #     are calling methods on this object from the message pump). We
     #     synchronise on this mutex for that.
-    #   - We need to make sure that multiple client requests dont try to start
+    #   - We need to make sure that multiple client requests don't try to start
     #     or stop the server simultaneously, so we also do all server
     #     start/stop/etc. operations under this mutex
     self._server_info_mutex = threading.Lock()
@@ -969,7 +969,7 @@ class LanguageServerCompleter( Completer ):
       # NOTE: While waiting for the connection to close, we must _not_ hold any
       # locks (in fact, we must not hold locks that might be needed when
       # processing messages in the poll thread - i.e. notifications).
-      # This is crucial, as the server closing (asyncronously) might
+      # This is crucial, as the server closing (asynchronously) might
       # involve _other activities_ if there are messages in the queue (e.g. on
       # the socket) and we need to store/handle them in the message pump
       # (such as notifications) or even the initialise response.
@@ -1670,10 +1670,10 @@ class LanguageServerCompleter( Completer ):
       # diagnostics and return them in OnFileReadyToParse. We also need these
       # for correct FixIt handling, as they are part of the FixIt context.
       params = notification[ 'params' ]
-      # Since percent-encoded strings are not cannonical, they can choose to use
+      # Since percent-encoded strings are not canonical, they can choose to use
       # upper case or lower case letters, also there are some characters that
       # can be encoded or not. Therefore, we convert them back and forth
-      # according to our implementation to make sure they are in a cannonical
+      # according to our implementation to make sure they are in a canonical
       # form for access later on.
       try:
         uri = lsp.FilePathToUri( lsp.UriToFilePath( params[ 'uri' ] ) )
@@ -1901,7 +1901,7 @@ class LanguageServerCompleter( Completer ):
         first directory from there
       - if there's an extra_conf file, use that directory
       - otherwise if we know the client's cwd, use that
-      - otherwise use the diretory of the file that we just opened
+      - otherwise use the directory of the file that we just opened
     Note: None of these are ideal. Ycmd doesn't really have a notion of project
     directory and therefore neither do any of our clients.
 
@@ -1910,7 +1910,7 @@ class LanguageServerCompleter( Completer ):
     """
 
     if 'project_directory' in self._settings:
-      return utils.AbsoluatePath( self._settings[ 'project_directory' ],
+      return utils.AbsolutePath( self._settings[ 'project_directory' ],
                                   self._extra_conf_dir )
 
     project_root_files = self.GetProjectRootFiles()
@@ -2385,7 +2385,7 @@ class LanguageServerCompleter( Completer ):
       raise ValueError( 'Must specify a command to execute' )
 
     # We don't have any actual knowledge of the responses here. Unfortunately,
-    # the LSP "comamnds" require client/server specific understanding of the
+    # the LSP "commands" require client/server specific understanding of the
     # commands.
     collector = EditCollector()
     with self.GetConnection().CollectApplyEdits( collector ):

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -147,7 +147,7 @@ class TypeScriptCompleter( Completer ):
     self._tsserver_is_running = threading.Event()
 
     # Used to prevent threads from concurrently writing to
-    # the tsserver process' stdin
+    # the tsserver process's stdin
     self._write_lock = threading.Lock()
 
     # Each request sent to tsserver must have a sequence id.
@@ -173,7 +173,7 @@ class TypeScriptCompleter( Completer ):
     self._latest_diagnostics_for_file_lock = threading.Lock()
     self._latest_diagnostics_for_file = defaultdict( list )
 
-    # There's someting in the API that lists the trigger characters, but
+    # There's something in the API that lists the trigger characters, but
     # there is no way to request that from the server, so we just hard-code
     # the signature triggers.
     self.SetSignatureHelpTriggers( [ '(', ',', '<' ] )
@@ -341,7 +341,7 @@ class TypeScriptCompleter( Completer ):
 
   def _Reload( self, request_data ):
     """
-    Syncronize TSServer's view of the file to
+    Synchronize TSServer's view of the file to
     the contents of the unsaved buffer.
     """
 

--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -203,7 +203,7 @@ def StartOfLongestIdentifierEndingAtIndex( text, index, filetype = None ):
   return index
 
 
-# If the index is not on a valid identifer, it searches forward until a valid
+# If the index is not on a valid identifier, it searches forward until a valid
 # identifier is found. Returns the identifier.
 def IdentifierAtIndex( text, index, filetype = None ):
   if index > len( text ):

--- a/ycmd/request_wrap.py
+++ b/ycmd/request_wrap.py
@@ -274,7 +274,7 @@ def CompletionStartCodepoint( line_value, column_num, filetype ):
   codepoint_column_num = ByteOffsetToCodepointOffset( line_value, column_num )
 
   unicode_line_value = ToUnicode( line_value )
-  # -1 and then +1 to account for difference betwen 0-based and 1-based
+  # -1 and then +1 to account for difference between 0-based and 1-based
   # indices/columns
   codepoint_start_column = StartOfLongestIdentifierEndingAtIndex(
       unicode_line_value, codepoint_column_num - 1, filetype ) + 1

--- a/ycmd/tests/clangd/utilities_test.py
+++ b/ycmd/tests/clangd/utilities_test.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-"""This test is for utilites used in clangd."""
+"""This test is for utilities used in clangd."""
 
 from unittest.mock import patch
 from hamcrest import assert_that, equal_to

--- a/ycmd/tests/java/debug_info_test.py
+++ b/ycmd/tests/java/debug_info_test.py
@@ -44,7 +44,7 @@ def DebugInfo_HandleNotificationInPollThread_Throw_test( app ):
                              'Test.java' )
   StartJavaCompleterServerInDirectory( app, filepath )
 
-  # This mock will be called in the message pump thread, so syncronize the
+  # This mock will be called in the message pump thread, so synchronize the
   # result (thrown) using an Event
   thrown = threading.Event()
 

--- a/ycmd/tests/java/diagnostics_test.py
+++ b/ycmd/tests/java/diagnostics_test.py
@@ -646,7 +646,7 @@ def FileReadyToParse_ChangeFileContentsFileData_test( app ):
   assert_that( diags, empty() )
 
   # Now send the request again, but don't include the unsaved file. It should be
-  # read from disk, casuing the diagnostics for that file to appear.
+  # read from disk, causing the diagnostics for that file to appear.
   event_data = BuildRequest( event_name = 'FileReadyToParse',
                              contents = contents,
                              filepath = filepath,

--- a/ycmd/tests/java/subcommands_test.py
+++ b/ycmd/tests/java/subcommands_test.py
@@ -1013,7 +1013,7 @@ def Subcommands_FixIt_SingleDiag_MultiOption_Delete_test( app ):
                         LocationMatcher( filepath, 15, 30 ) ),
         ),
       } ),
-      # The edit reported for this is juge and uninteresting really. Manual
+      # The edit reported for this is huge and uninteresting really. Manual
       # testing can show that it works. This test is really about the previous
       # FixIt (and nonetheless, the previous tests ensure that we correctly
       # populate the chunks list; the contents all come from jdt.ls)
@@ -2080,7 +2080,7 @@ def Subcommands_ExecuteCommand_test( app ):
       'filepath': TEST_JAVA,
     },
     'expect': {
-      # We dont specify the path for import organize, and jdt.ls returns shrug
+      # We don't specify the path for import organize, and jdt.ls returns shrug
       'response': requests.codes.ok,
       'data': ''
     }

--- a/ycmd/tests/java/testdata/simple_gradle_project/src/main/java/com/test/TestWidgetImpl.java
+++ b/ycmd/tests/java/testdata/simple_gradle_project/src/main/java/com/test/TestWidgetImpl.java
@@ -3,7 +3,7 @@ package com.test;
 /**
  * This is the actual code that matters.
  *
- * This concrete implentation is the equivalent of the main function in other
+ * This concrete implementation is the equivalent of the main function in other
  * languages
  */
 

--- a/ycmd/tests/java/testdata/simple_gradle_project/src/test/java/com/test/AppTest.java
+++ b/ycmd/tests/java/testdata/simple_gradle_project/src/test/java/com/test/AppTest.java
@@ -29,7 +29,7 @@ public class AppTest
     }
 
     /**
-     * Rigourous Test :-)
+     * Rigorous Test :-)
      */
     public void testApp()
     {

--- a/ycmd/tests/java/testdata/simple_maven_project/src/main/java/com/test/TestWidgetImpl.java
+++ b/ycmd/tests/java/testdata/simple_maven_project/src/main/java/com/test/TestWidgetImpl.java
@@ -3,7 +3,7 @@ package com.test;
 /**
  * This is the actual code that matters.
  *
- * This concrete implentation is the equivalent of the main function in other
+ * This concrete implementation is the equivalent of the main function in other
  * languages
  */
 

--- a/ycmd/tests/java/testdata/simple_maven_project/src/test/java/com/test/AppTest.java
+++ b/ycmd/tests/java/testdata/simple_maven_project/src/test/java/com/test/AppTest.java
@@ -29,7 +29,7 @@ public class AppTest
     }
 
     /**
-     * Rigourous Test :-)
+     * Rigorous Test :-)
      */
     public void testApp()
     {

--- a/ycmd/tests/tern/get_completions_test.py
+++ b/ycmd/tests/tern/get_completions_test.py
@@ -378,7 +378,7 @@ def GetCompletions_IncludeMultiFileType_test( app ):
   assert_that( response,
     has_entries( {
       'completion_start_column': 3,
-      # Note: This time, we *do* see the completions, becuase one of the 2
+      # Note: This time, we *do* see the completions, because one of the 2
       # filetypes for trivial.js is javascript.
       'completions': contains_inanyorder(
           CompletionEntryMatcher( 'y', 'string' ),

--- a/ycmd/tests/typescript/testdata/signatures.ts
+++ b/ycmd/tests/typescript/testdata/signatures.ts
@@ -1,4 +1,4 @@
-// SIMPLE FUNCITONS
+// SIMPLE FUNCTIONS
 
 function no_arguments_no_return() {
 }

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -157,7 +157,7 @@ def ByteOffsetToCodepointOffset( line_value, byte_offset ):
   """The API calls for byte offsets into the UTF-8 encoded version of the
   buffer. However, ycmd internally uses unicode strings. This means that
   when we need to walk 'characters' within the buffer, such as when checking
-  for semantic triggers and similar, we must use codepoint offets, rather than
+  for semantic triggers and similar, we must use codepoint offsets, rather than
   byte offsets.
 
   This method converts the |byte_offset|, which is a utf-8 byte offset, into
@@ -171,7 +171,7 @@ def CodepointOffsetToByteOffset( unicode_line_value, codepoint_offset ):
   """The API calls for byte offsets into the UTF-8 encoded version of the
   buffer. However, ycmd internally uses unicode strings. This means that
   when we need to walk 'characters' within the buffer, such as when checking
-  for semantic triggers and similar, we must use codepoint offets, rather than
+  for semantic triggers and similar, we must use codepoint offsets, rather than
   byte offsets.
 
   This method converts the |codepoint_offset| which is a unicode codepoint
@@ -528,8 +528,8 @@ def GetClangResourceDir():
 CLANG_RESOURCE_DIR = GetClangResourceDir()
 
 
-def AbsoluatePath( path, relative_to ):
-  """Returns a normalised, absoluate path to |path|. If |path| is relative, it
+def AbsolutePath( path, relative_to ):
+  """Returns a normalised, absolute path to |path|. If |path| is relative, it
   is resolved relative to |relative_to|."""
   if not os.path.isabs( path ):
     path = os.path.join( relative_to, path )


### PR DESCRIPTION
Hi,

a bunch of typo fixes mostly found by `codespell` after I stumbled manually over some. The first commit bundles most of them in documentation and code comments, so they shouldn't have an impact.

The second changes a function name, so technically an internal API break.

The third is still documentation, but it looks like a json scheme which might or might not be used to verify instances which would need to be fixed as well (or are finally valid now).

Note that while these change `docs/openapi.yml` I have not regenerated the html files as the README advises as I have no working `npm` setup and don't particular fancy one for this right now.

(You may squash, edit & discard to your hearts content – I do not claim copyright ownership for typo fixes.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1429)
<!-- Reviewable:end -->
