### PR TITLE
[READY] Use `os.path.abspath` in ycmd.responses.Location

### DIFF
--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -228,7 +228,7 @@ class Location:
     self.line_number_ = line
     self.column_number_ = column
     if filename:
-      self.filename_ = os.path.realpath( filename )
+      self.filename_ = os.path.abspath( filename )
     else:
       # When the filename passed (e.g. by a server) can't be recognized or
       # parsed, we send an empty filename. This at least allows the client to


### PR DESCRIPTION
This addresses the ycmd side of https://github.com/ycm-core/YouCompleteMe/issues/3662

My concern is whether or not this is a subtle API break. Is it possible that some other ycmd client, at this point, depends on `Location` holding the "real" path?

Note that we're changing [`realpath`](https://docs.python.org/3/library/os.path.html#os.path.normpath) to [`abspath`](https://docs.python.org/3/library/os.path.html#os.path.abspath). Neither of those are [`normpath`](https://docs.python.org/3/library/os.path.html#os.path.normpath).

I'm not sure if `os.path.realpath()` is supposed to behave like ycm-core/YouCompleteMe#3662 describes, even on Winblows.

@puremourning Please test the complete solution, outlined in the bug report.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1430)
<!-- Reviewable:end -->
