### PR TITLE
[READY] Don't return whitespace-only lines in GetDoc

### DIFF
--- a/ycmd/completers/python/python_completer.py
+++ b/ycmd/completers/python/python_completer.py
@@ -392,8 +392,9 @@ class PythonCompleter( Completer ):
       # codepoint offsets.
       column = request_data[ 'start_codepoint' ] - 1
       definitions = self._GetJediScript( request_data ).goto( line, column )
-      documentation = [ definition.docstring() for definition in definitions ]
-    documentation = '\n---\n'.join( documentation )
+      documentation = [
+        definition.docstring().strip() for definition in definitions ]
+    documentation = '\n---\n'.join( [ d for d in documentation if d ] )
     if documentation:
       return responses.BuildDetailedInfoResponse( documentation )
     raise RuntimeError( 'No documentation available.' )

--- a/ycmd/tests/python/subcommands_test.py
+++ b/ycmd/tests/python/subcommands_test.py
@@ -233,6 +233,27 @@ def Subcommands_GetDoc_Class_test( app ):
 
 
 @SharedYcmd
+def Subcommands_GetDoc_WhitespaceOnly_test( app ):
+  filepath = PathToTestFile( 'GetDoc.py' )
+  contents = ReadFile( filepath )
+
+  command_data = BuildRequest( filepath = filepath,
+                               filetype = 'python',
+                               line_num = 27,
+                               column_num = 10,
+                               contents = contents,
+                               command_arguments = [ 'GetDoc' ] )
+
+  response = app.post_json( '/run_completer_command',
+                            command_data,
+                            expect_errors = True ).json
+
+  assert_that( response,
+               ErrorMatcher( RuntimeError, 'No documentation available.' ) )
+
+
+
+@SharedYcmd
 def Subcommands_GetDoc_NoDocumentation_test( app ):
   filepath = PathToTestFile( 'GetDoc.py' )
   contents = ReadFile( filepath )

--- a/ycmd/tests/python/testdata/GetDoc.py
+++ b/ycmd/tests/python/testdata/GetDoc.py
@@ -18,3 +18,10 @@ _ModuleMethod()
 
 tc = TestClass()
 tc.TestMethod()
+
+class BoringClass:
+  def __init__( self ):
+    self._buffers = None
+
+  def BoringMethod( self ):
+    self._buffers = []


### PR DESCRIPTION
This was causing GetDoc to look like strange "---" to be printed for
without any actual documentation. This was way worse/more noticable with
auto-hover.

It seems that Jedi can return whitespace entries in the list, so we just
strip them and ignore any empty lines.

Example: ![example](https://files.gitter.im/Valloric/ycmd/FvBl/Screenshot-2020-04-30-at-20.14.08.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1431)
<!-- Reviewable:end -->
