### PR TITLE
Fix python GOTO from nested modules

### DIFF
--- a/ycmd/completers/python/python_completer.py
+++ b/ycmd/completers/python/python_completer.py
@@ -137,13 +137,13 @@ class PythonCompleter( Completer ):
       if hasattr( module, 'PythonSysPath' ):
         settings[ 'sys_path' ] = module.PythonSysPath( **settings )
       LOGGER.debug( 'No PythonSysPath function defined in %s', module.__file__ )
-    if not settings.get( 'project_directory' ):
-      module = extra_conf_store.ModuleForSourceFile( filepath )
-      if module:
-        settings[ 'project_directory' ] = os.path.dirname( module.__file__ )
-      else:
-        settings[ 'project_directory' ] = os.path.dirname( filepath )
-    return jedi.Project( settings[ 'project_directory' ],
+
+    project_directory = settings.get( 'project_directory' )
+    if not project_directory:
+      default_project = jedi.get_default_project(
+        os.path.dirname( request_data[ 'filepath' ] ) )
+      project_directory = default_project._path
+    return jedi.Project( project_directory,
                          sys_path = settings[ 'sys_path' ],
                          environment_path = settings[ 'interpreter_path' ] )
 

--- a/ycmd/tests/python/subcommands_test.py
+++ b/ycmd/tests/python/subcommands_test.py
@@ -136,13 +136,13 @@ def Subcommands_GoTo( app, test, command ):
     { 'request':  ( 'multifile1.py', 6, 14 ),
       'response': ( 'multifile1.py', 2, 36 ) },
     # Absolute import from nested module
-    { 'request':  ( 'nested_import/importer.py', 1, 19 ),
+    { 'request':  ( os.path.join( 'nested_import', 'importer.py' ), 1, 19 ),
       'response': ( 'basic.py', 4, 7 ) },
-    { 'request':  ( 'nested_import/importer.py', 2, 40 ),
-      'response': ( 'nested_import/to_import.py', 1, 5 ) },
+    { 'request':  ( os.path.join( 'nested_import', 'importer.py' ), 2, 40 ),
+      'response': ( os.path.join( 'nested_import', 'to_import.py' ), 1, 5 ) },
     # Relative within nested module
-    { 'request':  ( 'nested_import/importer.py', 3, 28 ),
-      'response': ( 'nested_import/to_import.py', 4, 5 ) },
+    { 'request':  ( os.path.join( 'nested_import', 'importer.py' ), 3, 28 ),
+      'response': ( os.path.join( 'nested_import', 'to_import.py' ), 4, 5 ) },
   ] )
 @SharedYcmd
 def Subcommands_GoTo_test( app, cmd, test ):

--- a/ycmd/tests/python/subcommands_test.py
+++ b/ycmd/tests/python/subcommands_test.py
@@ -135,6 +135,14 @@ def Subcommands_GoTo( app, test, command ):
       'response': ( 'multifile2.py', 1, 51 ) },
     { 'request':  ( 'multifile1.py', 6, 14 ),
       'response': ( 'multifile1.py', 2, 36 ) },
+    # Absolute import from nested module
+    { 'request':  ( 'nested_import/importer.py', 1, 19 ),
+      'response': ( 'basic.py', 4, 7 ) },
+    { 'request':  ( 'nested_import/importer.py', 2, 40 ),
+      'response': ( 'nested_import/to_import.py', 1, 5 ) },
+    # Relative within nested module
+    { 'request':  ( 'nested_import/importer.py', 3, 28 ),
+      'response': ( 'nested_import/to_import.py', 4, 5 ) },
   ] )
 @SharedYcmd
 def Subcommands_GoTo_test( app, cmd, test ):

--- a/ycmd/tests/python/testdata/goto/nested_import/importer.py
+++ b/ycmd/tests/python/testdata/goto/nested_import/importer.py
@@ -1,0 +1,3 @@
+from basic import MyClass
+from nested_import.to_import import import_me
+from .to_import import relative

--- a/ycmd/tests/python/testdata/goto/nested_import/to_import.py
+++ b/ycmd/tests/python/testdata/goto/nested_import/to_import.py
@@ -1,0 +1,5 @@
+def import_me():
+    pass
+
+def relative():
+    pass

--- a/ycmd/tests/python/testdata/goto/requirements.txt
+++ b/ycmd/tests/python/testdata/goto/requirements.txt
@@ -1,0 +1,1 @@
+# required so jedi understands this is the project root for absolute imports


### PR DESCRIPTION
Fixes https://github.com/ycm-core/ycmd/issues/1432

I've left it to `jedi` to work out where the project directory is using [get_default_project](https://github.com/davidhalter/jedi/blob/d16355fcf25db57dd0e6e4566ce1312274792f3e/jedi/api/project.py#L365). This relies on the presence of certain files or directories to correctly identify the project root, so it's not foolproof but should work for the majority of cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1437)
<!-- Reviewable:end -->
