### PR TITLE
Add the __syncthreads() intrinsic to __clang_cuda_device_functions.h

### DIFF
--- a/third_party/clang/lib/clang/10.0.0/include/__clang_cuda_device_functions.h
+++ b/third_party/clang/lib/clang/10.0.0/include/__clang_cuda_device_functions.h
@@ -539,6 +539,7 @@ __DEVICE__ void __sincosf(float __a, float *__s, float *__c) {
   return __nv_fast_sincosf(__a, __s, __c);
 }
 __DEVICE__ float __sinf(float __a) { return __nv_fast_sinf(__a); }
+__DEVICE__ int __syncthreads(void) { return __nvvm_bar0(); }  
 __DEVICE__ int __syncthreads_and(int __a) { return __nvvm_bar0_and(__a); }
 __DEVICE__ int __syncthreads_count(int __a) { return __nvvm_bar0_popc(__a); }
 __DEVICE__ int __syncthreads_or(int __a) { return __nvvm_bar0_or(__a); }


### PR DESCRIPTION
YCM currently does not recognize the `__syncthreads()` intrinsic that is used by CUDA. It seems like a small oversight since the `__syncthreads_{and|count|or}()` intrinsics are recognized by YCM.

With this PR, YCM will no longer complain about `__syncthreads()` in CUDA code with `__syncthreads() undeclared identifier`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1438)
<!-- Reviewable:end -->
