### PR TITLE
[WIP] Include the description in the doc string for typescript auto-import

### DIFF
--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -279,6 +279,9 @@ def BuildFixItResponse( fixits ):
   can be used to apply arbitrary changes to arbitrary files and is suitable for
   both quick fix and refactor operations"""
 
+  if not fixits:
+    return {}
+
   def BuildFixitChunkData( chunk ):
     return {
       'replacement_text': chunk.replacement_text,


### PR DESCRIPTION
This is just an example for discussion.

A user on Gitter requested this feature and I hacked a prototype.


![](https://files.gitter.im/Valloric/YouCompleteMe/iijT/Screenshot-2020-05-26-at-22.09.13.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1441)
<!-- Reviewable:end -->
