### PR TITLE
[READY] Allow "empty" responses after an `executeCommand` request

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -2379,7 +2379,13 @@ class LanguageServerCompleter( Completer ):
 
     # Return a ycmd fixit
     response = collector.requests
-    assert len( response ) == 1
+    assert len( response ) < 2
+    if not response:
+      return responses.BuildFixItResponse( [ responses.FixIt(
+        responses.Location( request_data[ 'line_num' ],
+                            request_data[ 'column_num' ],
+                            request_data[ 'filepath' ] ),
+        [] ) ] )
     fixit = WorkspaceEditToFixIt(
       request_data,
       response[ 0 ][ 'edit' ],


### PR DESCRIPTION
Resolving code actions is annoying.

1. ycmd sends `textDocument/codeAction` request
2. A LSP server responds with at least one code action that requires an
   `executeCommand` request to be resolved.
3. After sending an `executeCommand` request, the server is supposed to
   send N server-to-client requests to "explain" the code action.
4. The server finally responds to the `executeCommand` request.

We assume that, in step 3, the server would send a single `applyEdit`
request. This turned out to be a false assumption in some cases.

Specifically, it's possible that a server sends a `window/showMessage`
notification and then respond to `executeCommand`. (Looking at you, clangd!)
This pull request takes into account this possibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1446)
<!-- Reviewable:end -->
