### PR TITLE
[READY] Drop python 3.5 support

### DIFF
--- a/build.py
+++ b/build.py
@@ -21,8 +21,8 @@ import tempfile
 IS_64BIT = sys.maxsize > 2**32
 PY_MAJOR, PY_MINOR = sys.version_info[ 0 : 2 ]
 PY_VERSION = sys.version_info[ 0 : 3 ]
-if PY_VERSION < ( 3, 5, 1 ):
-  sys.exit( 'ycmd requires Python >= 3.5.1; '
+if PY_VERSION < ( 3, 6, 0 ):
+  sys.exit( 'ycmd requires Python >= 3.6.0; '
             'your version of Python is ' + sys.version +
             '\nHint: Try running python3 ' + ' '.join( sys.argv ) )
 
@@ -62,7 +62,7 @@ NO_PYTHON_HEADERS_ERROR = 'ERROR: Python headers are missing in {include_dir}.'
 # Regular expressions used to find static and dynamic Python libraries.
 # Notes:
 #  - Python 3 library name may have an 'm' suffix on Unix platforms, for
-#    instance libpython3.5m.so;
+#    instance libpython3.6m.so;
 #  - the linker name (the soname without the version) does not always
 #    exist so we look for the versioned names too;
 #  - on Windows, the .lib extension is used instead of the .dll one. See

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # ycmd example client
 
-The example client **requires** Python 3.5+.
+The example client **requires** Python 3.6+.
 
 First make sure you have built ycmd; see the top-level README for details.
 

--- a/examples/example_client.py
+++ b/examples/example_client.py
@@ -17,7 +17,7 @@
 import sys
 import platform
 if sys.version_info[ 0 ] < 3:
-  sys.exit( 'example_client.py requires Python 3.5+; detected Python ' +
+  sys.exit( 'example_client.py requires Python 3.6+; detected Python ' +
             platform.python_version() )
 
 from base64 import b64encode, b64decode
@@ -85,10 +85,9 @@ class YcmdHandle( object ):
     server_port = GetUnusedLocalhostPort()
     ycmd_args = [ sys.executable,
                   PATH_TO_YCMD,
-                  '--port={0}'.format( server_port ),
-                  '--options_file={0}'.format( options_file.name ),
-                  '--idle_suicide_seconds={0}'.format(
-                    SERVER_IDLE_SUICIDE_SECONDS ) ]
+                  f'--port={server_port}',
+                  f'--options_file={options_file.name}',
+                  f'--idle_suicide_seconds={SERVER_IDLE_SUICIDE_SECONDS}' ]
 
     std_handles = None if INCLUDE_YCMD_OUTPUT else subprocess.PIPE
     child_handle = subprocess.Popen( ycmd_args,
@@ -207,8 +206,8 @@ class YcmdHandle( object ):
       try:
         if total_slept > MAX_SERVER_WAIT_TIME_SECONDS:
           raise RuntimeError(
-              'waited for the server for {0} seconds, aborting'.format(
-                    MAX_SERVER_WAIT_TIME_SECONDS ) )
+            'waited for the server for '
+            f'{MAX_SERVER_WAIT_TIME_SECONDS} seconds, aborting' )
 
         if self.IsReady( filetype ):
           return

--- a/update_unicode.py
+++ b/update_unicode.py
@@ -572,7 +572,7 @@ def GenerateNormalizationTestCases( output_file ):
   test_contents = Download(
       'https://unicode.org/Public/UCD/latest/ucd/NormalizationTest.txt' )
   hex_codepoint = '(?:[A-F0-9]{4,} ?)+'
-  pattern = f'(?:{hex_codepoint};){{5}}'
+  pattern = f'(?:{ hex_codepoint };){{5}}'
   pattern = re.compile( pattern )
 
   res = []

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -624,7 +624,7 @@ def _MakeRelativePathsInFlagsAbsolute( flags, working_directory ):
         if flag.startswith( path_flag ):
           path = flag[ len( path_flag ): ]
           path = AbsolutePath( path, working_directory )
-          new_flag = '{0}{1}'.format( path_flag, path )
+          new_flag = f'{ path_flag }{ path }'
           break
 
     if new_flag:

--- a/ycmd/completers/cs/solutiondetection.py
+++ b/ycmd/completers/cs/solutiondetection.py
@@ -92,15 +92,15 @@ def _SolutionTestCheckHeuristics( candidates, tokens, i ):
   # there is more than one file, try some hints to decide
   # 1. is there a solution named just like the subdirectory with the source?
   if ( not selection and i < len( tokens ) - 1 and
-       '{0}.sln'.format( tokens[ i + 1 ] ) in candidates ):
-    selection = os.path.join( path, '{0}.sln'.format( tokens[ i + 1 ] ) )
+       f'{ tokens[ i + 1 ] }.sln' in candidates ):
+    selection = os.path.join( path, f'{ tokens[ i + 1] }.sln' )
     LOGGER.info( 'Selected solution file %s as it matches source subfolder',
                  selection )
 
   # 2. is there a solution named just like the directory containing the
   # solution?
-  if not selection and '{0}.sln'.format( tokens[ i ] ) in candidates :
-    selection = os.path.join( path, '{0}.sln'.format( tokens[ i ] ) )
+  if not selection and f'{ tokens[ i ] }.sln' in candidates :
+    selection = os.path.join( path, f'{ tokens[ i ] }.sln' )
     LOGGER.info( 'Selected solution file %s as it matches containing folder',
                  selection )
 

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -142,8 +142,7 @@ def _CollectExtensionBundles( extension_path ):
 
   for extension_dir in extension_path:
     if not os.path.isdir( extension_dir ):
-      LOGGER.info( 'extension directory does not exist: {0}'.format(
-        extension_dir ) )
+      LOGGER.info( f'extension directory does not exist: { extension_dir }' )
       continue
 
     for path in os.listdir( extension_dir ):
@@ -151,25 +150,24 @@ def _CollectExtensionBundles( extension_path ):
       manifest_file = os.path.join( path, 'package.json' )
 
       if not os.path.isdir( path ) or not os.path.isfile( manifest_file ):
-        LOGGER.debug( '{0} is not an extension directory'.format( path ) )
+        LOGGER.debug( f'{ path } is not an extension directory' )
         continue
 
       manifest_json = utils.ReadFile( manifest_file )
       try:
         manifest = json.loads( manifest_json )
       except ValueError:
-        LOGGER.exception( 'Could not load bundle {0}'.format( manifest_file ) )
+        LOGGER.exception( f'Could not load bundle { manifest_file }' )
         continue
 
       if ( 'contributes' not in manifest or
            'javaExtensions' not in manifest[ 'contributes' ] or
            not isinstance( manifest[ 'contributes' ][ 'javaExtensions' ],
                            list ) ):
-        LOGGER.info( 'Bundle {0} is not a java extension'.format(
-          manifest_file ) )
+        LOGGER.info( f'Bundle { manifest_file } is not a java extension' )
         continue
 
-      LOGGER.info( 'Found bundle: {0}'.format( manifest_file ) )
+      LOGGER.info( f'Found bundle: { manifest_file }' )
 
       extension_bundles.extend( [
         os.path.join( path, p )
@@ -293,8 +291,7 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
       self._workspace_root_path = DEFAULT_WORKSPACE_ROOT_PATH
 
     if not isinstance( self._extension_path, list ):
-      raise ValueError( '{0} option must be a list'.format(
-        EXTENSION_PATH_OPTION ) )
+      raise ValueError( f'{ EXTENSION_PATH_OPTION } option must be a list' )
 
     if not self._extension_path:
       self._extension_path = [ DEFAULT_EXTENSION_PATH ]
@@ -452,8 +449,7 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
 
         if not self._use_clean_workspace and wipe_workspace:
           if os.path.isdir( self._workspace_path ):
-            LOGGER.info( 'Wiping out workspace {0}'.format(
-              self._workspace_path ) )
+            LOGGER.info( f'Wiping out workspace { self._workspace_path }' )
             shutil.rmtree( self._workspace_path )
 
         self._launcher_config = _LauncherConfiguration(
@@ -519,11 +515,11 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
       if notification[ 'params' ][ 'type' ] == 'Started':
         self._started_message_sent = True
         return responses.BuildDisplayMessageResponse(
-          'Initializing Java completer: {}'.format( message ) )
+          f'Initializing Java completer: { message }' )
 
       if not self._started_message_sent:
         return responses.BuildDisplayMessageResponse(
-          'Initializing Java completer: {}'.format( message ) )
+          f'Initializing Java completer: { message }' )
 
     return super().ConvertNotificationToMessage( request_data, notification )
 

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -206,9 +206,11 @@ class Response:
 
     if 'error' in self._message:
       error = self._message[ 'error' ]
-      raise ResponseFailedException( 'Request failed: {0}: {1}'.format(
-        error.get( 'code' ) or 0,
-        error.get( 'message' ) or 'No message' ) )
+      raise ResponseFailedException(
+        'Request failed: '
+        f'{ error.get( "code" ) or 0 }'
+         ': '
+        f'{ error.get( "message" ) or "No message" }' )
 
     return self._message
 
@@ -909,8 +911,8 @@ class LanguageServerCompleter( Completer ):
                  self.GetServerName(),
                  self.GetCommandLine() )
 
-    self._stderr_file = utils.CreateLogfile( '{}_stderr'.format(
-      utils.MakeSafeFileNameString( self.GetServerName() ) ) )
+    self._stderr_file = utils.CreateLogfile(
+      f'{ utils.MakeSafeFileNameString( self.GetServerName() ) }_stderr' )
 
     with utils.OpenForStdHandle( self._stderr_file ) as stderr:
       self._server_handle = utils.SafePopen(
@@ -2715,8 +2717,7 @@ def _GetCompletionItemStartCodepointOrReject( text_edit, request_data ):
   # Conservatively rejecting candidates that breach the protocol
   if edit_range[ 'start' ][ 'line' ] != edit_range[ 'end' ][ 'line' ]:
     raise IncompatibleCompletionException(
-      "The TextEdit '{0}' spans multiple lines".format(
-        text_edit[ 'newText' ] ) )
+      f"""The TextEdit '{ text_edit[ "newText" ] }' spans multiple lines""" )
 
   file_contents = GetFileLines( request_data, request_data[ 'filepath' ] )
   line_value = file_contents[ edit_range[ 'start' ][ 'line' ] ]
@@ -2727,8 +2728,8 @@ def _GetCompletionItemStartCodepointOrReject( text_edit, request_data ):
 
   if start_codepoint > request_data[ 'start_codepoint' ]:
     raise IncompatibleCompletionException(
-      "The TextEdit '{0}' starts after the start position".format(
-        text_edit[ 'newText' ] ) )
+      f"""The TextEdit '{ text_edit[ "newText" ] }'"""
+       """starts after the start position""" )
 
   return start_codepoint
 

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -209,7 +209,7 @@ class Response:
       raise ResponseFailedException(
         'Request failed: '
         f'{ error.get( "code" ) or 0 }'
-         ': '
+        ': '
         f'{ error.get( "message" ) or "No message" }' )
 
     return self._message
@@ -2716,8 +2716,9 @@ def _GetCompletionItemStartCodepointOrReject( text_edit, request_data ):
 
   # Conservatively rejecting candidates that breach the protocol
   if edit_range[ 'start' ][ 'line' ] != edit_range[ 'end' ][ 'line' ]:
+    new_text = text_edit[ 'newText' ]
     raise IncompatibleCompletionException(
-      f"""The TextEdit '{ text_edit[ "newText" ] }' spans multiple lines""" )
+      f"The TextEdit '{ new_text }' spans multiple lines" )
 
   file_contents = GetFileLines( request_data, request_data[ 'filepath' ] )
   line_value = file_contents[ edit_range[ 'start' ][ 'line' ] ]
@@ -2727,9 +2728,9 @@ def _GetCompletionItemStartCodepointOrReject( text_edit, request_data ):
     edit_range[ 'start' ][ 'character' ] + 1 )
 
   if start_codepoint > request_data[ 'start_codepoint' ]:
+    new_text = text_edit[ 'newText' ]
     raise IncompatibleCompletionException(
-      f"""The TextEdit '{ text_edit[ "newText" ] }'"""
-       """starts after the start position""" )
+      f"The TextEdit '{ new_text }' starts after the start position" )
 
   return start_codepoint
 

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -637,8 +637,7 @@ def _BuildMessageData( message ):
   data = ToBytes( json.dumps( message,
                               separators = ( ',', ':' ),
                               sort_keys=True ) )
-  packet = ToBytes( 'Content-Length: {0}\r\n'
-                    '\r\n'.format( len( data ) ) ) + data
+  packet = ToBytes( f'Content-Length: { len( data ) }\r\n\r\n' ) + data
   return packet
 
 

--- a/ycmd/completers/python/python_completer.py
+++ b/ycmd/completers/python/python_completer.py
@@ -93,8 +93,8 @@ class PythonCompleter( Completer ):
       resolved_interpreter_path = FindExecutable(
         ExpandVariablesInPath( interpreter_path ) )
       if not resolved_interpreter_path:
-        raise RuntimeError( 'Cannot find Python interpreter path {}.'.format(
-          interpreter_path ) )
+        raise RuntimeError( 'Cannot find Python interpreter path '
+                            f'{ interpreter_path }.' )
       interpreter_path = os.path.normpath( resolved_interpreter_path )
 
     try:

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -150,7 +150,7 @@ class RustCompleter( language_server_completer.LanguageServerCompleter ):
       message = notification[ 'params' ]
       if message != 'invalid': # RA produces a better message for `invalid`
         return responses.BuildDisplayMessageResponse(
-          'Initializing Rust completer: {}'.format( message ) )
+          f'Initializing Rust completer: { message }' )
     return super().ConvertNotificationToMessage( request_data, notification )
 
 

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -197,8 +197,7 @@ class TypeScriptCompleter( Completer ):
       return
 
     self._logfile = utils.CreateLogfile( LOGFILE_FORMAT )
-    tsserver_log = '-file {path} -level {level}'.format( path = self._logfile,
-                                                         level = _LogLevel() )
+    tsserver_log = f'-file { self._logfile } -level {_LogLevel()}'
     # TSServer gets the configuration for the log file through the
     # environment variable 'TSS_LOG'. This seems to be undocumented but
     # looking at the source code it seems like this is the way:
@@ -794,8 +793,7 @@ class TypeScriptCompleter( Completer ):
       'offset': request_data[ 'column_codepoint' ]
     } )
 
-    message = '{0}\n\n{1}'.format( info[ 'displayString' ],
-                                   info[ 'documentation' ] )
+    message = f'{ info[ "displayString" ] }\n\n{info[ "documentation" ]}'
     return responses.BuildDetailedInfoResponse( message )
 
 
@@ -854,8 +852,8 @@ class TypeScriptCompleter( Completer ):
     } )
 
     if not response[ 'info' ][ 'canRename' ]:
-      raise RuntimeError( 'Value cannot be renamed: {0}'.format(
-        response[ 'info' ][ 'localizedErrorMessage' ] ) )
+      raise RuntimeError( 'Value cannot be renamed: '
+                          f'{ response[ "info" ][ "localizedErrorMessage" ] }' )
 
     # The format of the response is:
     #

--- a/ycmd/request_validation.py
+++ b/ycmd/request_validation.py
@@ -38,11 +38,12 @@ def _FieldMissingMessage( field ):
 
 
 def _FilepathInFileDataSpec( request_json ):
-  return f'''file_data[ "{ request_json[ 'filepath' ] }" ]'''
+  filepath = request_json[ 'filepath' ]
+  return f'file_data[ "{ filepath }" ]'
 
 
 def _SingleFileDataFieldSpec( request_json, field ):
-  return f'''{ _FilepathInFileDataSpec( request_json ) }[ "{field}" ]'''
+  return f'{ _FilepathInFileDataSpec( request_json ) }[ "{ field }" ]'
 
 
 def _MissingFieldsForFileData( request_json ):

--- a/ycmd/request_validation.py
+++ b/ycmd/request_validation.py
@@ -34,15 +34,15 @@ def EnsureRequestValid( request_json ):
 
 
 def _FieldMissingMessage( field ):
-  return 'Request missing required field: {0}'.format( field )
+  return f'Request missing required field: { field }'
 
 
 def _FilepathInFileDataSpec( request_json ):
-  return 'file_data["{0}"]'.format( request_json[ 'filepath' ] )
+  return f'''file_data[ "{ request_json[ 'filepath' ] }" ]'''
 
 
 def _SingleFileDataFieldSpec( request_json, field ):
-  return '{0}["{1}"]'.format( _FilepathInFileDataSpec( request_json ), field )
+  return f'''{ _FilepathInFileDataSpec( request_json ) }[ "{field}" ]'''
 
 
 def _MissingFieldsForFileData( request_json ):
@@ -55,8 +55,8 @@ def _MissingFieldsForFileData( request_json ):
         missing.add( _SingleFileDataFieldSpec( request_json, required ) )
     filetypes = data_for_file.get( 'filetypes', [] )
     if not filetypes:
-      missing.add( '{0}[0]'.format(
-          _SingleFileDataFieldSpec( request_json, 'filetypes' ) ) )
+      missing.add(
+        f'{ _SingleFileDataFieldSpec( request_json, "filetypes" ) }[ 0 ]' )
   else:
     missing.add( _FilepathInFileDataSpec( request_json ) )
   return missing

--- a/ycmd/request_wrap.py
+++ b/ycmd/request_wrap.py
@@ -105,7 +105,7 @@ class RequestWrap:
         setter( value )
         return
 
-    raise ValueError( 'Key "{0}" is read-only'.format( key ) )
+    raise ValueError( f'Key "{ key }" is read-only' )
 
 
   def __contains__( self, key ):

--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -24,9 +24,9 @@ YCM_EXTRA_CONF_FILENAME = '.ycm_extra_conf.py'
 CONFIRM_CONF_FILE_MESSAGE = ( 'Found {0}. Load? \n\n(Question can be turned '
                               'off with options, see YCM docs)' )
 
-NO_EXTRA_CONF_FILENAME_MESSAGE = ( 'No {0} file detected, so no compile flags '
-  'are available. Thus no semantic support for C/C++/ObjC/ObjC++. Go READ THE '
-  'DOCS *NOW*, DON\'T file a bug report.' ).format( YCM_EXTRA_CONF_FILENAME )
+NO_EXTRA_CONF_FILENAME_MESSAGE = ( f'No { YCM_EXTRA_CONF_FILENAME } file '
+  'detected, so no compile flags are available. Thus no semantic support for '
+  'C/C++/ObjC/ObjC++. Go READ THE ' 'DOCS *NOW*, DON\'T file a bug report.' )
 
 NO_DIAGNOSTIC_SUPPORT_MESSAGE = ( 'YCM has no diagnostics support for this '
   'filetype; refer to Syntastic docs if using Syntastic.' )

--- a/ycmd/server_state.py
+++ b/ycmd/server_state.py
@@ -62,7 +62,7 @@ class ServerState:
         pass
 
       try:
-        module = import_module( 'ycmd.completers.{}.hook'.format( filetype ) )
+        module = import_module( f'ycmd.completers.{ filetype }.hook' )
         completer = module.GetCompleter( self._user_options )
       except ImportError:
         completer = None
@@ -88,8 +88,8 @@ class ServerState:
       if completer:
         return completer
 
-    raise ValueError( 'No semantic completer exists for filetypes: {0}'.format(
-        current_filetypes ) )
+    raise ValueError(
+      f'No semantic completer exists for filetypes: { current_filetypes }' )
 
 
   def GetLoadedFiletypeCompleters( self ):

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -1271,7 +1271,7 @@ def CompilationDatabase_CUDALanguageFlags_test():
     compile_commands = [
       {
         'directory': tmp_dir,
-        'command': 'clang++ -Wall {}'.format( './test.cu' ),
+        'command': 'clang++ -Wall ./test.cu',
         'file': os.path.join( tmp_dir, 'test.cu' ),
       },
     ]

--- a/ycmd/tests/clang/get_completions_test.py
+++ b/ycmd/tests/clang/get_completions_test.py
@@ -106,8 +106,7 @@ def RunTest( app, test ):
   assert_that( response.status_code,
                equal_to( test[ 'expect' ][ 'response' ] ) )
 
-  print( 'Completer response: {0}'.format( json.dumps(
-    response.json, indent = 2 ) ) )
+  print( f'Completer response: { json.dumps( response.json, indent = 2 ) }' )
 
   assert_that( response.json, test[ 'expect' ][ 'data' ] )
 

--- a/ycmd/tests/clangd/__init__.py
+++ b/ycmd/tests/clangd/__init__.py
@@ -74,8 +74,7 @@ def RunAfterInitialized( app, test ):
                               expect_errors = expect_errors )
 
   if 'expect' in test:
-    print( "Completer response: {}".format( json.dumps( response.json,
-                                                        indent = 2 ) ) )
+    print( f'Completer response: { json.dumps( response.json, indent = 2 ) }' )
     assert_that( response.status_code,
                  equal_to( test[ 'expect' ][ 'response' ] ) )
     assert_that( response.json, test[ 'expect' ][ 'data' ] )

--- a/ycmd/tests/clangd/diagnostics_test.py
+++ b/ycmd/tests/clangd/diagnostics_test.py
@@ -534,7 +534,7 @@ struct S{static int h();};
 
     # Assert no diagnostics
     for message in PollForMessages( app, messages_request ):
-      print( 'Message {}'.format( pformat( message ) ) )
+      print( f'Message { pformat( message ) }' )
       if 'diagnostics' in message:
         assert_that( message,
           has_entries( { 'diagnostics': empty() } ) )

--- a/ycmd/tests/clangd/get_completions_test.py
+++ b/ycmd/tests/clangd/get_completions_test.py
@@ -83,8 +83,8 @@ def RunTest( app, test ):
       assert_that( response.status_code,
                    equal_to( test[ 'expect' ][ 'response' ] ) )
 
-      print( 'Completer response: {}'.format( json.dumps(
-        response.json, indent = 2 ) ) )
+      print( 'Completer response: '
+             f'{ json.dumps( response.json, indent = 2 ) }' )
 
       assert_that( response.json, test[ 'expect' ][ 'data' ] )
       break

--- a/ycmd/tests/clangd/signature_help_test.py
+++ b/ycmd/tests/clangd/signature_help_test.py
@@ -76,8 +76,7 @@ def RunTest( app, test ):
   assert_that( response.status_code,
                equal_to( test[ 'expect' ][ 'response' ] ) )
 
-  print( 'Completer response: {}'.format( json.dumps(
-    response.json, indent = 2 ) ) )
+  print( f'Completer response: { json.dumps( response.json, indent = 2 ) }' )
 
   assert_that( response.json, test[ 'expect' ][ 'data' ] )
 

--- a/ycmd/tests/client_test.py
+++ b/ycmd/tests/client_test.py
@@ -84,11 +84,11 @@ class Client_test:
     ycmd_args = [
       sys.executable,
       PATH_TO_YCMD,
-      '--port={0}'.format( self._port ),
-      '--options_file={0}'.format( options_file.name ),
+      f'--port={ self._port }',
+      f'--options_file={ options_file.name }',
       '--log=debug',
-      '--idle_suicide_seconds={0}'.format( idle_suicide_seconds ),
-      '--check_interval_seconds={0}'.format( check_interval_seconds ),
+      f'--idle_suicide_seconds={ idle_suicide_seconds }',
+      f'--check_interval_seconds={ check_interval_seconds }',
     ]
 
     stdout = CreateLogfile(
@@ -96,8 +96,8 @@ class Client_test:
     stderr = CreateLogfile(
         LOGFILE_FORMAT.format( port = self._port, std = 'stderr' ) )
     self._logfiles.extend( [ stdout, stderr ] )
-    ycmd_args.append( '--stdout={0}'.format( stdout ) )
-    ycmd_args.append( '--stderr={0}'.format( stderr ) )
+    ycmd_args.append( f'--stdout={ stdout }' )
+    ycmd_args.append( f'--stderr={ stderr }' )
 
     self._popen_handle = SafePopen( ycmd_args,
                                     stdin_windows = subprocess.PIPE,
@@ -123,10 +123,9 @@ class Client_test:
     while True:
       try:
         if time.time() > expiration:
-          server = ( 'the {0} subserver'.format( filetype ) if filetype else
-                     'ycmd' )
-          raise RuntimeError( 'Waited for {0} to be ready for {1} seconds, '
-                              'aborting.'.format( server, timeout ) )
+          server = ( f'the { filetype } subserver' if filetype else 'ycmd' )
+          raise RuntimeError( f'Waited for { server } to be ready '
+                              f'for { timeout } seconds, aborting.' )
 
         if self._IsReady( filetype ):
           return
@@ -248,7 +247,7 @@ class Client_test:
       finally:
         for logfile in self._logfiles:
           if os.path.isfile( logfile ):
-            sys.stdout.write( 'Logfile {0}:\n\n'.format( logfile ) )
+            sys.stdout.write( f'Logfile { logfile }:\n\n' )
             sys.stdout.write( ReadFile( logfile ) )
             sys.stdout.write( '\n' )
 

--- a/ycmd/tests/cs/conftest.py
+++ b/ycmd/tests/cs/conftest.py
@@ -154,7 +154,7 @@ def WrapOmniSharpServer( app, filepath ):
         log_content, log_end_position = ReadFile(
             logfile, shared_log_indexes.get( logfile, 0 ) )
         shared_log_indexes[ logfile ] = log_end_position
-        sys.stdout.write( 'Logfile {0}:\n\n'.format( logfile ) )
+        sys.stdout.write( f'Logfile { logfile }:\n\n' )
         sys.stdout.write( log_content )
         sys.stdout.write( '\n' )
 

--- a/ycmd/tests/cs/subcommands_test.py
+++ b/ycmd/tests/cs/subcommands_test.py
@@ -689,7 +689,7 @@ def StopServer_KeepLogFiles( app ):
     try:
       for logfile in logfiles:
         assert_that( os.path.exists( logfile ),
-             'Logfile should exist at {0}'.format( logfile ) )
+                     f'Logfile should exist at { logfile }' )
     finally:
       app.post_json(
         '/run_completer_command',
@@ -703,11 +703,11 @@ def StopServer_KeepLogFiles( app ):
     if user_options_store.Value( 'server_keep_logfiles' ):
       for logfile in logfiles:
         assert_that( os.path.exists( logfile ),
-             'Logfile should still exist at {0}'.format( logfile ) )
+                     f'Logfile should still exist at { logfile }' )
     else:
       for logfile in logfiles:
         assert_that( not os.path.exists( logfile ),
-             'Logfile should no longer exist at {0}'.format( logfile ) )
+                     f'Logfile should no longer exist at { logfile }' )
 
 
 @IsolatedYcmd( { 'server_keep_logfiles': 1 } )

--- a/ycmd/tests/go/diagnostics_test.py
+++ b/ycmd/tests/go/diagnostics_test.py
@@ -76,7 +76,7 @@ def Diagnostics_FileReadyToParse_test( app ):
 
   # It can take a while for the diagnostics to be ready.
   results = WaitForDiagnosticsToBeReady( app, filepath, contents, 'go' )
-  print( 'completer response: {}'.format( pformat( results ) ) )
+  print( f'completer response: { pformat( results ) }' )
 
   assert_that( results, DIAG_MATCHERS_PER_FILE[ filepath ] )
 
@@ -114,6 +114,5 @@ def Diagnostics_Poll_test( app ):
     raise AssertionError(
       str( e ) +
       'Timed out waiting for full set of diagnostics. '
-      'Expected to see diags for {}, but only saw {}.'.format(
-        json.dumps( to_see, indent=2 ),
-        json.dumps( sorted( seen.keys() ), indent=2 ) ) )
+      f'Expected to see diags for { json.dumps( to_see, indent = 2 ) }, '
+      f'but only saw { json.dumps( sorted( seen.keys() ), indent = 2 ) }.' )

--- a/ycmd/tests/go/subcommands_test.py
+++ b/ycmd/tests/go/subcommands_test.py
@@ -82,7 +82,7 @@ def RunTest( app, test, contents = None ):
     expect_errors = True
   )
 
-  print( 'completer response: {}'.format( pformat( response.json ) ) )
+  print( f'completer response: { pformat( response.json ) }' )
 
   assert_that( response.status_code,
                equal_to( test[ 'expect' ][ 'response' ] ) )

--- a/ycmd/tests/java/diagnostics_test.py
+++ b/ycmd/tests/java/diagnostics_test.py
@@ -229,7 +229,7 @@ def _WaitForDiagnosticsForFile( app,
                                     **kwargs ):
       if ( 'diagnostics' in message and
            message[ 'filepath' ] == diags_filepath ):
-        print( 'Message {0}'.format( pformat( message ) ) )
+        print( f'Message { pformat( message ) }' )
         diags = message[ 'diagnostics' ]
         if diags_are_ready( diags ):
           return diags
@@ -238,9 +238,7 @@ def _WaitForDiagnosticsForFile( app,
       # if we don't see the diagnostics go empty
   except PollForMessagesTimeoutException as e:
     raise AssertionError(
-      '{0}. Timed out waiting for diagnostics for file {1}. '.format(
-        e,
-        diags_filepath )
+      f'{ e }. Timed out waiting for diagnostics for file { diags_filepath }.'
     )
 
   return diags
@@ -272,7 +270,7 @@ def FileReadyToParse_Diagnostics_Simple_test( app ):
 
   # It can take a while for the diagnostics to be ready
   results = WaitForDiagnosticsToBeReady( app, filepath, contents, 'java' )
-  print( 'completer response: {0}'.format( pformat( results ) ) )
+  print( f'completer response: { pformat( results ) }' )
 
   assert_that( results, DIAG_MATCHERS_PER_FILE[ filepath ] )
 
@@ -318,7 +316,7 @@ def FileReadyToParse_Diagnostics_FileNotOnDisk_test( app ):
                                     'contents': contents,
                                     'filetype': 'java' } ):
     if 'diagnostics' in message and message[ 'filepath' ] == filepath:
-      print( 'Message {0}'.format( pformat( message ) ) )
+      print( f'Message { pformat( message ) }' )
       assert_that( message, has_entries( {
         'diagnostics': diag_matcher,
         'filepath': filepath
@@ -332,7 +330,7 @@ def FileReadyToParse_Diagnostics_FileNotOnDisk_test( app ):
       break
     time.sleep( 0.5 )
 
-  print( 'completer response: {0}'.format( pformat( results ) ) )
+  print( f'completer response: { pformat( results ) }' )
 
   assert_that( results, diag_matcher )
 
@@ -355,13 +353,12 @@ def Poll_Diagnostics_ProjectWide_Eclipse_test( app ):
                                     { 'filepath': filepath,
                                       'contents': contents,
                                       'filetype': 'java' } ):
-      print( 'Message {0}'.format( pformat( message ) ) )
+      print( f'Message { pformat( message ) }' )
       if 'diagnostics' in message:
         seen[ message[ 'filepath' ] ] = True
         if message[ 'filepath' ] not in DIAG_MATCHERS_PER_FILE:
-          raise AssertionError(
-            'Received diagnostics for unexpected file {0}. '
-            'Only expected {1}'.format( message[ 'filepath' ], to_see ) )
+          raise AssertionError( 'Received diagnostics for unexpected file '
+            f'{ message[ "filepath" ] }. Only expected { to_see }' )
         assert_that( message, has_entries( {
           'diagnostics': DIAG_MATCHERS_PER_FILE[ message[ 'filepath' ] ],
           'filepath': message[ 'filepath' ]
@@ -371,8 +368,8 @@ def Poll_Diagnostics_ProjectWide_Eclipse_test( app ):
         break
       else:
         print( 'Seen diagnostics for {0}, still waiting for {1}'.format(
-          json.dumps( sorted( seen.keys() ), indent=2 ),
-          json.dumps( [ x for x in to_see if x not in seen ], indent=2 ) ) )
+          json.dumps( sorted( seen.keys() ), indent = 2 ),
+          json.dumps( [ x for x in to_see if x not in seen ], indent = 2 ) ) )
 
       # Eventually PollForMessages will throw
       # a timeout exception and we'll fail
@@ -381,9 +378,8 @@ def Poll_Diagnostics_ProjectWide_Eclipse_test( app ):
     raise AssertionError(
       str( e ) +
       'Timed out waiting for full set of diagnostics. '
-      'Expected to see diags for {0}, but only saw {1}.'.format(
-        json.dumps( to_see, indent=2 ),
-        json.dumps( sorted( seen.keys() ), indent=2 ) ) )
+      f'Expected to see diags for { json.dumps( to_see, indent = 2 ) }, '
+      f'but only saw { json.dumps( sorted( seen.keys() ), indent = 2 ) }.' )
 
 
 @contextlib.contextmanager
@@ -571,7 +567,7 @@ def FileReadyToParse_ChangeFileContents_test( app ):
                                     { 'filepath': filepath,
                                       'contents': contents,
                                       'filetype': 'java' } ):
-      print( 'Message {0}'.format( pformat( message ) ) )
+      print( f'Message { pformat( message ) }' )
       if 'diagnostics' in message and message[ 'filepath' ]  == filepath:
         diags = message[ 'diagnostics' ]
         if not diags:
@@ -581,8 +577,8 @@ def FileReadyToParse_ChangeFileContents_test( app ):
       # if we don't see the diagnostics go empty
   except PollForMessagesTimeoutException as e:
     raise AssertionError(
-      '{0}. Timed out waiting for diagnostics to clear for updated file. '
-      'Expected to see none, but diags were: {1}'.format( e, diags ) )
+      f'{ e }. Timed out waiting for diagnostics to clear for updated file. '
+      f'Expected to see none, but diags were: { diags }' )
 
   assert_that( diags, empty() )
 
@@ -762,8 +758,8 @@ def PollForMessages_AbortedWhenServerDies_test( app ):
         state[ 'aborted' ] = True
         return
 
-    raise AssertionError( 'The poll request was not aborted in {} tries'.format(
-      max_tries ) )
+    raise AssertionError(
+      f'The poll request was not aborted in { max_tries } tries' )
 
   message_poll_task = StartThread( AwaitMessages )
 

--- a/ycmd/tests/java/get_completions_test.py
+++ b/ycmd/tests/java/get_completions_test.py
@@ -80,7 +80,7 @@ def RunTest( app, test ):
                             } ),
                             expect_errors = True )
 
-  print( 'completer response: {0}'.format( pformat( response.json ) ) )
+  print( f'completer response: { pformat( response.json ) }' )
 
   assert_that( response.status_code,
                equal_to( test[ 'expect' ][ 'response' ] ) )

--- a/ycmd/tests/java/server_management_test.py
+++ b/ycmd/tests/java/server_management_test.py
@@ -422,9 +422,9 @@ def ServerManagement_ServerDies_test( app ):
 
   request_data = BuildRequest( filetype = 'java' )
   debug_info = app.post_json( '/debug_info', request_data ).json
-  print( 'Debug info: {0}'.format( debug_info ) )
+  print( f'Debug info: { debug_info }' )
   pid = debug_info[ 'completer' ][ 'servers' ][ 0 ][ 'pid' ]
-  print( 'pid: {0}'.format( pid ) )
+  print( f'pid: { pid }' )
   process = psutil.Process( pid )
   process.terminate()
 
@@ -453,9 +453,9 @@ def ServerManagement_ServerDiesWhileShuttingDown_test( app ):
 
   request_data = BuildRequest( filetype = 'java' )
   debug_info = app.post_json( '/debug_info', request_data ).json
-  print( 'Debug info: {0}'.format( debug_info ) )
+  print( f'Debug info: { debug_info }' )
   pid = debug_info[ 'completer' ][ 'servers' ][ 0 ][ 'pid' ]
-  print( 'pid: {0}'.format( pid ) )
+  print( f'pid: { pid }' )
   process = psutil.Process( pid )
 
 
@@ -499,9 +499,9 @@ def ServerManagement_ConnectionRaisesWhileShuttingDown_test( app ):
 
   request_data = BuildRequest( filetype = 'java' )
   debug_info = app.post_json( '/debug_info', request_data ).json
-  print( 'Debug info: {0}'.format( debug_info ) )
+  print( f'Debug info: { debug_info }' )
   pid = debug_info[ 'completer' ][ 'servers' ][ 0 ][ 'pid' ]
-  print( 'pid: {0}'.format( pid ) )
+  print( f'pid: { pid }' )
   process = psutil.Process( pid )
 
   completer = handlers._server_state.GetFiletypeCompleter( [ 'java' ] )

--- a/ycmd/tests/java/subcommands_test.py
+++ b/ycmd/tests/java/subcommands_test.py
@@ -175,7 +175,7 @@ def RunTest( app, test, contents = None ):
         expect_errors = True
       )
 
-      print( 'completer response: {0}'.format( pformat( response.json ) ) )
+      print( f'completer response: { pformat( response.json ) }' )
 
       assert_that( response.status_code,
                    equal_to( test[ 'expect' ][ 'response' ] ) )
@@ -2155,8 +2155,8 @@ def Subcommands_ExtraConf_SettingsValid_UnknownExtraConf_test( app ):
                             } ),
                             expect_errors = True )
 
-  print( 'FileReadyToParse result: {}'.format( json.dumps( response.json,
-                                                           indent = 2 ) ) )
+  print( 'FileReadyToParse result: '
+         f'{ json.dumps( response.json, indent = 2 ) }' )
 
   assert_that( response.status_code,
                equal_to( requests.codes.internal_server_error ) )

--- a/ycmd/tests/javascript/get_completions_test.py
+++ b/ycmd/tests/javascript/get_completions_test.py
@@ -57,7 +57,7 @@ def RunTest( app, test ):
     } )
   )
 
-  print( 'completer response: {0}'.format( pprint.pformat( response.json ) ) )
+  print( f'completer response: { pprint.pformat( response.json ) }' )
 
   assert_that( response.status_code,
                equal_to( test[ 'expect' ][ 'response' ] ) )

--- a/ycmd/tests/javascript/subcommands_test.py
+++ b/ycmd/tests/javascript/subcommands_test.py
@@ -70,7 +70,7 @@ def RunTest( app, test ):
     expect_errors = True
   )
 
-  print( 'completer response: {0}'.format( pprint.pformat( response.json ) ) )
+  print( f'completer response: { pprint.pformat( response.json ) }' )
 
   assert_that( response.status_code,
                equal_to( test[ 'expect' ][ 'response' ] ) )

--- a/ycmd/tests/language_server/generic_completer_test.py
+++ b/ycmd/tests/language_server/generic_completer_test.py
@@ -93,8 +93,7 @@ def GenericLSPCompleter_GetCompletions_FilteredNoForce_test( app ):
   request.pop( 'event_name' )
   response = app.post_json( '/completions', BuildRequest( **request ) )
   assert_that( response.status_code, equal_to( 200 ) )
-  print( 'Completer response: {}'.format( json.dumps(
-    response.json, indent = 2 ) ) )
+  print( f'Completer response: { json.dumps( response.json, indent = 2 ) }' )
   assert_that( response.json, has_entries( {
     'completions': contains_exactly(
       CompletionEntryMatcher( 'JavaScript', 'JavaScript details' ),
@@ -119,8 +118,7 @@ def GenericLSPCompleter_GetCompletions_test( app ):
   request.pop( 'event_name' )
   response = app.post_json( '/completions', BuildRequest( **request ) )
   assert_that( response.status_code, equal_to( 200 ) )
-  print( 'Completer response: {}'.format( json.dumps(
-    response.json, indent = 2 ) ) )
+  print( f'Completer response: { json.dumps( response.json, indent = 2 ) }' )
   assert_that( response.json, has_entries( {
     'completions': contains_exactly(
       CompletionEntryMatcher( 'JavaScript', 'JavaScript details' ),

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -323,7 +323,7 @@ def LanguageServerCompleter_GoTo_test( app ):
         )
       else:
         result = completer.OnUserCommand( [ command ], request_data )
-        print( 'Result: {}'.format( result ) )
+        print( f'Result: { result }' )
         assert_that( result, exception )
 
 
@@ -578,7 +578,7 @@ def WorkspaceEditToFixIt_test():
     lsc.WorkspaceEditToFixIt( request_data, workspace_edit, 'test' )
   ] )
 
-  print( 'Response: {0}'.format( response ) )
+  print( f'Response: { response }' )
   assert_that(
     response,
     has_entries( {
@@ -609,8 +609,8 @@ def WorkspaceEditToFixIt_test():
     lsc.WorkspaceEditToFixIt( request_data, workspace_edit, 'test' )
   ] )
 
-  print( 'Response: {0}'.format( response ) )
-  print( 'Type Response: {0}'.format( type( response ) ) )
+  print( f'Response: { response }' )
+  print( f'Type Response: { type( response ) }' )
 
   assert_that(
     response,

--- a/ycmd/tests/python/subcommands_test.py
+++ b/ycmd/tests/python/subcommands_test.py
@@ -67,7 +67,7 @@ def RunTest( app, test ):
     expect_errors = True
   )
 
-  print( 'completer response: {0}'.format( pformat( response.json ) ) )
+  print( f'completer response: { pformat( response.json ) }' )
 
   assert_that( response.status_code,
                equal_to( test[ 'expect' ][ 'response' ] ) )

--- a/ycmd/tests/rust/diagnostics_test.py
+++ b/ycmd/tests/rust/diagnostics_test.py
@@ -81,7 +81,7 @@ def Diagnostics_FileReadyToParse_test( app ):
 
   # It can take a while for the diagnostics to be ready.
   results = WaitForDiagnosticsToBeReady( app, filepath, contents, 'rust' )
-  print( 'completer response: {}'.format( pformat( results ) ) )
+  print( f'completer response: { pformat( results ) }' )
 
   assert_that( results, DIAG_MATCHERS_PER_FILE[ filepath ] )
 
@@ -102,16 +102,15 @@ def Diagnostics_Poll_test( app ):
                                     { 'filepath': filepath,
                                       'contents': contents,
                                       'filetype': 'rust' } ):
-      print( 'Message {}'.format( pformat( message ) ) )
+      print( f'Message { pformat( message ) }' )
       if 'diagnostics' in message:
         if message[ 'diagnostics' ] == []:
           # Sometimes we get empty diagnostics before the real ones.
           continue
         seen[ message[ 'filepath' ] ] = True
         if message[ 'filepath' ] not in DIAG_MATCHERS_PER_FILE:
-          raise AssertionError(
-            'Received diagnostics for unexpected file {}. '
-            'Only expected {}'.format( message[ 'filepath' ], to_see ) )
+          raise AssertionError( 'Received diagnostics for unexpected file '
+            f'{ message[ "filepath" ] }. Only expected { to_see }' )
         assert_that( message, has_entries( {
           'diagnostics': DIAG_MATCHERS_PER_FILE[ message[ 'filepath' ] ],
           'filepath': message[ 'filepath' ]
@@ -126,6 +125,5 @@ def Diagnostics_Poll_test( app ):
     raise AssertionError(
       str( e ) +
       'Timed out waiting for full set of diagnostics. '
-      'Expected to see diags for {}, but only saw {}.'.format(
-        json.dumps( to_see, indent=2 ),
-        json.dumps( sorted( seen.keys() ), indent=2 ) ) )
+      f'Expected to see diags for { json.dumps( to_see, indent = 2 ) }, '
+      f'but only saw { json.dumps( sorted( seen.keys() ), indent = 2 ) }.' )

--- a/ycmd/tests/rust/subcommands_test.py
+++ b/ycmd/tests/rust/subcommands_test.py
@@ -78,7 +78,7 @@ def RunTest( app, test, contents = None ):
     expect_errors = True
   )
 
-  print( 'completer response: {}'.format( pformat( response.json ) ) )
+  print( f'completer response: { pformat( response.json ) }' )
 
   assert_that( response.status_code,
                equal_to( test[ 'expect' ][ 'response' ] ) )

--- a/ycmd/tests/tern/event_notification_test.py
+++ b/ycmd/tests/tern/event_notification_test.py
@@ -104,7 +104,7 @@ def EventNotification_OnFileReadyToParse_NoProjectFile_test(
                             expect_errors = True )
 
 
-  print( 'event response: {0}'.format( pformat( response.json ) ) )
+  print( f'event response: { pformat( response.json ) }' )
 
   assert_that( response.status_code,
                equal_to( requests.codes.internal_server_error ) )
@@ -142,7 +142,7 @@ def EventNotification_OnFileReadyToParse_NoProjectFile_test(
                                           filetype = 'javascript' ),
                             expect_errors = True )
 
-  print( 'event response: {0}'.format( pformat( response.json ) ) )
+  print( f'event response: { pformat( response.json ) }' )
 
   assert_that( response.status_code, equal_to( requests.codes.ok ) )
   assert_that( response.json, empty() )
@@ -159,7 +159,7 @@ def EventNotification_OnFileReadyToParse_NoProjectFile_test(
                                           filetype = 'javascript' ),
                             expect_errors = True )
 
-  print( 'event response: {0}'.format( pformat( response.json ) ) )
+  print( f'event response: { pformat( response.json ) }' )
 
   assert_that( response.status_code,
                equal_to( requests.codes.internal_server_error ) )
@@ -188,7 +188,7 @@ def EventNotification_OnFileReadyToParse_NoProjectFile_test(
                                           filetype = 'javascript' ),
                             expect_errors = True )
 
-  print( 'event response: {0}'.format( pformat( response.json ) ) )
+  print( f'event response: { pformat( response.json ) }' )
 
   assert_that( response.status_code, equal_to( requests.codes.ok ) )
   assert_that( response.json, empty() )
@@ -222,7 +222,7 @@ def EventNotification_OnFileReadyToParse_UseGlobalConfig_test(
                                           filetype = 'javascript' ),
                             expect_errors = True )
 
-  print( 'event response: {0}'.format( pformat( response.json ) ) )
+  print( f'event response: { pformat( response.json ) }' )
 
   assert_that( response.status_code, equal_to( requests.codes.ok ) )
   assert_that( response.json, empty() )

--- a/ycmd/tests/tern/get_completions_test.py
+++ b/ycmd/tests/tern/get_completions_test.py
@@ -69,7 +69,7 @@ def RunTest( app, test ):
                             } ),
                             expect_errors = True )
 
-  print( 'completer response: {0}'.format( pformat( response.json ) ) )
+  print( f'completer response: { pformat( response.json ) }' )
 
   assert_that( response.status_code,
                equal_to( test[ 'expect' ][ 'response' ] ) )
@@ -328,7 +328,7 @@ def GetCompletions_IgoreNonJSFiles_test( app ):
     'filepath': PathToTestFile( 'trivial2.js' ),
   } ) ).json
 
-  print( 'completer response: {0}'.format( pformat( response, indent=2 ) ) )
+  print( f'completer response: { pformat( response ) }' )
 
   assert_that( response,
     has_entries( {
@@ -373,7 +373,7 @@ def GetCompletions_IncludeMultiFileType_test( app ):
     'force_semantic': True,
   } ) ).json
 
-  print( 'completer response: {0}'.format( pformat( response, indent=2 ) ) )
+  print( f'completer response: { pformat( response, indent = 2 ) }' )
 
   assert_that( response,
     has_entries( {

--- a/ycmd/tests/tern/subcommands_test.py
+++ b/ycmd/tests/tern/subcommands_test.py
@@ -81,7 +81,7 @@ def RunTest( app, test, contents = None ):
     expect_errors = True
   )
 
-  print( 'completer response: {0}'.format( pformat( response.json ) ) )
+  print( f'completer response: { pformat( response.json ) }' )
 
   assert_that( response.status_code,
                equal_to( test[ 'expect' ][ 'response' ] ) )

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -469,9 +469,8 @@ def PollForMessages( app, request_data, timeout = 60 ):
   expiration = time.time() + timeout
   while True:
     if time.time() > expiration:
-      raise PollForMessagesTimeoutException(
-        'Waited for diagnostics to be ready for {0} seconds, aborting.'.format(
-          timeout ) )
+      raise PollForMessagesTimeoutException( 'Waited for diagnostics to be '
+        f'ready for { timeout } seconds, aborting.' )
 
     default_args = {
       'line_num'  : 1,

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -283,8 +283,8 @@ def WaitUntilCompleterServerReady( app, filetype, timeout = 30 ):
   expiration = time.time() + timeout
   while True:
     if time.time() > expiration:
-      raise RuntimeError( 'Waited for the {0} subserver to be ready for '
-                          '{1} seconds, aborting.'.format( filetype, timeout ) )
+      raise RuntimeError( f'Waited for the { filetype } subserver to be ready '
+                          f'for { timeout } seconds, aborting.' )
 
     if app.get( '/ready', { 'subserver': filetype } ).json:
       return
@@ -294,8 +294,8 @@ def WaitUntilCompleterServerReady( app, filetype, timeout = 30 ):
 
 def MockProcessTerminationTimingOut( handle, timeout = 5 ):
   WaitUntilProcessIsTerminated( handle, timeout )
-  raise RuntimeError( 'Waited process to terminate for {0} seconds, '
-                      'aborting.'.format( timeout ) )
+  raise RuntimeError( f'Waited process to terminate for { timeout } seconds, '
+                      'aborting.' )
 
 
 def ClearCompletionsCache():
@@ -368,8 +368,7 @@ def ExpectedFailure( reason, *exception_matchers ):
         # Failed for the right reason
         pytest.skip( reason )
       else:
-        raise AssertionError( 'Test was expected to fail: {0}'.format(
-          reason ) )
+        raise AssertionError( f'Test was expected to fail: { reason }' )
     return Wrapper
 
   return decorator
@@ -405,7 +404,7 @@ def WithRetry( test ):
       except Exception as test_exception:
         if time.time() > expiry:
           raise
-        print( 'Test failed, retrying: {0}'.format( str( test_exception ) ) )
+        print( f'Test failed, retrying: { test_exception }' )
         time.sleep( 0.25 )
   return wrapper
 
@@ -435,7 +434,7 @@ def TemporaryClangProject( tmp_dir, compile_commands ):
   path = os.path.join( tmp_dir, 'compile_commands.json' )
 
   with open( path, 'w' ) as f:
-    f.write( ToUnicode( json.dumps( compile_commands, indent=2 ) ) )
+    f.write( ToUnicode( json.dumps( compile_commands, indent = 2 ) ) )
 
   try:
     yield
@@ -483,7 +482,7 @@ def PollForMessages( app, request_data, timeout = 60 ):
 
     response = app.post_json( '/receive_messages', BuildRequest( **args ) ).json
 
-    print( 'poll response: {0}'.format( pformat( response ) ) )
+    print( f'poll response: { pformat( response ) }' )
 
     if isinstance( response, bool ):
       if not response:
@@ -492,7 +491,7 @@ def PollForMessages( app, request_data, timeout = 60 ):
       for message in response:
         yield message
     else:
-      raise AssertionError( 'Message poll response was wrong type: {0}'.format(
-        type( response ).__name__ ) )
+      raise AssertionError(
+        f'Message poll response was wrong type: { type( response ).__name__ }' )
 
     time.sleep( 0.25 )

--- a/ycmd/tests/typescript/get_completions_test.py
+++ b/ycmd/tests/typescript/get_completions_test.py
@@ -59,7 +59,7 @@ def RunTest( app, test ):
     } )
   )
 
-  print( 'completer response: {0}'.format( pprint.pformat( response.json ) ) )
+  print( f'completer response: { pprint.pformat( response.json ) }' )
 
   assert_that( response.status_code,
                equal_to( test[ 'expect' ][ 'response' ] ) )

--- a/ycmd/tests/typescript/subcommands_test.py
+++ b/ycmd/tests/typescript/subcommands_test.py
@@ -74,7 +74,7 @@ def RunTest( app, test ):
     expect_errors = True
   )
 
-  print( 'completer response: {0}'.format( pprint.pformat( response.json ) ) )
+  print( f'completer response: { pprint.pformat( response.json ) }' )
 
   assert_that( response.status_code,
                equal_to( test[ 'expect' ][ 'response' ] ) )

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -244,7 +244,7 @@ def GetExecutable( filename ):
   return None
 
 
-# Adapted from https://github.com/python/cpython/blob/v3.5.0/Lib/shutil.py#L1072
+# Adapted from https://github.com/python/cpython/blob/v3.6.0/Lib/shutil.py#L1087
 # to be backward compatible with Python2 and more consistent to our codebase.
 def FindExecutable( executable ):
   # If we're given a path with a directory part, look it up directly rather

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -306,8 +306,8 @@ def WaitUntilProcessIsTerminated( handle, timeout = 5 ):
   expiration = time.time() + timeout
   while True:
     if time.time() > expiration:
-      raise RuntimeError( 'Waited process to terminate for {0} seconds, '
-                          'aborting.'.format( timeout ) )
+      raise RuntimeError( f'Waited process to terminate for { timeout } '
+                          'seconds, aborting.' )
     if not ProcessIsRunning( handle ):
       return
     time.sleep( 0.1 )

--- a/ycmd/wsgi_server.py
+++ b/ycmd/wsgi_server.py
@@ -32,9 +32,7 @@ class StoppableWSGIServer( TcpWSGIServer ):
 
     # Message for compatibility with clients who expect the output from
     # waitress.serve here
-    print( 'serving on http://{0}:{1}'.format(
-      self.effective_host,
-      self.effective_port ) )
+    print( f'serving on http://{ self.effective_host }:{self.effective_port}' )
 
     try:
       self.run()


### PR DESCRIPTION
A few notes:

1. Review by commits.
2. Every `str.format` was replaced with an f-string. I know this isn't always a good idea, but it was easier for me to do that and then discuss and revert cases where f-strings hurt readability.
3. ~~I write f-strings as `f'{expression}'` instead of `f'{ expression }'`. No preference either way, it was just less typing.~~
4. Type annotations are left out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1455)
<!-- Reviewable:end -->
