### PR TITLE
Fix issue with readonly go modules

### DIFF
--- a/build.py
+++ b/build.py
@@ -844,6 +844,7 @@ def EnableGoCompleter( args ):
   new_env[ 'GO111MODULE' ] = 'on'
   new_env[ 'GOPATH' ] = p.join( DIR_OF_THIS_SCRIPT, 'third_party', 'go' )
   new_env[ 'GOBIN' ] = p.join( new_env[ 'GOPATH' ], 'bin' )
+  new_env[ 'GOFLAGS' ] = new_env.get( 'GOFLAGS', '' ) + ' -modcacherw'
   CheckCall( [ go, 'get', 'golang.org/x/tools/gopls@v0.4.2' ],
              env = new_env,
              quiet = args.quiet,


### PR DESCRIPTION
Hello.

As mentioned in issue https://github.com/ycm-core/YouCompleteMe/issues/3721, `--go-completer` causes the state, when the YCM directory couldn't be deleted.

This is the intended behavior, see https://github.com/golang/go/issues/27161. But in https://github.com/golang/go/issues/31481 the flag `-modcacherw` was proposed, and in https://golang.org/cl/202079 it was implemented.

To keep backward compatibility, the `GOFLAGS` ENV is used.

This fix https://github.com/ycm-core/YouCompleteMe/issues/3721

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1456)
<!-- Reviewable:end -->
