### PR TITLE
[READY] Use full path to check java version

### DIFF
--- a/build.py
+++ b/build.py
@@ -967,8 +967,9 @@ def CheckJavaVersion( required_version ):
   java_version = None
   try:
     java_version = int(
-      subprocess.check_output( [ java, 'CheckJavaVersion.java' ],
-                               stderr=subprocess.STDOUT )
+      subprocess.check_output(
+        [ java, os.path.join( DIR_OF_THIS_SCRIPT, 'CheckJavaVersion.java' ) ],
+        stderr=subprocess.STDOUT )
       .decode( 'utf-8' )
       .strip() )
   except subprocess.CalledProcessError:


### PR DESCRIPTION
This fixes the check when running `install.py` in YCM, or when running
from a different dir.

Before this change you _always_ received the warning when running install.py from YCM's directory. Now it works properly, using the absoute path to the check script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1459)
<!-- Reviewable:end -->
