### PR TITLE
[READY] Support signature parameter offsets in LSP signatureHelp responses

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1302,13 +1302,16 @@ class LanguageServerCompleter( Completer ):
         sig[ 'parameters' ] = []
       for arg in sig[ 'parameters' ]:
         arg_label = arg[ 'label' ]
-        assert not isinstance( arg_label, list )
-        begin = sig[ 'label' ].find( arg_label, end )
-        end = begin + len( arg_label )
+        if not isinstance( arg_label, list ):
+          begin = sig[ 'label' ].find( arg_label, end )
+          end = begin + len( arg_label )
+        else:
+          begin, end = arg_label
         arg[ 'label' ] = [
           utils.CodepointOffsetToByteOffset( sig_label, begin ),
           utils.CodepointOffsetToByteOffset( sig_label, end ) ]
     result.setdefault( 'activeParameter', 0 )
+    result.setdefault( 'activeSignature', 0 )
     return result
 
 

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -318,7 +318,7 @@ def Initialize( request_id, project_directory, settings ):
         'signatureHelp': {
           'signatureInformation': {
             'parameterInformation': {
-              'labelOffsetSupport': False, # For now.
+              'labelOffsetSupport': True,
             },
             'documentationFormat': [
               'plaintext',


### PR DESCRIPTION
According to my testing, this works. Latest rust-analyzer exercises its freedom to use offsets, instead of strings and it also omits `activeSignature` when there's only one.

No tests, because [the missing `rustfmt`](https://rust-lang.github.io/rustup-components-history/) is preventing us from upgrading to the newer nightly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1464)
<!-- Reviewable:end -->
