### PR TITLE
[READY] Supply code action ranges according to cursor position

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -2187,67 +2187,36 @@ class LanguageServerCompleter( Completer ):
 
     self._UpdateServerWithFileContents( request_data )
 
-    line_num_ls = request_data[ 'line_num' ] - 1
     request_id = self.GetConnection().NextRequestId()
-    if 'range' in request_data:
-      code_actions = self.GetConnection().GetResponse(
-        request_id,
-        lsp.CodeAction( request_id,
-                        request_data,
-                        lsp.Range( request_data ),
-                        [] ),
-        REQUEST_TIMEOUT_COMMAND )
-    else:
 
-      def WithinRange( diag ):
-        start = diag[ 'range' ][ 'start' ]
-        end = diag[ 'range' ][ 'end' ]
+    cursor_range_ls = lsp.Range( request_data )
 
-        if line_num_ls < start[ 'line' ] or line_num_ls > end[ 'line' ]:
-          return False
+    with self._server_info_mutex:
+      # _latest_diagnostics contains LSP rnages, _not_ YCM ranges
+      file_diagnostics = list( self._latest_diagnostics[
+          lsp.FilePathToUri( request_data[ 'filepath' ] ) ] )
 
-        return True
+    matched_diagnostics = [
+      d for d in file_diagnostics if lsp.RangesOverlap( d[ 'range' ],
+                                                        cursor_range_ls )
+    ]
 
-      with self._server_info_mutex:
-        file_diagnostics = list( self._latest_diagnostics[
-            lsp.FilePathToUri( request_data[ 'filepath' ] ) ] )
 
+    # If we didn't find any overlapping the strict range/character. Find any
+    # that overlap line of the cursor.
+    if not matched_diagnostics and 'range' not in request_data:
       matched_diagnostics = [
-        d for d in file_diagnostics if WithinRange( d )
+        d for d in file_diagnostics
+        if lsp.RangesOverlapLines( d[ 'range' ], cursor_range_ls )
       ]
 
-      if matched_diagnostics:
-        code_actions = self.GetConnection().GetResponse(
-          request_id,
-          lsp.CodeAction( request_id,
-                          request_data,
-                          matched_diagnostics[ 0 ][ 'range' ],
-                          matched_diagnostics ),
-          REQUEST_TIMEOUT_COMMAND )
-
-      else:
-        line_value = request_data[ 'line_value' ]
-
-        code_actions = self.GetConnection().GetResponse(
-          request_id,
-          lsp.CodeAction(
-            request_id,
-            request_data,
-            # Use the whole line
-            {
-              'start': {
-                'line': line_num_ls,
-                'character': 0,
-              },
-              'end': {
-                'line': line_num_ls,
-                'character': lsp.CodepointsToUTF16CodeUnits(
-                  line_value,
-                  len( line_value ) + 1 ) - 1,
-              }
-            },
-            [] ),
-          REQUEST_TIMEOUT_COMMAND )
+    code_actions = self.GetConnection().GetResponse(
+      request_id,
+      lsp.CodeAction( request_id,
+                      request_data,
+                      cursor_range_ls,
+                      matched_diagnostics ),
+      REQUEST_TIMEOUT_COMMAND )
 
     return self.CodeActionResponseToFixIts( request_data,
                                             code_actions[ 'result' ] )

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -578,17 +578,30 @@ def FormattingOptions( request_data ):
 def Range( request_data ):
   lines = request_data[ 'lines' ]
 
-  start = request_data[ 'range' ][ 'start' ]
-  start_line_num = start[ 'line_num' ]
-  start_line_value = lines[ start_line_num - 1 ]
-  start_codepoint = ByteOffsetToCodepointOffset( start_line_value,
-                                                 start[ 'column_num' ] )
+  if 'range' not in request_data:
+    start_codepoint = request_data[ 'start_codepoint' ]
+    start_line_num = request_data[ 'line_num' ]
+    start_line_value = request_data[ 'line_value' ]
 
-  end = request_data[ 'range' ][ 'end' ]
-  end_line_num = end[ 'line_num' ]
-  end_line_value = lines[ end_line_num - 1 ]
-  end_codepoint = ByteOffsetToCodepointOffset( end_line_value,
-                                               end[ 'column_num' ] )
+    end_codepoint = start_codepoint + 1
+    end_line_num = start_line_num
+    end_line_value = start_line_value
+  else:
+    start = request_data[ 'range' ][ 'start' ]
+    start_line_num = start[ 'line_num' ]
+    end = request_data[ 'range' ][ 'end' ]
+    end_line_num = end[ 'line_num' ]
+
+    try:
+      start_line_value = lines[ start_line_num - 1 ]
+      start_codepoint = ByteOffsetToCodepointOffset( start_line_value,
+                                                     start[ 'column_num' ] )
+
+      end_line_value = lines[ end_line_num - 1 ]
+      end_codepoint = ByteOffsetToCodepointOffset( end_line_value,
+                                                   end[ 'column_num' ] )
+    except IndexError:
+      raise RuntimeError( "Invalid range" )
 
   # LSP requires to use the start of the next line as the end position for a
   # range that ends with a newline.
@@ -683,3 +696,39 @@ def UTF16CodeUnitsToCodepoints( line_value, code_unit_offset ):
 
   bytes_included = value_as_utf16_bytes[ : code_unit_offset * 2 ]
   return len( bytes_included.decode( 'utf-16-le' ) )
+
+
+def ComparePositions( a, b ):
+  """Returns < 0 if a is before b, 0 if a and b are equal and > 0 if a is
+  after b. a and b are both LSP positions."""
+
+  # If they are on the same line, compare character pos
+  if a[ 'line' ] == b[ 'line' ]:
+    return a[ 'character' ] - b[ 'character' ]
+  # otherwise, just compare the lines
+  return a[ 'line' ] - b[ 'line' ]
+
+
+def RangesOverlap( a, b ):
+  """Returns true if the LSP ranges a and b strictly overlap"""
+  # if the diag ends before the start of the cursor, it's not overlapping
+  if ComparePositions( a[ 'end' ], b[ 'start' ] ) < 0:
+    return False
+
+  # if the diag starts after the end of the cursor, it's not overlapping
+  if ComparePositions( a[ 'start' ], b[ 'end' ] ) > 0:
+    return False
+
+  # Otherwise it overaps in at least 1 char
+  return True
+
+
+def RangesOverlapLines( a, b ):
+  """Returns true if the LSP ranges a and b share any lines"""
+  if a[ 'end' ][ 'line' ] < b[ 'start' ][ 'line' ]:
+    return False
+
+  if a[ 'start' ][ 'line' ] > b[ 'end' ][ 'line' ]:
+    return False
+
+  return True

--- a/ycmd/tests/clangd/subcommands_test.py
+++ b/ycmd/tests/clangd/subcommands_test.py
@@ -604,7 +604,7 @@ def FixIt_Check_cpp11_Ins( results ):
           } ),
         } )
       ),
-      'location': has_entries( { 'line_num': 16, 'column_num': 0 } )
+      'location': has_entries( { 'line_num': 16, 'column_num': 1 } )
     } ) )
   } ) )
 
@@ -758,40 +758,6 @@ def FixIt_Check_cpp11_MultiFirst( results ):
         ),
         'location': has_entries( { 'line_num': 54, 'column_num': 15 } )
       } ),
-      # second fix-it at 54,52
-      has_entries( {
-        'kind': 'quickfix',
-        'chunks': contains_exactly(
-          has_entries( {
-            'replacement_text': equal_to( '' ),
-            'range': has_entries( {
-              'start': has_entries( { 'line_num': 54, 'column_num': 52 } ),
-              'end'  : has_entries( { 'line_num': 54, 'column_num': 53 } ),
-            } ),
-          } ),
-          has_entries( {
-            'replacement_text': equal_to( '~' ),
-            'range': has_entries( {
-              'start': has_entries( { 'line_num': 54, 'column_num': 58 } ),
-              'end'  : has_entries( { 'line_num': 54, 'column_num': 58 } ),
-            } ),
-          } ),
-        ),
-        'location': has_entries( { 'line_num': 54, 'column_num': 15 } )
-      } ),
-      has_entries( {
-        'kind': 'quickfix',
-        'chunks': contains_exactly(
-          has_entries( {
-            'replacement_text': equal_to( '= default;' ),
-            'range': has_entries( {
-              'start': has_entries( { 'line_num': 54, 'column_num': 64 } ),
-              'end'  : has_entries( { 'line_num': 54, 'column_num': 67 } ),
-            } ),
-          } )
-        ),
-        'location': has_entries( { 'line_num': 54, 'column_num': 15 } )
-      } ),
     )
   } ) )
 
@@ -799,20 +765,6 @@ def FixIt_Check_cpp11_MultiFirst( results ):
 def FixIt_Check_cpp11_MultiSecond( results ):
   assert_that( results, has_entries( {
     'fixits': contains_exactly(
-      # first fix-it at 54,16
-      has_entries( {
-        'kind': 'quickfix',
-        'chunks': contains_exactly(
-          has_entries( {
-            'replacement_text': equal_to( 'foo' ),
-            'range': has_entries( {
-              'start': has_entries( { 'line_num': 54, 'column_num': 16 } ),
-              'end'  : has_entries( { 'line_num': 54, 'column_num': 19 } ),
-            } ),
-          } )
-        ),
-        'location': has_entries( { 'line_num': 54, 'column_num': 51 } )
-      } ),
       # second fix-it at 54,52
       has_entries( {
         'kind': 'quickfix',
@@ -993,7 +945,7 @@ def FixIt_Check_AutoExpand_Resolved( results ):
 
 
 @pytest.mark.parametrize( 'line,column,language,filepath,check', [
-    [ 16, 0,  'cpp11', PathToTestFile( 'FixIt_Clang_cpp11.cpp' ),
+    [ 16, 1,  'cpp11', PathToTestFile( 'FixIt_Clang_cpp11.cpp' ),
       FixIt_Check_cpp11_Ins ],
     [ 25, 14, 'cpp11', PathToTestFile( 'FixIt_Clang_cpp11.cpp' ),
       FixIt_Check_cpp11_InsMultiLine ],
@@ -1009,7 +961,8 @@ def FixIt_Check_AutoExpand_Resolved( results ):
       FixIt_Check_objc_NoFixIt ],
     [ 3, 12,  'cuda', PathToTestFile( 'cuda', 'fixit_test.cu' ),
       FixIt_Check_cuda ],
-    # multiple errors on a single line; both with fixits
+    # multiple errors on a single line; both with fixits. The cursor is on the
+    # first one (so just that one is fixed)
     [ 54, 15, 'cpp11', PathToTestFile( 'FixIt_Clang_cpp11.cpp' ),
       FixIt_Check_cpp11_MultiFirst ],
     # should put closest fix-it first?

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -1021,6 +1021,8 @@ def LanguageServerCompleter_GetCodeActions_CursorOnEmptyLine_test( app ):
                      has_entry( 'fixits', empty() ) )
         assert_that(
           # Range passed to lsp.CodeAction.
+          # LSP requires to use the start of the next line as the end position
+          # for a range that ends with a newline.
           code_action.call_args[ 0 ][ 2 ],
           has_entries( {
             'start': has_entries( {
@@ -1028,7 +1030,7 @@ def LanguageServerCompleter_GetCodeActions_CursorOnEmptyLine_test( app ):
               'character': 0
             } ),
             'end': has_entries( {
-              'line': 0,
+              'line': 1,
               'character': 0
             } )
           } )

--- a/ycmd/tests/rust/subcommands_test.py
+++ b/ycmd/tests/rust/subcommands_test.py
@@ -496,7 +496,7 @@ def Subcommands_FixIt_Basic_test( app ):
     'request': {
       'command': 'FixIt',
       'line_num': 17,
-      'column_num': 13,
+      'column_num': 2,
       'filepath': filepath
     },
     'expect': {


### PR DESCRIPTION
The LSP has been clarified since we first implemented codeActions. It's
clear now from the spec that we shoud supply a range that corresponds to
the cursor position (or visual selection). The diagnostics supplied
should be those that overlap this position/range.

Where there is no visual seletion we have no choice but to supply an
(arbitrary) range which is the cursor position to the cursor position +
1 unicode character. It's not clear if that's strictly correct but
realistically it matches what editors like Vim actually do/show (a range
of 1 char).

Historically ycmd has provided FixIts for any diagnostics on the current
line. We retain that behaviour when there are no diagnostics that
overlap the actual cursor position - if so, we find any diagnostics that
overlap the line of cursor position (or range).

---

The functional effect of this is that running `FixIt` with the cursor on a specific diagnostic in clangd or jdt.ls will just fix that diagnostic, rather than ask you which one. It also opens up a bunch of new code actions such as "extract sub expression to variable" in clangd, which is questionable, but kinda cool.

cc @kadircet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1465)
<!-- Reviewable:end -->
