### PR TITLE
Remove unused import

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -29,7 +29,6 @@
 # For more information, please refer to <http://unlicense.org/>
 
 from distutils.sysconfig import get_python_inc
-import os
 import platform
 import os.path as p
 import subprocess


### PR DESCRIPTION
Remove unused  `import os` in [.ycm_extra_conf.py](../blob/master/.ycm_extra_conf.py)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1466)
<!-- Reviewable:end -->
