### PR TITLE
Fix build error with java because of env variable JAVA_TOOL_OPTIONS

### DIFF
--- a/build.py
+++ b/build.py
@@ -965,6 +965,11 @@ def CheckJavaVersion( required_version ):
     'java',
     f'java {required_version} is required to install JDT.LS' )
   java_version = None
+
+  java_tool_options=os.getenv('JAVA_TOOL_OPTIONS')
+
+  if(java_tool_options is not None):
+      os.unsetenv('JAVA_TOOL_OPTIONS')
   try:
     java_version = int(
       subprocess.check_output(
@@ -974,6 +979,8 @@ def CheckJavaVersion( required_version ):
       .strip() )
   except subprocess.CalledProcessError:
     pass
+
+  os.environ['JAVA_TOOL_OPTIONS']=java_tool_options
 
   if java_version is None or java_version < required_version:
     print( f'\n\n*** WARNING ***: jdt.ls requires Java { required_version }.'

--- a/build.py
+++ b/build.py
@@ -966,10 +966,10 @@ def CheckJavaVersion( required_version ):
     f'java {required_version} is required to install JDT.LS' )
   java_version = None
 
-  java_tool_options=os.getenv('JAVA_TOOL_OPTIONS')
+  java_tool_options = os.getenv( 'JAVA_TOOL_OPTIONS' )
 
-  if(java_tool_options is not None):
-      os.unsetenv('JAVA_TOOL_OPTIONS')
+  if( java_tool_options is not None ):
+      os.unsetenv( 'JAVA_TOOL_OPTIONS' )
   try:
     java_version = int(
       subprocess.check_output(
@@ -980,7 +980,7 @@ def CheckJavaVersion( required_version ):
   except subprocess.CalledProcessError:
     pass
 
-  os.environ['JAVA_TOOL_OPTIONS']=java_tool_options
+  os.environ[ 'JAVA_TOOL_OPTIONS' ] = java_tool_options
 
   if java_version is None or java_version < required_version:
     print( f'\n\n*** WARNING ***: jdt.ls requires Java { required_version }.'


### PR DESCRIPTION
There is an error one gets when building for java completions while having environment variable of JAVA_TOOL_OPTIONS, the value of that env will be printed and it's not an int, so we get errors. Made it such that the value of JAVA_TOOL_OPTIONS get saved into a variable and then cleared from env until we execute and get the version, then we reset the JAVA_TOOL_OPTIONS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1469)
<!-- Reviewable:end -->
