### PR TITLE
[READY] Resolve completion items on demand rather than upfront

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -220,6 +220,18 @@
                     </tr>
                     <tr>
                             <td class="swagger--summary-path" rowspan="1">
+                                <a href="#path--resolve_completion">/resolve_completion</a>
+                            </td>
+                        <td>
+                            <a href="#operation--resolve_completion-post">POST</a>
+                        </td>
+                        <td>
+                            <p>Resolve detailed_info for a completion item</p>
+        
+                        </td>
+                    </tr>
+                    <tr>
+                            <td class="swagger--summary-path" rowspan="1">
                                 <a href="#path--resolve_fixit">/resolve_fixit</a>
                             </td>
                         <td>
@@ -1652,6 +1664,214 @@
                 </div>
             </div>
         
+        <span id="path--resolve_completion"></span>
+            <div id="operation--resolve_completion-post" class="swagger--panel-operation-post panel">
+                <div class="panel-heading">
+                    <div class="operation-summary">Resolve detailed_info for a completion item</div>
+                    <h3 class="panel-title"><span class="operation-name">POST</span> <strong>/resolve_completion</strong></h3>
+                </div>
+                <div class="panel-body">
+                    <section class="sw-operation-description">
+                        <p>Given the <code>resolve</code> ID for a completion item, returns the item with
+            additional data filled in.</p>
+            <p>Note, the supplied <code>request_data</code> must match exactly the <code>request_data</code>
+            for the corresponding completion request, except with the <code>resolve</code> key
+            filled in with the <code>resolve</code> ID from the completion item&#39;s <code>extra_data</code>.</p>
+            
+                    </section>
+            
+                        
+                            <section class="sw-request-body">
+                                
+                                        <div class="row">
+                                            <div class="col-md-6">
+                                                <p><p>The context data, including the current cursor position, and details
+                        of dirty buffers.</p>
+                        </p>
+                                            </div>
+                                            <div class="col-md-6 sw-request-model">
+                            <div  class="panel panel-definition">
+                                <div class="panel-body">
+                                        
+                                                <section class="json-schema-properties">
+                                                    <dl>
+                                                            <dt data-property-name="line_num">
+                                                                <span class="json-property-name">line_num:</span>
+                                                                
+                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/LineNumber">LineNumber</a>
+                                                                </span>
+                                                                <span class="json-property-range" title="Value limits"></span>
+                                                                
+                                                                    <span class="json-property-required"></span>
+                                                            </dt>
+                                                            <dd>
+                                                                
+                                                                <div class="json-inner-schema">
+                                                                    
+                                                                </div>
+                                                            </dd>
+                                                            <dt data-property-name="column_num">
+                                                                <span class="json-property-name">column_num:</span>
+                                                                
+                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/ColumnNumber">ColumnNumber</a>
+                                                                </span>
+                                                                <span class="json-property-range" title="Value limits"></span>
+                                                                
+                                                                    <span class="json-property-required"></span>
+                                                            </dt>
+                                                            <dd>
+                                                                
+                                                                <div class="json-inner-schema">
+                                                                    
+                                                                </div>
+                                                            </dd>
+                                                            <dt data-property-name="filepath">
+                                                                <span class="json-property-name">filepath:</span>
+                                                                
+                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/FilePath">FilePath</a>
+                                                                </span>
+                                                                <span class="json-property-range" title="Value limits"></span>
+                                                                
+                                                                    <span class="json-property-required"></span>
+                                                            </dt>
+                                                            <dd>
+                                                                
+                                                                <div class="json-inner-schema">
+                                                                    
+                                                                </div>
+                                                            </dd>
+                                                            <dt data-property-name="file_data">
+                                                                <span class="json-property-name">file_data:</span>
+                                                                
+                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/FileDataMap">FileDataMap</a>
+                                                                </span>
+                                                                <span class="json-property-range" title="Value limits"></span>
+                                                                
+                                                                    <span class="json-property-required"></span>
+                                                            </dt>
+                                                            <dd>
+                                                                
+                                                                <div class="json-inner-schema">
+                                                                    
+                                                                </div>
+                                                            </dd>
+                                                            <dt data-property-name="completer_target">
+                                                                <span class="json-property-name">completer_target:</span>
+                                                                
+                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/CompleterTarget">CompleterTarget</a>
+                                                                </span>
+                                                                <span class="json-property-range" title="Value limits"></span>
+                                                                
+                                                            </dt>
+                                                            <dd>
+                                                                
+                                                                <div class="json-inner-schema">
+                                                                    
+                                                                </div>
+                                                            </dd>
+                                                            <dt data-property-name="working_dir">
+                                                                <span class="json-property-name">working_dir:</span>
+                                                                
+                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/WorkingDirectory">WorkingDirectory</a>
+                                                                </span>
+                                                                <span class="json-property-range" title="Value limits"></span>
+                                                                
+                                                            </dt>
+                                                            <dd>
+                                                                
+                                                                <div class="json-inner-schema">
+                                                                    
+                                                                </div>
+                                                            </dd>
+                                                            <dt data-property-name="extra_conf_data">
+                                                                <span class="json-property-name">extra_conf_data:</span>
+                                                                
+                                                                <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/ExtraConfData">ExtraConfData</a>
+                                                                </span>
+                                                                <span class="json-property-range" title="Value limits"></span>
+                                                                
+                                                            </dt>
+                                                            <dd>
+                                                                
+                                                                <div class="json-inner-schema">
+                                                                    
+                                                                </div>
+                                                            </dd>
+                                                            <dt data-property-name="resolve">
+                                                                <span class="json-property-name">resolve:</span>
+                                                                
+                                                                <span class="json-property-type">object</span>
+                                                                <span class="json-property-range" title="Value limits"></span>
+                                                                
+                                                                    <span class="json-property-required"></span>
+                                                            </dt>
+                                                            <dd>
+                                                                <p>The &#39;resolve&#39; key from the &#39;extra_data&#39; in the completion item
+                                                to resolve.</p>
+                                                
+                                                                <div class="json-inner-schema">
+                                                                    
+                                                                </div>
+                                                            </dd>
+                                                    </dl>
+                                                </section>
+                                </div>
+                            </div></div>
+                                        </div>
+                            </section>        
+                    
+                        <section class="sw-responses">
+                                <p><span class="label label-default">application/json</span> 
+                    </p>
+                    
+                            <dl>
+                                    <dt class="sw-response-200">
+                                        200 OK
+                                    
+                                    </dt>
+                                    <dd class="sw-response-200">
+                                            <div class="row">
+                                                <div class="col-md-12">
+                                                    <p>The list of completion suggestions.</p>
+                                            
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                
+                                                <div class="col-md-6 sw-response-model">
+                                                <div  class="panel panel-definition">
+                                                    <div class="panel-body">
+                                                                <a class="json-schema-ref" href="#/definitions/ResolveCompletionResponse">ResolveCompletionResponse</a>
+                                                    </div>
+                                                </div></div>
+                                            
+                                            </div>                </dd>
+                                    <dt class="sw-response-500">
+                                        500 Internal Server Error
+                                    
+                                    </dt>
+                                    <dd class="sw-response-500">
+                                            <div class="row">
+                                                <div class="col-md-12">
+                                                    <p>An error occurred.</p>
+                                            
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                
+                                                <div class="col-md-6 sw-response-model">
+                                                <div  class="panel panel-definition">
+                                                    <div class="panel-body">
+                                                                <a class="json-schema-ref" href="#/definitions/ExceptionResponse">ExceptionResponse</a>
+                                                    </div>
+                                                </div></div>
+                                            
+                                            </div>                </dd>
+                            </dl>
+                        </section>
+                </div>
+            </div>
+        
         <span id="path--resolve_fixit"></span>
             <div id="operation--resolve_fixit-post" class="swagger--panel-operation-post panel">
                 <div class="panel-heading">
@@ -2863,6 +3083,45 @@
                                                                                     
                                                                                 </div>
                                                                             </dd>
+                                                                            <dt data-property-name="fixits">
+                                                                                <span class="json-property-name">fixits:</span>
+                                                                                
+                                                                                <span class="json-property-type">object[]</span>
+                                                                                <span class="json-property-range" title="Value limits"></span>
+                                                                                
+                                                                            </dt>
+                                                                            <dd>
+                                                                                <p>Any editional edits to apply when selecting this completion</p>
+                                                                
+                                                                                <div class="json-inner-schema">
+                                                                                    
+                                                                                                    <section class="json-schema-array-items">
+                                                                                                        
+                                                                                                        <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/FixIt">FixIt</a>
+                                                                                                        </span>
+                                                                                                        <span class="json-property-range" title="Value limits"></span>
+                                                                                                        
+                                                                                                        <div class="json-inner-schema">
+                                                                                                            
+                                                                                                        </div>
+                                                                                                    </section>                </div>
+                                                                            </dd>
+                                                                            <dt data-property-name="resolve">
+                                                                                <span class="json-property-name">resolve:</span>
+                                                                                
+                                                                                <span class="json-property-type">number</span>
+                                                                                <span class="json-property-range" title="Value limits"></span>
+                                                                                
+                                                                            </dt>
+                                                                            <dd>
+                                                                                <p>Identifier used to resolve this completion item using
+                                                                /resolve_completion. If not supplied, the item is already
+                                                                fully resolved.</p>
+                                                                
+                                                                                <div class="json-inner-schema">
+                                                                                    
+                                                                                </div>
+                                                                            </dd>
                                                                     </dl>
                                                                 </section>
                                                     </div>
@@ -3979,6 +4238,63 @@
                                                     <div class="json-inner-schema">
                                                         
                                                     </div>
+                                                </dd>
+                                        </dl>
+                                    </section>
+                    </div>
+                </div>        
+                <div id="definition-ResolveCompletionResponse" class="panel panel-definition">
+                        <div class="panel-heading">
+                                <h3 class="panel-title"><a name="/definitions/ResolveCompletionResponse"></a>ResolveCompletionResponse:
+                                    <span class="json-property-type">
+                <span class="json-property-type">object</span>
+                <span class="json-property-range" title="Value limits"></span>
+                
+                </span>
+                                </h3>
+                        </div>
+                    <div class="panel-body">
+                            
+                                    <section class="json-schema-properties">
+                                        <dl>
+                                                <dt data-property-name="completion">
+                                                    <span class="json-property-name">completion:</span>
+                                                    
+                                                    <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/Candidate">Candidate</a>
+                                                    </span>
+                                                    <span class="json-property-range" title="Value limits"></span>
+                                                    
+                                                        <span class="json-property-required"></span>
+                                                </dt>
+                                                <dd>
+                                                    
+                                                    <div class="json-inner-schema">
+                                                        
+                                                    </div>
+                                                </dd>
+                                                <dt data-property-name="errors">
+                                                    <span class="json-property-name">errors:</span>
+                                                    
+                                                    <span class="json-property-type">object[]</span>
+                                                    <span class="json-property-range" title="Value limits"></span>
+                                                    
+                                                        <span class="json-property-required"></span>
+                                                </dt>
+                                                <dd>
+                                                    <p>Any errors reported by the semantic completion engine.</p>
+                                    
+                                                    <div class="json-inner-schema">
+                                                        
+                                                                        <section class="json-schema-array-items">
+                                                                            
+                                                                            <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/ExceptionResponse">ExceptionResponse</a>
+                                                                            </span>
+                                                                            <span class="json-property-range" title="Value limits"></span>
+                                                                            
+                                                                            <div class="json-inner-schema">
+                                                                                
+                                                                            </div>
+                                                                        </section>                </div>
                                                 </dd>
                                         </dl>
                                     </section>

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -480,6 +480,19 @@ definitions:
             description: |-
               Additional documentation/information to be displayed
               alongside (after) information in `detailed_info`.
+          fixits:
+            type: array
+            description: |-
+              Any editional edits to apply when selecting this completion
+            items:
+              $ref: "#/definitions/FixIt"
+          resolve:
+            type: number
+            description: |-
+              Identifier used to resolve this completion item using
+              /resolve_completion. If not supplied, the item is already
+              fully resolved.
+
 
   CompletionResponse:
     type: object
@@ -498,6 +511,20 @@ definitions:
           1-based byte index of the column from which the completion should be
           applied. This is the column in which the words suggested in
           `completions` should be placed.
+      errors:
+        type: array
+        description: Any errors reported by the semantic completion engine.
+        items:
+          $ref: "#/definitions/ExceptionResponse"
+
+  ResolveCompletionResponse:
+    type: object
+    required:
+      - completion
+      - errors
+    properties:
+      completion:
+        $ref: "#/definitions/Candidate"
       errors:
         type: array
         description: Any errors reported by the semantic completion engine.
@@ -931,6 +958,62 @@ paths:
           description: An error occurred.
           schema:
             $ref: "#/definitions/ExceptionResponse"
+  /resolve_completion:
+    post:
+      summary: Resolve detailed_info for a completion item
+      description: |-
+        Given the `resolve` ID for a completion item, returns the item with
+        additional data filled in.
+
+        Note, the supplied `request_data` must match exactly the `request_data`
+        for the corresponding completion request, except with the `resolve` key
+        filled in with the `resolve` ID from the completion item's `extra_data`.
+      produces:
+        - application/json
+      parameters:
+        - name: request_data
+          in: body
+          description: |-
+            The context data, including the current cursor position, and details
+            of dirty buffers.
+          required: true
+          schema:
+            type: object
+            required:
+              - line_num
+              - column_num
+              - filepath
+              - file_data
+              - resolve
+            properties:
+              line_num:
+                $ref: "#/definitions/LineNumber"
+              column_num:
+                $ref: "#/definitions/ColumnNumber"
+              filepath:
+                $ref: "#/definitions/FilePath"
+              file_data:
+                $ref: "#/definitions/FileDataMap"
+              completer_target:
+                $ref: "#/definitions/CompleterTarget"
+              working_dir:
+                $ref: "#/definitions/WorkingDirectory"
+              extra_conf_data:
+                $ref: "#/definitions/ExtraConfData"
+              resolve:
+                description: |-
+                  The 'resolve' key from the 'extra_data' in the completion item
+                  to resolve.
+      responses:
+        200:
+          description: The list of completion suggestions.
+          schema:
+            $ref: "#/definitions/ResolveCompletionResponse"
+        500:
+          description: An error occurred.
+          schema:
+            $ref: "#/definitions/ExceptionResponse"
+
 
   /signature_help_available:
     get:

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -937,6 +937,13 @@ class LanguageServerCompleter( Completer ):
     pass # pragma: no cover
 
 
+  # Resolve all completion items up-front
+  RESOLVE_ALL = True
+
+  # Don't resolve any completion items, but prepare them for resolve
+  RESOLVE_NONE = False
+
+
   def __init__( self, user_options, connection_type = 'stdio' ):
     super().__init__( user_options )
 
@@ -1263,10 +1270,11 @@ class LanguageServerCompleter( Completer ):
     # should be based on ycmd's version of the insertion_text. Fortunately it's
     # likely much quicker to do the simple calculations inline rather than a
     # series of potentially many blocking server round trips.
-    return ( self._CandidatesFromCompletionItems( items,
-                                                  False, # don't do resolve
-                                                  request_data ),
-             is_incomplete )
+    return ( self._CandidatesFromCompletionItems(
+              items,
+              LanguageServerCompleter.RESOLVE_NONE,
+              request_data ),
+            is_incomplete )
 
 
   def _GetCandidatesFromSubclass( self, request_data ):
@@ -1287,7 +1295,9 @@ class LanguageServerCompleter( Completer ):
 
   def DetailCandidates( self, request_data, completions ):
     if not self._resolve_completion_items:
-      # We already did all of the work.
+      return completions
+
+    if not self.ShouldDetailCandidateList( completions ):
       return completions
 
     # Note: _CandidatesFromCompletionItems does a lot of work on the actual
@@ -1300,8 +1310,19 @@ class LanguageServerCompleter( Completer ):
     # text. See the fixup algorithm for more details on that.
     return self._CandidatesFromCompletionItems(
       [ c[ 'extra_data' ][ 'item' ] for c in completions ],
-      True, # Do a full resolve
+      LanguageServerCompleter.RESOLVE_ALL,
       request_data )
+
+
+  def DetailSingleCandidate( self, request_data, completions, to_resolve ):
+    completion = completions[ to_resolve ]
+    if not self._resolve_completion_items:
+      return completion
+
+    return self._CandidatesFromCompletionItems(
+      [ completion[ 'extra_data' ][ 'item' ] ],
+      LanguageServerCompleter.RESOLVE_ALL,
+      request_data )[ 0 ]
 
 
   def _ResolveCompletionItem( self, item ):
@@ -1329,7 +1350,10 @@ class LanguageServerCompleter( Completer ):
       'resolveProvider', False )
 
 
-  def _CandidatesFromCompletionItems( self, items, resolve, request_data ):
+  def _CandidatesFromCompletionItems( self,
+                                      items,
+                                      resolve_completions,
+                                      request_data ):
     """Issue the resolve request for each completion item in |items|, then fix
     up the items such that a single start codepoint is used."""
 
@@ -1371,10 +1395,15 @@ class LanguageServerCompleter( Completer ):
     # First generate all of the completion items and store their
     # start_codepoints. Then, we fix-up the completion texts to use the
     # earliest start_codepoint by borrowing text from the original line.
-    for item in items:
-      if resolve and not item.get( '_resolved', False ):
+    for idx, item in enumerate( items ):
+      this_tem_is_resolved = item.get( '_resolved', False )
+
+      if ( resolve_completions and
+           not this_tem_is_resolved and
+           self._resolve_completion_items ):
         self._ResolveCompletionItem( item )
         item[ '_resolved' ] = True
+        this_tem_is_resolved = True
 
       try:
         insertion_text, extra_data, start_codepoint = (
@@ -1384,10 +1413,15 @@ class LanguageServerCompleter( Completer ):
                           item )
         continue
 
-      if not resolve and self._resolve_completion_items:
-        # Store the actual item in the extra_data area of the completion item.
-        # We'll use this later to do the full resolve.
+      if not resolve_completions and self._resolve_completion_items:
         extra_data = {} if extra_data is None else extra_data
+
+        # Deferred resolve - the client must read this and send the
+        # /resolve_completion request to update the candidate set
+        extra_data[ 'resolve' ] = idx
+
+        # Store the actual item in the extra_data area of the completion item.
+        # We'll use this later to do the resolve.
         extra_data[ 'item' ] = item
 
       min_start_codepoint = min( min_start_codepoint, start_codepoint )
@@ -2152,6 +2186,13 @@ class LanguageServerCompleter( Completer ):
       self._server_capabilities = response[ 'result' ][ 'capabilities' ]
       self._resolve_completion_items = self._ShouldResolveCompletionItems()
 
+      if self._resolve_completion_items:
+        LOGGER.info( '%s: Language server requires resolve request',
+                     self.Langauge() )
+      else:
+        LOGGER.info( '%s: Language server does not require resolve request',
+                     self.Langauge() )
+
       self._is_completion_provider = (
           'completionProvider' in self._server_capabilities )
 
@@ -2172,7 +2213,8 @@ class LanguageServerCompleter( Completer ):
             sync = 1
 
         self._sync_type = SYNC_TYPE[ sync ]
-        LOGGER.info( 'Language server requires sync type of %s',
+        LOGGER.info( '%s: Language server requires sync type of %s',
+                     self.Langauge(),
                      self._sync_type )
 
       # Update our semantic triggers if they are supplied by the server

--- a/ycmd/default_settings.json
+++ b/ycmd/default_settings.json
@@ -10,6 +10,7 @@
   "collect_identifiers_from_comments_and_strings": 0,
   "max_num_identifier_candidates": 10,
   "max_num_candidates": 50,
+  "max_num_candidates_to_detail": -1,
   "extra_conf_globlist": [],
   "global_ycm_extra_conf": "",
   "confirm_extra_conf": 1,

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -27,6 +27,7 @@ from bottle import request
 from ycmd import extra_conf_store, hmac_plugin, server_state, user_options_store
 from ycmd.responses import ( BuildExceptionResponse,
                              BuildCompletionResponse,
+                             BuildResolveCompletionResponse,
                              BuildSignatureHelpResponse,
                              BuildSignatureHelpAvailableResponse,
                              SignatureHelpAvailalability,
@@ -140,6 +141,22 @@ def GetCompletions():
       BuildCompletionResponse( completions if completions else [],
                                request_data[ 'start_column' ],
                                errors = errors ) )
+
+
+@app.post( '/resolve_completion' )
+def ResolveCompletionItem():
+  LOGGER.info( "Received resolve request" )
+  request_data = RequestWrap( request.json )
+  completer = _GetCompleterForRequestData( request_data )
+
+  errors = None
+  completion = None
+  try:
+    completion = completer.ResolveCompletionItem( request_data )
+  except Exception as e:
+    errors = [ BuildExceptionResponse( e, traceback.format_exc() ) ]
+
+  return _JsonResponse( BuildResolveCompletionResponse( completion, errors ) )
 
 
 @app.post( '/signature_help' )

--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -137,6 +137,13 @@ def BuildCompletionResponse( completions,
   }
 
 
+def BuildResolveCompletionResponse( completion, errors ):
+  return {
+    'completion': completion,
+    'errors': errors if errors else [],
+  }
+
+
 def BuildSignatureHelpResponse( signature_info, errors = None ):
   return {
     'signature_help':

--- a/ycmd/tests/go/get_completions_test.py
+++ b/ycmd/tests/go/get_completions_test.py
@@ -15,7 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-from hamcrest import all_of, assert_that, has_items
+from hamcrest import ( all_of,
+                       assert_that,
+                       has_items,
+                       has_key,
+                       is_not )
 
 from ycmd.tests.go import PathToTestFile, SharedYcmd
 from ycmd.tests.test_utils import ( BuildRequest,
@@ -64,3 +68,8 @@ def GetCompletions_Basic_test( app ):
                        'kind': 'Struct',
                      }
                    ) ) ) )
+
+
+  # This completer does not require or support resolve
+  assert_that( results[ 0 ], is_not( has_key( 'resolve' ) ) )
+  assert_that( results[ 0 ], is_not( has_key( 'item' ) ) )

--- a/ycmd/tests/java/get_completions_test.py
+++ b/ycmd/tests/java/get_completions_test.py
@@ -43,7 +43,8 @@ from ycmd.tests.test_utils import ( ClearCompletionsCache,
                                     CompletionEntryMatcher,
                                     ErrorMatcher,
                                     LocationMatcher,
-                                    WithRetry )
+                                    WithRetry,
+                                    UnixOnly )
 from ycmd.utils import ReadFile
 from unittest.mock import patch
 from ycmd.completers.completer import CompletionsChanged
@@ -554,6 +555,7 @@ def GetCompletions_ServerNotInitialized_test( app ):
     } )
 
 
+@UnixOnly
 @SharedYcmd
 def GetCompletions_MoreThan10_NoResolve_ThenResolve_test( app ):
   ClearCompletionsCache()
@@ -630,6 +632,7 @@ def GetCompletions_MoreThan10_NoResolve_ThenResolve_test( app ):
 
 
 
+@UnixOnly
 @SharedYcmd
 def GetCompletions_FewerThan10_Resolved_test( app ):
   ClearCompletionsCache()
@@ -675,6 +678,7 @@ def GetCompletions_FewerThan10_Resolved_test( app ):
 
 
 
+@UnixOnly
 @SharedYcmd
 def GetCompletions_MoreThan10_NoResolve_ThenResolveCacheBad_test( app ):
   ClearCompletionsCache()
@@ -732,6 +736,7 @@ def GetCompletions_MoreThan10_NoResolve_ThenResolveCacheBad_test( app ):
 
 
 
+@UnixOnly
 @SharedYcmd
 def GetCompletions_MoreThan10ForceSemantic_test( app ):
   ClearCompletionsCache()

--- a/ycmd/tests/java/testdata/simple_eclipse_project/src/com/test/MethodsWithDocumentation.java
+++ b/ycmd/tests/java/testdata/simple_eclipse_project/src/com/test/MethodsWithDocumentation.java
@@ -1,0 +1,36 @@
+package com.test;
+
+public class MethodsWithDocumentation {
+
+  /**
+   * This is the contructor
+   */
+  public MethodsWithDocumentation() {
+  }
+
+  /**
+   * Single line description.
+   *
+   * @return a string
+   */
+  public String getAString() {
+    return "";
+  }
+
+  /**
+   * Multiple lines of
+   * description
+   * here.
+   *
+   * @param s a string
+   */
+  public void useAString( String s ) {
+  }
+
+
+  public static void main( String[] args ) {
+    MethodsWithDocumentation m = new MethodsWithDocumentation();
+    m.useAString( m.getAString() );
+    m.hashCode();
+  }
+}

--- a/ycmd/tests/rust/get_completions_test.py
+++ b/ycmd/tests/rust/get_completions_test.py
@@ -15,7 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-from hamcrest import assert_that, contains_exactly
+from hamcrest import ( assert_that,
+                       contains_exactly,
+                       empty,
+                       has_key,
+                       is_not )
+from pprint import pformat
+
 
 from ycmd.tests.rust import PathToTestFile, SharedYcmd
 from ycmd.tests.test_utils import ( BuildRequest,
@@ -62,3 +68,18 @@ def GetCompletions_Basic_test( app ):
       )
     )
   )
+
+  # This completer does not require or support resolve
+  assert_that( results[ 0 ], is_not( has_key( 'resolve' ) ) )
+  assert_that( results[ 0 ], is_not( has_key( 'item' ) ) )
+
+  # So (erroneously) resolving an item returns the item
+  completion_data[ 'resolve' ] = 0
+  response = app.post_json( '/resolve_completion', completion_data ).json
+  print( f"Resolve resolve: { pformat( response ) }" )
+
+  # We can't actually check the result because we don't know what completion
+  # resolve ID 0 actually is (could be anything), so we just check that we get 1
+  # result, and that there are no errors.
+  assert_that( response[ 'completion' ], is_not( None ) )
+  assert_that( response[ 'errors' ], empty() )

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -52,6 +52,11 @@ ycm_core = ImportCore()
 from unittest import skipIf
 
 TESTS_DIR = os.path.abspath( os.path.dirname( __file__ ) )
+TEST_OPTIONS = {
+  # The 'client' represented by the tests supports on-demand resolve, but the
+  # server default config doesn't for backward compatibility
+  'max_num_candidates_to_detail': 10
+}
 
 WindowsOnly = skipIf( not OnWindows(), 'Windows only' )
 ClangOnly = skipIf( not ycm_core.HasClangSupport(),
@@ -237,6 +242,7 @@ def TemporarySymlink( source, link ):
 def SetUpApp( custom_options = {} ):
   bottle.debug( True )
   options = user_options_store.DefaultOptions()
+  options.update( TEST_OPTIONS )
   options.update( custom_options )
   handlers.UpdateUserOptions( options )
   extra_conf_store.Reset()
@@ -399,8 +405,7 @@ def WithRetry( test ):
     expiry = time.time() + 30
     while True:
       try:
-        test( *args, **kwargs )
-        return
+        return test( *args, **kwargs )
       except Exception as test_exception:
         if time.time() > expiry:
           raise


### PR DESCRIPTION
Again, opening this for thoughts while testing.

Previously we would do completion/resolve for every matching completion candidate up front. This was also embarrassingly serial. For 100 candidates, we'd do 100 synchronous resolve requests. This can lead to timeouts.

This leads to unusable performance on the Godot server (because for some reason there are a lot of candidates and they take a _long_ time to resolve serially).

So we implement an endpoint to resolve a completion item on-demand, and change the resolve behaviour so that we only ever resolve 10 candidates up-front.

The approach is to add a `'resolve'` key to the `extra_data` dictionary which is an ID telling the client that this item needs to be resolved to fill in the extra data documentation. If this key is not present, resolve is not required.

Couple of things to note:

1. we resolve up to 10 _matching_ candidates (i.e. we still do FilterAndSortCandidates _first_)
2. we therefore still have a mixture of resolved and un-resolved candidates in the cache
3. we only allow resolving a candidate if there is a cache HIT for the request data. this means we can use the index into the full set of items as the "key" for what to resolve.
4. we don't resolve things multiple times. for candidates that are already resolved, we don't include the 'resolve' key which tells the client that it might need resolving.


Client changes are here: https://github.com/puremourning/YouCompleteMe/tree/resolve (also very much WIP right now)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1473)
<!-- Reviewable:end -->
