### PR TITLE
[READY] Do not set architecture on Windows when using Ninja

### DIFF
--- a/build.py
+++ b/build.py
@@ -495,7 +495,7 @@ def GetCmakeCommonArgs( args ):
   cmake_args = [ '-G', GetGenerator( args ) ]
 
   # Set the architecture for the Visual Studio 16 generator.
-  if OnWindows() and args.msvc == 16:
+  if OnWindows() and args.msvc == 16 and not args.ninja:
     arch = 'x64' if IS_64BIT else 'Win32'
     cmake_args.extend( [ '-A', arch ] )
 


### PR DESCRIPTION
Passing `-A` flag to CMake, in combination with `-G Ninja` errors with:

```
CMake Error at CMakeLists.txt:26 (project):
  Generator

    Ninja

  does not support platform specification, but platform

    x64

  was specified.
```

Fixes #1467

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1475)
<!-- Reviewable:end -->
