### PR TITLE
[READY] Support generating a port when connecting to LS over TCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,10 @@ wouldn't usually know about. The value is a list of dictionaries containing:
 
 - `name`: the string representing the name of the server
 - `cmdline`: the list representing the command line to execute the server
+  (optional; mandatory if port not specified)
+- `port`: optional. If specified, a TCP connection is used to this port. If set
+  to `*`, an unused locall port is selected and made availble in the `cmdline`
+  as `${port}` (see below examples).
 - `filetypes`: list of supported filetypes.
 - `project_root_files`: Tells ycmd which files indicate project root.
 - `capabilities'`: Overrides the default LSP capabilities of ycmd.
@@ -293,6 +297,34 @@ wouldn't usually know about. The value is a list of dictionaries containing:
   } ]
 }
 ```
+
+Or, to use a TCP connection:
+
+```json
+{
+  "language_server": [ {
+    "name": "godot",
+    "port": "6008",
+    "filetypes": [ "gdscript" ]
+  } ]
+}
+```
+
+Or, to use an unused  local port, set `port` to `*` and use `${port}` in the
+`cmdline`:
+
+```json
+{
+  "language_server": [ {
+    "name": "someserver",
+    "cmdline": [ "/path/to/some/server", "--port", "${port}" ],
+    "port": "*",
+    "filetypes": [ "somethign" ],
+    "project_root_files": [ "somethingfile" ]
+  } ]
+}
+```
+
 
 When plugging in a completer in this way, the `kwargs[ 'language' ]` will be set
 to the value of the `name` key, i.e. `gopls` in the above example.

--- a/ycmd/completers/language_server/generic_lsp_completer.py
+++ b/ycmd/completers/language_server/generic_lsp_completer.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
+import string
 from ycmd import responses, utils
 from ycmd.completers.language_server import language_server_completer
 
@@ -30,12 +31,20 @@ class GenericLSPCompleter( language_server_completer.LanguageServerCompleter ):
     self._port = server_settings.get( 'port' )
     if self._port:
       connection_type = 'tcp'
+      if self._port == '*':
+        self._port = utils.GetUnusedLocalhostPort()
     else:
       connection_type = 'stdio'
 
     if self._command_line:
       self._command_line[ 0 ] = utils.FindExecutable(
         self._command_line[ 0 ] )
+
+      for idx in range( len( self._command_line ) ):
+        self._command_line[ idx ] = string.Template(
+          self._command_line[ idx ] ).safe_substitute( {
+            'port': self._port
+          } )
 
     super().__init__( user_options, connection_type )
 

--- a/ycmd/tests/language_server/generic_completer_test.py
+++ b/ycmd/tests/language_server/generic_completer_test.py
@@ -193,7 +193,56 @@ def GenericLSPCompleter_DebugInfo_TCP_test( app ):
         'name': 'fooCompleter',
         'port': TEST_PORT,
         'pid': instance_of( int ),
-        'logfiles': contains_exactly( instance_of( str ) ),
+        'logfiles': contains_exactly( instance_of( str ),
+                                      instance_of( str ) ),
+        'extras': contains_exactly(
+          has_entries( {
+            'key': 'Server State',
+            'value': instance_of( str ),
+          } ),
+          has_entries( {
+            'key': 'Project Directory',
+            'value': PathToTestFile( 'generic_server' ),
+          } ),
+          has_entries( {
+            'key': 'Settings',
+            'value': '{}'
+          } ),
+        )
+      } ) ),
+    } ) )
+  )
+
+
+@IsolatedYcmd( { 'language_server':
+  [ { 'name': 'foo',
+      'filetypes': [ 'foo' ],
+      'cmdline': [ 'node',
+                   PATH_TO_GENERIC_COMPLETER,
+                   '--listen', '${port}' ],
+      'port': '*' } ] } )
+def GenericLSPCompleter_DebugInfo_TCP_GeneratePort_test( app ):
+  request = BuildRequest( filepath = TEST_FILE,
+                          filetype = 'foo',
+                          line_num = 1,
+                          column_num = 1,
+                          contents = TEST_FILE_CONTENT,
+                          event_name = 'FileReadyToParse' )
+  app.post_json( '/event_notification', request )
+  WaitUntilCompleterServerReady( app, 'foo' )
+
+  request.pop( 'event_name' )
+  response = app.post_json( '/debug_info', request ).json
+  assert_that(
+    response,
+    has_entry( 'completer', has_entries( {
+      'name': 'GenericLSP',
+      'servers': contains_exactly( has_entries( {
+        'name': 'fooCompleter',
+        'port': instance_of( int ),
+        'pid': instance_of( int ),
+        'logfiles': contains_exactly( instance_of( str ),
+                                      instance_of( str ) ),
         'extras': contains_exactly(
           has_entries( {
             'key': 'Server State',


### PR DESCRIPTION
In the scenario where we are starting the server then connecting to it
over TCP, it makes sense to use an unused local port, rather than
requiring the user hard-code one in their configuration.

This change allows the Generic LSP config to set 'port' to '*' in which
case an unused local port is selected and used. The selected port is
made available to the 'cmdline' as '${port}'.

This is needed to support the new PHP completer in a better way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1482)
<!-- Reviewable:end -->
