### PR TITLE
[READY] Make test reliable - use a file that's not changing to get the docs

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -8,4 +8,4 @@ coverage              >= 4.2
 codecov               >= 2.0.5
 pytest
 pytest-cov
-flaky                 >= 3.7.0
+pytest-rerunfailures

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -8,3 +8,4 @@ coverage              >= 4.2
 codecov               >= 2.0.5
 pytest
 pytest-cov
+flaky                 >= 3.7.0

--- a/valgrind.suppressions
+++ b/valgrind.suppressions
@@ -455,3 +455,30 @@
 	fun:cfunction_vectorcall_FASTCALL_KEYWORDS
 	fun:_PyObject_Vectorcall
 }
+{
+	<insert_a_suppression_name_here>
+	Memcheck:Leak
+	match-leak-kinds: possible
+	fun:malloc
+	fun:new_keys_object
+	fun:insert_to_emptydict
+	fun:_PyDict_SetItem_KnownHash
+	fun:bounded_lru_cache_wrapper
+	fun:_PyObject_MakeTpCall
+	fun:_PyObject_Vectorcall
+	fun:trace_call_function
+	fun:call_function
+	fun:_PyEval_EvalFrameDefault
+	fun:function_code_fastcall
+	fun:_PyObject_Vectorcall
+	fun:call_function
+	fun:_PyEval_EvalFrameDefault
+	fun:function_code_fastcall
+	fun:_PyObject_Vectorcall
+	fun:call_function
+	fun:_PyEval_EvalFrameDefault
+	fun:function_code_fastcall
+	fun:_PyObject_Vectorcall
+	fun:method_vectorcall
+	fun:PyVectorcall_Call
+}

--- a/ycmd/tests/clangd/subcommands_test.py
+++ b/ycmd/tests/clangd/subcommands_test.py
@@ -983,7 +983,6 @@ def Subcommands_FixIt_all_test( app, line, column, language, filepath, check ):
   RunFixItTest( app, line, column, language, filepath, check )
 
 
-@WithRetry
 def RunRangedFixItTest( app, rng, expected, chosen_fixit = 0 ):
   contents = ReadFile( PathToTestFile( 'FixIt_Clang_cpp11.cpp' ) )
   args = {
@@ -1010,6 +1009,7 @@ def RunRangedFixItTest( app, rng, expected, chosen_fixit = 0 ):
   expected( response )
 
 
+@WithRetry
 @pytest.mark.parametrize( 'test', [
     [ {
         'start': { 'line_num': 80, 'column_num': 1 },
@@ -1068,6 +1068,7 @@ def Subcommands_FixIt_AlreadyResolved_test( app ):
   assert_that( actual, equal_to( expected ) )
 
 
+@WithRetry
 @IsolatedYcmd( { 'clangd_args': [ '-hidden-features' ] } )
 def Subcommands_FixIt_ClangdTweaks_test( app ):
   selection = {

--- a/ycmd/tests/go/get_completions_test.py
+++ b/ycmd/tests/go/get_completions_test.py
@@ -28,7 +28,7 @@ from ycmd.tests.test_utils import ( BuildRequest,
 from ycmd.utils import ReadFile
 
 
-@WithRetry
+@WithRetry( reruns = 100 )
 @SharedYcmd
 def GetCompletions_Basic_test( app ):
   filepath = PathToTestFile( 'td', 'test.go' )

--- a/ycmd/tests/java/diagnostics_test.py
+++ b/ycmd/tests/java/diagnostics_test.py
@@ -25,7 +25,8 @@ from hamcrest import ( assert_that,
                        equal_to,
                        has_entries,
                        has_entry,
-                       has_item )
+                       has_item,
+                       matches_regexp )
 
 from ycmd.tests.java import ( DEFAULT_PROJECT_DIR,
                               IsolatedYcmd,
@@ -210,6 +211,11 @@ DIAG_MATCHERS_PER_FILE = {
                                         ( 13, 23 ) ) ),
       'fixit_available': False
     } ),
+  ),
+  PathToTestFile( DEFAULT_PROJECT_DIR, 'test.java' ): contains_exactly(
+    has_entries( {
+      'text': matches_regexp( 'test.java is not on the classpath .*' )
+    } )
   ),
 }
 

--- a/ycmd/tests/java/get_completions_test.py
+++ b/ycmd/tests/java/get_completions_test.py
@@ -58,7 +58,6 @@ def ProjectPath( *args ):
                          *args )
 
 
-@WithRetry
 def RunTest( app, test ):
   """
   Method to run a simple completion test and verify the result
@@ -143,6 +142,7 @@ def WithObjectMethods( *args ):
   return list( PUBLIC_OBJECT_METHODS ) + list( args )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_NoQuery_test( app ):
   RunTest( app, {
@@ -172,6 +172,7 @@ def GetCompletions_NoQuery_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_WithQuery_test( app ):
   RunTest( app, {
@@ -201,6 +202,7 @@ def GetCompletions_WithQuery_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_DetailFromCache_test( app ):
   for i in range( 0, 2 ):
@@ -231,6 +233,7 @@ def GetCompletions_DetailFromCache_test( app ):
     } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_Package_test( app ):
   RunTest( app, {
@@ -256,6 +259,7 @@ def GetCompletions_Package_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_Import_Class_test( app ):
   RunTest( app, {
@@ -282,6 +286,7 @@ def GetCompletions_Import_Class_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_Import_Classes_test( app ):
   filepath = ProjectPath( 'TestLauncher.java' )
@@ -321,6 +326,7 @@ def GetCompletions_Import_Classes_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_Import_ModuleAndClass_test( app ):
   filepath = ProjectPath( 'TestLauncher.java' )
@@ -352,6 +358,7 @@ def GetCompletions_Import_ModuleAndClass_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_WithFixIt_test( app ):
   filepath = ProjectPath( 'TestFactory.java' )
@@ -393,6 +400,7 @@ def GetCompletions_WithFixIt_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_RejectMultiLineInsertion_test( app ):
   filepath = ProjectPath( 'TestLauncher.java' )
@@ -426,6 +434,7 @@ def GetCompletions_RejectMultiLineInsertion_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_UnicodeIdentifier_test( app ):
   filepath = PathToTestFile( DEFAULT_PROJECT_DIR,
@@ -467,6 +476,7 @@ def GetCompletions_UnicodeIdentifier_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_ResolveFailed_test( app ):
   filepath = PathToTestFile( DEFAULT_PROJECT_DIR,
@@ -517,6 +527,7 @@ def GetCompletions_ResolveFailed_test( app ):
     } )
 
 
+@WithRetry
 @IsolatedYcmd()
 def GetCompletions_ServerNotInitialized_test( app ):
   filepath = PathToTestFile( 'simple_eclipse_project',
@@ -555,6 +566,7 @@ def GetCompletions_ServerNotInitialized_test( app ):
     } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_MoreThan10_NoResolve_ThenResolve_test( app ):
   ClearCompletionsCache()
@@ -631,6 +643,7 @@ def GetCompletions_MoreThan10_NoResolve_ThenResolve_test( app ):
 
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_FewerThan10_Resolved_test( app ):
   ClearCompletionsCache()
@@ -676,6 +689,7 @@ def GetCompletions_FewerThan10_Resolved_test( app ):
 
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_MoreThan10_NoResolve_ThenResolveCacheBad_test( app ):
   ClearCompletionsCache()
@@ -733,6 +747,7 @@ def GetCompletions_MoreThan10_NoResolve_ThenResolveCacheBad_test( app ):
 
 
 
+@WithRetry
 @UnixOnly
 @SharedYcmd
 def GetCompletions_MoreThan10ForceSemantic_test( app ):
@@ -766,6 +781,7 @@ def GetCompletions_MoreThan10ForceSemantic_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_ForceAtTopLevel_NoImport_test( app ):
   RunTest( app, {
@@ -793,6 +809,7 @@ def GetCompletions_ForceAtTopLevel_NoImport_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_NoForceAtTopLevel_NoImport_test( app ):
   RunTest( app, {
@@ -817,6 +834,7 @@ def GetCompletions_NoForceAtTopLevel_NoImport_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_ForceAtTopLevel_WithImport_test( app ):
   filepath = ProjectPath( 'TestWidgetImpl.java' )
@@ -854,6 +872,7 @@ def GetCompletions_ForceAtTopLevel_WithImport_test( app ):
   } )
 
 
+@WithRetry
 @SharedYcmd
 def GetCompletions_UseServerTriggers_test( app ):
   filepath = ProjectPath( 'TestWidgetImpl.java' )

--- a/ycmd/tests/java/get_completions_test.py
+++ b/ycmd/tests/java/get_completions_test.py
@@ -555,7 +555,6 @@ def GetCompletions_ServerNotInitialized_test( app ):
     } )
 
 
-@UnixOnly
 @SharedYcmd
 def GetCompletions_MoreThan10_NoResolve_ThenResolve_test( app ):
   ClearCompletionsCache()
@@ -563,8 +562,8 @@ def GetCompletions_MoreThan10_NoResolve_ThenResolve_test( app ):
     'description': "More than 10 candiates after filtering, don't resolve",
     'request': {
       'filetype'  : 'java',
-      'filepath'  : ProjectPath( 'MethodsWithDocumentation.java' ),
-      'line_num'  : 33,
+      'filepath'  : ProjectPath( 'TestWithDocumentation.java' ),
+      'line_num'  : 6,
       'column_num': 7,
     },
     'expect': {
@@ -632,7 +631,6 @@ def GetCompletions_MoreThan10_NoResolve_ThenResolve_test( app ):
 
 
 
-@UnixOnly
 @SharedYcmd
 def GetCompletions_FewerThan10_Resolved_test( app ):
   ClearCompletionsCache()
@@ -641,8 +639,8 @@ def GetCompletions_FewerThan10_Resolved_test( app ):
     'description': "More than 10 candiates after filtering, don't resolve",
     'request': {
       'filetype'  : 'java',
-      'filepath'  : ProjectPath( 'MethodsWithDocumentation.java' ),
-      'line_num'  : 33,
+      'filepath'  : ProjectPath( 'TestWithDocumentation.java' ),
+      'line_num'  : 6,
       'column_num': 10,
     },
     'expect': {
@@ -678,7 +676,6 @@ def GetCompletions_FewerThan10_Resolved_test( app ):
 
 
 
-@UnixOnly
 @SharedYcmd
 def GetCompletions_MoreThan10_NoResolve_ThenResolveCacheBad_test( app ):
   ClearCompletionsCache()
@@ -686,8 +683,8 @@ def GetCompletions_MoreThan10_NoResolve_ThenResolveCacheBad_test( app ):
     'description': "More than 10 candiates after filtering, don't resolve",
     'request': {
       'filetype'  : 'java',
-      'filepath'  : ProjectPath( 'MethodsWithDocumentation.java' ),
-      'line_num'  : 33,
+      'filepath'  : ProjectPath( 'TestWithDocumentation.java' ),
+      'line_num'  : 6,
       'column_num': 7,
     },
     'expect': {

--- a/ycmd/tests/java/subcommands_test.py
+++ b/ycmd/tests/java/subcommands_test.py
@@ -720,6 +720,16 @@ def Subcommands_GoToSymbol_Multiple_test( app ):
       'description': "Test",
       'line_num': 3,
       'column_num': 14,
+    } ),
+    has_entries( {
+      'filepath': PathToTestFile( 'simple_eclipse_project',
+                                  'src',
+                                  'com',
+                                  'test',
+                                  'TestWithDocumentation.java' ) ,
+      'description': "TestWithDocumentation",
+      'line_num': 3,
+      'column_num': 14,
     } )
   ) )
 

--- a/ycmd/tests/java/subcommands_test.py
+++ b/ycmd/tests/java/subcommands_test.py
@@ -913,7 +913,6 @@ def Subcommands_RefactorRename_Unicode_test( app ):
 
 
 
-@WithRetry
 def RunFixItTest( app, description, filepath, line, col, fixits_for_line ):
   RunTest( app, {
     'description': description,
@@ -930,6 +929,7 @@ def RunFixItTest( app, description, filepath, line, col, fixits_for_line ):
   } )
 
 
+@WithRetry
 @pytest.mark.parametrize( 'description,column', [
   ( 'FixIt works at the firtst char of the line', 1 ),
   ( 'FixIt works at the begin of the range of the diag.', 15 ),
@@ -1068,6 +1068,7 @@ def Subcommands_FixIt_SingleDiag_MultipleOption_Insertion_test( app,
   RunFixItTest( app, description, filepath, 19, column, fixits_for_line )
 
 
+@WithRetry
 @SharedYcmd
 def Subcommands_FixIt_SingleDiag_SingleOption_Modify_test( app ):
   filepath = PathToTestFile( 'simple_eclipse_project',
@@ -1129,6 +1130,7 @@ def Subcommands_FixIt_SingleDiag_SingleOption_Modify_test( app ):
                 filepath, 27, 12, fixits )
 
 
+@WithRetry
 @SharedYcmd
 def Subcommands_FixIt_SingleDiag_MultiOption_Delete_test( app ):
   filepath = PathToTestFile( 'simple_eclipse_project',
@@ -1175,6 +1177,7 @@ def Subcommands_FixIt_SingleDiag_MultiOption_Delete_test( app ):
                 filepath, 15, 29, fixits )
 
 
+@WithRetry
 @pytest.mark.parametrize( 'description,column,expect_fixits', [
   ( 'diags are merged in FixIt options - start of line', 1, 'MERGE' ),
   ( 'diags are not merged in FixIt options - start of diag 1', 10, 'FIRST' ),
@@ -1370,6 +1373,7 @@ def Subcommands_FixIt_Range_test( app ):
 
 
 
+@WithRetry
 @SharedYcmd
 def Subcommands_FixIt_NoDiagnostics_test( app ):
   filepath = PathToTestFile( 'simple_eclipse_project',
@@ -1390,6 +1394,7 @@ def Subcommands_FixIt_NoDiagnostics_test( app ):
                                    'chunks': instance_of( list ) } ) ) } ) )
 
 
+@WithRetry
 @SharedYcmd
 def Subcommands_FixIt_Unicode_test( app ):
   fixits = has_entries( {

--- a/ycmd/tests/java/testdata/simple_eclipse_project/src/com/test/TestWithDocumentation.java
+++ b/ycmd/tests/java/testdata/simple_eclipse_project/src/com/test/TestWithDocumentation.java
@@ -1,0 +1,9 @@
+package com.test;
+
+public class TestWithDocumentation {
+  public static void main( String[] args ) {
+    MethodsWithDocumentation m = new MethodsWithDocumentation();
+    m.useAString( m.getAString() );
+    m.hashCode();
+  }
+}

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -394,7 +394,14 @@ def TemporaryTestDir():
 
 
 """Decorator to be applied to tests that retries the test over and over"""
-WithRetry = pytest.mark.flaky( max_runs = 5 )
+if os.environ.get( 'YCM_TEST_NO_RETRY' ) == 'IGNORE':
+  WithRetry = pytest.mark.xfail( strict = False )
+elif os.environ.get( 'YCM_TEST_NO_RETRY' ):
+  # This is a "null" decorator
+  def WithRetry( f ):
+    return f
+else:
+  WithRetry = pytest.mark.flaky( reruns=20, reruns_delay=0.5 )
 
 
 @contextlib.contextmanager

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -393,25 +393,8 @@ def TemporaryTestDir():
     shutil.rmtree( tmp_dir )
 
 
-def WithRetry( test ):
-  """Decorator to be applied to tests that retries the test over and over
-  until it passes or |timeout| seconds have passed."""
-
-  if 'YCM_TEST_NO_RETRY' in os.environ:
-    return test
-
-  @functools.wraps( test )
-  def wrapper( *args, **kwargs ):
-    expiry = time.time() + 30
-    while True:
-      try:
-        return test( *args, **kwargs )
-      except Exception as test_exception:
-        if time.time() > expiry:
-          raise
-        print( f'Test failed, retrying: { test_exception }' )
-        time.sleep( 0.25 )
-  return wrapper
+"""Decorator to be applied to tests that retries the test over and over"""
+WithRetry = pytest.mark.flaky( max_runs = 5 )
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This is actually needed to make YCM test stable but makes sense to do same in server. The reason that we're seeing flakes in the "Resolve" tests in the YCM tests suite is that we're editing the "MathodsWithDocumentation.java" class _while_ asking jdt.ls to use the class in that file to return documentation. I think what's happening is that the _change_ to the file makes it unparseable, and jdt.ls drops parts of the AST (or something).

Anyway, I found that if we use a class file which is _not_ being edited and/or requesting completion _within_ it, we get stable responses for the completionItem/resolve. So let's do that. 

It also means we can run those tests on Windows.

Incidentally, there is another valigridn error that popped up. None of our code has changed, so suppressed it.

Tests give an output like this:

```
ycmd/tests/go/diagnostics_test.py::Diagnostics_Poll_test[] PASSED        [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] RERUN [ 66%]
ycmd/tests/go/get_completions_test.py::GetCompletions_Basic_test[] PASSED [ 66%]
ycmd/tests/go/go_completer_test.py::GetCompleter_GoplsFound_test PASSED  [ 66%]
```

`YCM_TEST_NO_RETRY` can take 3 value:

* `XFAIL` - to just mark them as expected fail and skip if they need to re-run
* `1` - to just fail and don't retry
* `<unset>` to retry up to 20 times by default 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1484)
<!-- Reviewable:end -->
