### PR TITLE
[READY] Switch to C++17

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -86,10 +86,12 @@ get_python_inc(),
 ]
 
 # Clang automatically sets the '-std=' flag to 'c++14' for MSVC 2015 or later,
-# which is required for compiling the standard library, and to 'c++11' for older
+# which is required for compiling the standard library, and to 'c++17' for older
 # versions.
 if platform.system() != 'Windows':
-  flags.append( '-std=c++11' )
+  flags.append( '-std=c++17' )
+else:
+  flags.append( '/std:c++17' )
 
 
 # Set this to the absolute path to the folder (NOT the file!) containing the

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,10 +27,10 @@ jobs:
         YCM_PYTHON_VERSION: '3.6.3'
         YCM_BENCHMARK: true
         COVERAGE: false
-      # 'C++ linting':
-      #   YCM_PYTHON_VERSION: '3.9.0'
-      #   YCM_CLANG_TIDY: true
-      #   COVERAGE: false
+      'C++ linting':
+        YCM_PYTHON_VERSION: '3.9.0'
+        YCM_CLANG_TIDY: true
+        COVERAGE: false
     maxParallel: 5
   variables:
     COVERAGE: true

--- a/azure/linux/install_dependencies.sh
+++ b/azure/linux/install_dependencies.sh
@@ -7,11 +7,13 @@ set -e
 sudo apt-get update
 sudo apt-get install libsqlite3-dev
 if [ "${YCM_COMPILER}" == "clang" ]; then
-  sudo apt-get install clang-8
-  sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-8 100
-  sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-8 100
+  sudo apt-get install clang-7
+  sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-7 100
+  sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-7 100
 else
-  sudo apt-get install gcc g++
+  sudo apt-get install gcc-8 g++-8
+  sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-8 100
+  sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-8 100
 fi
 
 if [ "${YCM_CLANG_TIDY}" ]; then

--- a/build.py
+++ b/build.py
@@ -403,7 +403,7 @@ def ParseArguments():
   parser.add_argument( '--system-libclang', action = 'store_true',
                        help = 'Use system libclang instead of downloading one '
                        'from llvm.org. NOT RECOMMENDED OR SUPPORTED!' )
-  parser.add_argument( '--msvc', type = int, choices = [ 14, 15, 16 ],
+  parser.add_argument( '--msvc', type = int, choices = [ 15, 16 ],
                        default = 16, help = 'Choose the Microsoft Visual '
                        'Studio version (default: %(default)s).' )
   parser.add_argument( '--ninja', action = 'store_true',

--- a/build.py
+++ b/build.py
@@ -560,8 +560,8 @@ def RunYcmdTests( args, build_dir ):
             '--gen-suppressions=all',
             '--error-exitcode=1',
             '--leak-check=full',
-            '--show-leak-kinds=all',
-            '--show-reachable=no',
+            '--show-leak-kinds=definite,indirect',
+            '--errors-for-leak-kinds=definite,indirect',
             '--suppressions=' + p.join( DIR_OF_THIS_SCRIPT,
                                         'valgrind.suppressions' ),
             p.join( tests_dir, 'ycm_core_tests' ) ]

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -87,9 +87,6 @@ set( CMAKE_EXPORT_COMPILE_COMMANDS 1 )
 # This is needed so that on macs, the library is built in both 32 bit and 64 bit
 # versions. Without this python might refuse to load the module, depending on
 # how python was built.
-# On Mac, boost needs to be compiled universal as well, if used instead of the
-# included BoostParts lib. For brew, that's
-# "brew install boost --universal"
 # If the user chose to use the system libclang.dylib (or the libclang.dylib
 # binary downloaded from llvm.org) on a mac, then we don't specify universal
 # binary building since the system libclang on macs is not  universal (and thus
@@ -150,7 +147,6 @@ endif()
 #############################################################################
 
 # MSVC has snprintf since version 14 which is newer than what we support.
-# *NOT* defining HAVE_SNPRINTF will break compiling the bundled boost libraries.
 if ( MSVC )
   add_definitions( -DHAVE_SNPRINTF )
 endif()
@@ -164,21 +160,21 @@ endif()
 
 #############################################################################
 
-# Determining the presence of C++11 support in the compiler
-set( CPP11_AVAILABLE false )
+# Determining the presence of C++17 support in the compiler
+set( CPP17_AVAILABLE false )
 if ( CMAKE_COMPILER_IS_GNUCXX )
-  if ( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8 )
-    set( CPP11_AVAILABLE true )
+  if ( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8 )
+    set( CPP17_AVAILABLE true )
   endif()
 elseif( COMPILER_IS_CLANG )
-  if ( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.3 )
-    set( CPP11_AVAILABLE true )
-    set( CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11" )
+  if ( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7 )
+    set( CPP17_AVAILABLE true )
+    set( CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++17" )
     set( CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++" )
   endif()
 elseif( MSVC )
-  if ( NOT MSVC_VERSION LESS 1900 )
-    set( CPP11_AVAILABLE true )
+  if ( NOT MSVC_VERSION LESS 1914 )
+    set( CPP17_AVAILABLE true )
   endif()
 endif()
 
@@ -188,13 +184,8 @@ endif()
 # number of sections that an object file can hold. This is needed for storing
 # the Unicode table. Also, force MSVC to treat source files as UTF-8 encoded.
 if ( MSVC )
-  add_definitions( /DUNICODE /D_UNICODE /Zc:wchar_t- )
+  add_definitions( /DUNICODE /D_UNICODE )
   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /bigobj /utf-8" )
-endif()
-
-if( MSVC OR CYGWIN OR MSYS)
-  # BOOST_ALL_NO_LIB turns off MSVC library autolinking
-  add_definitions( -DBOOST_ALL_NO_LIB )
 endif()
 
 # Enables Python compilation for 64-bit Windows. Already defined by Python
@@ -205,49 +196,45 @@ endif()
 
 #############################################################################
 
-if ( CPP11_AVAILABLE )
+if ( CPP17_AVAILABLE )
   # Cygwin needs its hand held a bit; see issue #473
   if ( CYGWIN AND CMAKE_COMPILER_IS_GNUCXX )
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11" )
+    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17" )
   elseif( NOT MSVC )
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11" )
+    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17" )
+  elseif( MSVC )
+    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17" )
   endif()
 else()
   # Platform-specific advice goes here. In particular, we have plenty of users
   # in corporate environments on RHEL/CentOS, where the default system compiler
   # is too old.
 
-  # on RHEL and CentOS, users require the devtoolset-3 or greater. However, we
-  # recommended the devtoolset-6 because it is the newest at the time of
+  # on RHEL and CentOS, users require the devtoolset-8 or greater. However, we
+  # recommended the devtoolset-8 because it is the newest at the time of
   # writing. And why not.
   if ( DISTRIBUTION STREQUAL "CentOS" OR DISTRIBUTION STREQUAL "Red Hat" )
     message( STATUS "NOTE: You appear to be on ${DISTRIBUTION}. "
     "In order to use this application, you require a more modern compiler "
     "than the default compiler on this platform. "
-    "Please install the devtoolset-6 or greater. For example, see this link: "
-    "https://www.softwarecollections.org/en/scls/rhscl/devtoolset-6/" )
+    "Please install the devtoolset-8 or greater. For example, see this link: "
+    "https://www.softwarecollections.org/en/scls/rhscl/devtoolset-8/" )
 
     # Finally, just check if it is installed and they just need to activate it.
-    if ( EXISTS /opt/rh/devtoolset-6 )
-      message( STATUS "NOTE: It looks like you have the devtoolset-6 "
-                      "installed in /opt/rh/devtoolset-6, so you probably "
+    if ( EXISTS /opt/rh/devtoolset-8 )
+      message( STATUS "NOTE: It looks like you have the devtoolset-8 "
+                      "installed in /opt/rh/devtoolset-8, so you probably "
                       "just need to activate it and re-run the installation. "
-                      "For example: source /opt/rh/devtoolset-6/enable")
+                      "For example: source /opt/rh/devtoolset-8/enable")
     endif()
   endif()
 
-  message( FATAL_ERROR "Your C++ compiler does NOT fully support C++11." )
+  message( FATAL_ERROR "Your C++ compiler does NOT fully support C++17." )
 endif()
 
-set( Python_ADDITIONAL_VERSIONS 3.9 3.8 3.7 3.6 3.5 )
-find_package( PythonLibs 3.5 REQUIRED )  # 3.5 is ONLY the minimum
+set( Python_ADDITIONAL_VERSIONS 3.10 3.9 3.8 3.7 3.6 )
+find_package( PythonLibs 3.6 REQUIRED )  # 3.6 is ONLY the minimum
 
 #############################################################################
-
-option( USE_SYSTEM_BOOST "Set to ON to use the system boost libraries" OFF )
-
-if (NOT USE_SYSTEM_BOOST)
-  add_subdirectory( BoostParts )
-endif()
 
 add_subdirectory( ycm )

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -191,15 +191,12 @@ if ( APPLE )
   set( CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem " )
 endif()
 
-if ( USE_SYSTEM_BOOST )
-  set( Boost_COMPONENTS filesystem )
-  find_package( Boost REQUIRED COMPONENTS ${Boost_COMPONENTS} )
-else()
-  set( Boost_INCLUDE_DIR ${BoostParts_SOURCE_DIR} )
-  set( Boost_LIBRARIES BoostParts )
-endif()
-
 set( PYBIND11_INCLUDES_DIR "${CMAKE_SOURCE_DIR}/pybind11" )
+
+# Makes MSVC conform to the standard
+if ( MSVC )
+  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-" )
+endif()
 
 file( GLOB_RECURSE SERVER_SOURCES *.h *.cpp )
 
@@ -228,14 +225,13 @@ endif()
 
 # The SYSTEM flag makes sure that -isystem[header path] is passed to the
 # compiler instead of the standard -I[header path]. Headers included with
-# -isystem do not generate warnings (and they shouldn't; e.g. boost warnings are
-# just noise for us since we won't be changing them).
+# -isystem do not generate warnings (and they shouldn't; e.g. pybind11 warnings
+# are just noise for us since we won't be changing them).
 # Since there is no -isystem flag equivalent on Windows, headers from external
 # projects may conflict with our headers and override them. We prevent that by
 # including these directories after ours.
 include_directories(
   SYSTEM
-  ${Boost_INCLUDE_DIR}
   ${PYBIND11_INCLUDES_DIR}
   ${PYTHON_INCLUDE_DIRS}
   ${CLANG_INCLUDES_DIR}
@@ -318,6 +314,36 @@ if ( UNIX AND NOT ( APPLE OR SYSTEM_IS_OPENBSD OR HAIKU ) )
   set( EXTRA_LIBS rt )
 endif()
 
+# Check if we need to add -lstdc++fs or -lc++fs or nothing
+if( MSVC )
+  set( STD_FS_NO_LIB_NEEDED TRUE )
+else()
+  file( WRITE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp "#include <filesystem>\nint main( int argc, char ** argv ) {\n  std::filesystem::path p( argv[ 0 ] );\n  return p.string().length();\n}" )
+  try_compile( STD_FS_NO_LIB_NEEDED ${CMAKE_CURRENT_BINARY_DIR}
+               SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+               COMPILE_DEFINITIONS -std=c++17 )
+  try_compile( STD_FS_NEEDS_STDCXXFS ${CMAKE_CURRENT_BINARY_DIR}
+               SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+               COMPILE_DEFINITIONS -std=c++17
+               LINK_LIBRARIES stdc++fs )
+  try_compile( STD_FS_NEEDS_CXXFS ${CMAKE_CURRENT_BINARY_DIR}
+               SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+               COMPILE_DEFINITIONS -std=c++17
+               LINK_LIBRARIES c++fs )
+  file( REMOVE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp )
+endif()
+
+if( ${STD_FS_NEEDS_STDCXXFS} )
+  set( STD_FS_LIB stdc++fs )
+elseif( ${STD_FS_NEEDS_CXXFS} )
+  set( STD_FS_LIB c++fs )
+elseif( ${STD_FS_NO_LIB_NEEDED} )
+  set( STD_FS_LIB "" )
+else()
+  message( WARNING "Unknown compiler - not passing -lstdc++fs" )
+  set( STD_FS_LIB "" )
+endif()
+
 #############################################################################
 
 add_library( ${PROJECT_NAME} SHARED
@@ -331,9 +357,9 @@ if ( USE_CLANG_COMPLETER AND NOT LIBCLANG_TARGET )
 endif()
 
 target_link_libraries( ${PROJECT_NAME}
-                       ${Boost_LIBRARIES}
                        ${PYTHON_LIBRARIES}
                        ${LIBCLANG_TARGET}
+                       ${STD_FS_LIB}
                        ${EXTRA_LIBS}
                      )
 
@@ -398,11 +424,7 @@ set_target_properties( ${PROJECT_NAME} PROPERTIES
 
 #############################################################################
 
-
-# For some reason, Xcode is too dumb to understand the -isystem flag and thus
-# borks on warnings in Boost.
-if ( USE_DEV_FLAGS AND ( CMAKE_COMPILER_IS_GNUCXX OR COMPILER_IS_CLANG ) AND
-     NOT CMAKE_GENERATOR_IS_XCODE )
+if ( USE_DEV_FLAGS AND ( CMAKE_COMPILER_IS_GNUCXX OR COMPILER_IS_CLANG ) )
   # We want all warnings, and warnings should be treated as errors
   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror" )
 endif()

--- a/cpp/ycm/CandidateRepository.cpp
+++ b/cpp/ycm/CandidateRepository.cpp
@@ -64,7 +64,7 @@ std::vector< const Candidate * > CandidateRepository::GetCandidatesForStrings(
                                                   nullptr );
 
       if ( !candidate ) {
-        candidate.reset( new Candidate( std::move( candidate_text ) ) );
+        candidate = std::make_unique< Candidate >( std::move( candidate_text ) );
       }
 
       candidates.push_back( candidate.get() );

--- a/cpp/ycm/CandidateRepository.cpp
+++ b/cpp/ycm/CandidateRepository.cpp
@@ -16,10 +16,7 @@
 // along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "CandidateRepository.h"
-#include "Candidate.h"
 #include "Utils.h"
-
-#include <mutex>
 
 #ifdef USE_CLANG_COMPLETER
 #  include "ClangCompleter/CompletionData.h"
@@ -42,8 +39,8 @@ CandidateRepository &CandidateRepository::Instance() {
 }
 
 
-size_t CandidateRepository::NumStoredCandidates() {
-  std::lock_guard< std::mutex > locker( candidate_holder_mutex_ );
+size_t CandidateRepository::NumStoredCandidates() const {
+  std::shared_lock locker( candidate_holder_mutex_ );
   return candidate_holder_.size();
 }
 
@@ -54,7 +51,7 @@ std::vector< const Candidate * > CandidateRepository::GetCandidatesForStrings(
   candidates.reserve( strings.size() );
 
   {
-    std::lock_guard< std::mutex > locker( candidate_holder_mutex_ );
+    std::lock_guard locker( candidate_holder_mutex_ );
 
     for ( auto&& candidate_text : strings ) {
       if ( candidate_text.size() > MAX_CANDIDATE_SIZE ) {

--- a/cpp/ycm/CandidateRepository.h
+++ b/cpp/ycm/CandidateRepository.h
@@ -21,7 +21,7 @@
 #include "Candidate.h"
 
 #include <memory>
-#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -47,7 +47,7 @@ public:
   CandidateRepository( const CandidateRepository& ) = delete;
   CandidateRepository& operator=( const CandidateRepository& ) = delete;
 
-  size_t NumStoredCandidates();
+  size_t NumStoredCandidates() const;
 
   YCM_EXPORT std::vector< const Candidate * > GetCandidatesForStrings(
     std::vector< std::string >&& strings );
@@ -61,7 +61,7 @@ private:
 
   // This data structure owns all the Candidate pointers
   CandidateHolder candidate_holder_;
-  std::mutex candidate_holder_mutex_;
+  mutable std::shared_mutex candidate_holder_mutex_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/Character.cpp
+++ b/cpp/ycm/Character.cpp
@@ -64,7 +64,7 @@ CodePointSequence CanonicalSort( CodePointSequence code_points ) {
 // Decompose a UTF-8 encoded string into a sequence of code points according to
 // Canonical Decomposition. See
 // https://www.unicode.org/versions/Unicode13.0.0/ch03.pdf#G733
-CodePointSequence CanonicalDecompose( const std::string &text ) {
+CodePointSequence CanonicalDecompose( std::string_view text ) {
   CodePointSequence code_points = BreakIntoCodePoints( text );
   std::string normal;
 
@@ -77,7 +77,7 @@ CodePointSequence CanonicalDecompose( const std::string &text ) {
 
 } // unnamed namespace
 
-Character::Character( const std::string &character )
+Character::Character( std::string_view character )
   : is_base_( true ),
     is_letter_( false ),
     is_punctuation_( false ),

--- a/cpp/ycm/Character.h
+++ b/cpp/ycm/Character.h
@@ -19,6 +19,7 @@
 #define CHARACTER_H_YTIET2HZ
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace YouCompleteMe {
@@ -32,7 +33,7 @@ namespace YouCompleteMe {
 // punctuation, and if it is uppercase.
 class Character {
 public:
-  YCM_EXPORT explicit Character( const std::string &character );
+  YCM_EXPORT explicit Character( std::string_view character );
   // Make class noncopyable
   Character( const Character& ) = delete;
   Character& operator=( const Character& ) = delete;

--- a/cpp/ycm/CharacterRepository.cpp
+++ b/cpp/ycm/CharacterRepository.cpp
@@ -16,10 +16,8 @@
 // along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "CharacterRepository.h"
-#include "Character.h"
 #include "Utils.h"
 
-#include <mutex>
 #include <string_view>
 
 namespace YouCompleteMe {
@@ -30,8 +28,8 @@ CharacterRepository &CharacterRepository::Instance() {
 }
 
 
-size_t CharacterRepository::NumStoredCharacters() {
-  std::lock_guard< std::mutex > locker( character_holder_mutex_ );
+size_t CharacterRepository::NumStoredCharacters() const {
+  std::shared_lock locker( character_holder_mutex_ );
   return character_holder_.size();
 }
 
@@ -42,7 +40,7 @@ CharacterSequence CharacterRepository::GetCharacters(
   character_objects.reserve( characters.size() );
 
   {
-    std::lock_guard< std::mutex > locker( character_holder_mutex_ );
+    std::lock_guard locker( character_holder_mutex_ );
 
     for ( std::string_view character : characters ) {
       std::unique_ptr< Character > &character_object = GetValueElseInsert(

--- a/cpp/ycm/CharacterRepository.cpp
+++ b/cpp/ycm/CharacterRepository.cpp
@@ -20,6 +20,7 @@
 #include "Utils.h"
 
 #include <mutex>
+#include <string_view>
 
 namespace YouCompleteMe {
 
@@ -43,7 +44,7 @@ CharacterSequence CharacterRepository::GetCharacters(
   {
     std::lock_guard< std::mutex > locker( character_holder_mutex_ );
 
-    for ( const std::string & character : characters ) {
+    for ( std::string_view character : characters ) {
       std::unique_ptr< Character > &character_object = GetValueElseInsert(
                                                          character_holder_,
                                                          character,

--- a/cpp/ycm/CharacterRepository.cpp
+++ b/cpp/ycm/CharacterRepository.cpp
@@ -49,7 +49,7 @@ CharacterSequence CharacterRepository::GetCharacters(
                                                          nullptr );
 
       if ( !character_object ) {
-        character_object.reset( new Character( character ) );
+        character_object = std::make_unique< Character >( character );
       }
 
       character_objects.push_back( character_object.get() );

--- a/cpp/ycm/CharacterRepository.h
+++ b/cpp/ycm/CharacterRepository.h
@@ -21,7 +21,7 @@
 #include "Character.h"
 
 #include <memory>
-#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -44,7 +44,7 @@ public:
   CharacterRepository( const CharacterRepository& ) = delete;
   CharacterRepository& operator=( const CharacterRepository& ) = delete;
 
-  YCM_EXPORT size_t NumStoredCharacters();
+  YCM_EXPORT size_t NumStoredCharacters() const;
 
   YCM_EXPORT CharacterSequence GetCharacters(
     const std::vector< std::string > &characters );
@@ -58,7 +58,7 @@ private:
 
   // This data structure owns all the Character pointers
   CharacterHolder character_holder_;
-  std::mutex character_holder_mutex_;
+  mutable std::shared_mutex character_holder_mutex_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <filesystem>
 #include <memory>
 
 using std::unique_lock;
@@ -522,13 +523,13 @@ std::vector< FixIt > TranslationUnit::GetFixItsForLocationInFile(
 
   std::vector< FixIt > fixits;
 
-  auto normal_filename = NormalizePath( filename );
+  auto normal_filename = fs::weakly_canonical( filename );
 
   {
     unique_lock< mutex > lock( diagnostics_mutex_ );
 
     for ( const Diagnostic& diagnostic : latest_diagnostics_ ) {
-      auto this_filename = NormalizePath( diagnostic.location_.filename_ );
+      auto this_filename = fs::weakly_canonical( diagnostic.location_.filename_ );
 
       if ( normal_filename != this_filename ) {
         continue;

--- a/cpp/ycm/CodePoint.cpp
+++ b/cpp/ycm/CodePoint.cpp
@@ -47,7 +47,7 @@ int GetCodePointLength( uint8_t leading_byte ) {
 }
 
 
-RawCodePoint FindCodePoint( const char *text ) {
+RawCodePoint FindCodePoint( std::string_view text ) {
 #include "UnicodeTable.inc"
 
   // Do a binary search on the array of code points to find the raw code point
@@ -55,14 +55,8 @@ RawCodePoint FindCodePoint( const char *text ) {
   // raw code point for that text.
   const auto& original = code_points.original;
 
-  auto it = std::lower_bound(
-    original.begin(),
-    original.end(),
-    text,
-    []( const char* cp, const char* text ) {
-      return std::strcmp( cp, text ) < 0;
-    } );
-  if ( it != original.end() && strcmp( text, *it ) == 0 ) {
+  auto it = std::lower_bound( original.begin(), original.end(), text );
+  if ( it != original.end() && text == *it ) {
     size_t index = std::distance( original.begin(), it );
     return { *it,
              code_points.normal[ index ],
@@ -80,8 +74,8 @@ RawCodePoint FindCodePoint( const char *text ) {
 
 } // unnamed namespace
 
-CodePoint::CodePoint( const std::string &code_point )
-  : CodePoint( FindCodePoint( code_point.c_str() ) ) {
+CodePoint::CodePoint( std::string_view code_point )
+  : CodePoint( FindCodePoint( code_point ) ) {
 }
 
 
@@ -98,7 +92,7 @@ CodePoint::CodePoint( RawCodePoint&& code_point )
 }
 
 
-CodePointSequence BreakIntoCodePoints( const std::string &text ) {
+CodePointSequence BreakIntoCodePoints( std::string_view text ) {
   // NOTE: for efficiency, we don't check if the number of continuation bytes
   // and the bytes themselves are valid (they must start with bits '10').
   std::vector< std::string > code_points;

--- a/cpp/ycm/CodePoint.h
+++ b/cpp/ycm/CodePoint.h
@@ -50,10 +50,10 @@ enum class BreakProperty : uint8_t {
 // This is the structure used to store the data in the Unicode table. See the
 // CodePoint class for a description of the members.
 struct RawCodePoint {
-  const char *original;
-  const char *normal;
-  const char *folded_case;
-  const char *swapped_case;
+  std::string_view original;
+  std::string_view normal;
+  std::string_view folded_case;
+  std::string_view swapped_case;
   bool is_letter;
   bool is_punctuation;
   bool is_uppercase;
@@ -83,7 +83,7 @@ struct RawCodePoint {
 //    https://www.unicode.org/versions/Unicode13.0.0/ch03.pdf#G49591).
 class CodePoint {
 public:
-  YCM_EXPORT explicit CodePoint( const std::string &code_point );
+  YCM_EXPORT explicit CodePoint( std::string_view code_point );
   // Make class noncopyable
   CodePoint( const CodePoint& ) = delete;
   CodePoint& operator=( const CodePoint& ) = delete;
@@ -144,7 +144,7 @@ using CodePointSequence = std::vector< const CodePoint * >;
 
 
 // Split a UTF-8 encoded string into UTF-8 code points.
-YCM_EXPORT CodePointSequence BreakIntoCodePoints( const std::string &text );
+YCM_EXPORT CodePointSequence BreakIntoCodePoints( std::string_view text );
 
 
 // Thrown when an error occurs while decoding a UTF-8 string.

--- a/cpp/ycm/CodePointRepository.cpp
+++ b/cpp/ycm/CodePointRepository.cpp
@@ -48,7 +48,7 @@ CodePointSequence CodePointRepository::GetCodePoints(
                                                           nullptr );
 
       if ( !code_point_object ) {
-        code_point_object.reset( new CodePoint( code_point ) );
+        code_point_object = std::make_unique< CodePoint >( code_point );
       }
 
       code_point_objects.push_back( code_point_object.get() );

--- a/cpp/ycm/CodePointRepository.cpp
+++ b/cpp/ycm/CodePointRepository.cpp
@@ -43,7 +43,7 @@ CodePointSequence CodePointRepository::GetCodePoints(
   {
     std::lock_guard< std::mutex > locker( code_point_holder_mutex_ );
 
-    for ( const std::string & code_point : code_points ) {
+    for ( std::string_view code_point : code_points ) {
       std::unique_ptr< CodePoint > &code_point_object = GetValueElseInsert(
                                                           code_point_holder_,
                                                           code_point,

--- a/cpp/ycm/CodePointRepository.cpp
+++ b/cpp/ycm/CodePointRepository.cpp
@@ -19,8 +19,6 @@
 #include "CodePoint.h"
 #include "Utils.h"
 
-#include <mutex>
-
 namespace YouCompleteMe {
 
 CodePointRepository &CodePointRepository::Instance() {
@@ -29,8 +27,8 @@ CodePointRepository &CodePointRepository::Instance() {
 }
 
 
-size_t CodePointRepository::NumStoredCodePoints() {
-  std::lock_guard< std::mutex > locker( code_point_holder_mutex_ );
+size_t CodePointRepository::NumStoredCodePoints() const {
+  std::shared_lock locker( code_point_holder_mutex_ );
   return code_point_holder_.size();
 }
 
@@ -41,7 +39,7 @@ CodePointSequence CodePointRepository::GetCodePoints(
   code_point_objects.reserve( code_points.size() );
 
   {
-    std::lock_guard< std::mutex > locker( code_point_holder_mutex_ );
+    std::lock_guard locker( code_point_holder_mutex_ );
 
     for ( std::string_view code_point : code_points ) {
       std::unique_ptr< CodePoint > &code_point_object = GetValueElseInsert(

--- a/cpp/ycm/CodePointRepository.h
+++ b/cpp/ycm/CodePointRepository.h
@@ -21,7 +21,7 @@
 #include "CodePoint.h"
 
 #include <memory>
-#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -44,7 +44,7 @@ public:
   CodePointRepository( const CodePointRepository& ) = delete;
   CodePointRepository& operator=( const CodePointRepository& ) = delete;
 
-  YCM_EXPORT size_t NumStoredCodePoints();
+  YCM_EXPORT size_t NumStoredCodePoints() const;
 
   YCM_EXPORT CodePointSequence GetCodePoints(
     const std::vector< std::string > &code_points );
@@ -58,7 +58,7 @@ private:
 
   // This data structure owns all the CodePoint pointers
   CodePointHolder code_point_holder_;
-  std::mutex code_point_holder_mutex_;
+  mutable std::shared_mutex code_point_holder_mutex_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/IdentifierCompleter.cpp
+++ b/cpp/ycm/IdentifierCompleter.cpp
@@ -33,38 +33,41 @@ IdentifierCompleter::IdentifierCompleter(
 
 IdentifierCompleter::IdentifierCompleter(
   std::vector< std::string >&& candidates,
-  const std::string &filetype,
-  const std::string &filepath ) {
+  std::string&& filetype,
+  std::string&& filepath ) {
   identifier_database_.AddIdentifiers( std::move( candidates ),
-                                       filetype,
-                                       filepath );
+                                       std::move( filetype ),
+                                       std::move( filepath ) );
 }
 
 
 void IdentifierCompleter::AddIdentifiersToDatabase(
   std::vector< std::string > new_candidates,
-  const std::string &filetype,
-  const std::string &filepath ) {
+  std::string& filetype,
+  std::string& filepath ) {
   identifier_database_.AddIdentifiers( std::move( new_candidates ),
-                                       filetype,
-                                       filepath );
+                                       std::move( filetype ),
+                                       std::move( filepath ) );
 }
 
 
 void IdentifierCompleter::ClearForFileAndAddIdentifiersToDatabase(
   std::vector< std::string > new_candidates,
-  const std::string &filetype,
-  const std::string &filepath ) {
-  identifier_database_.ClearCandidatesStoredForFile( filetype, filepath );
-  AddIdentifiersToDatabase( std::move( new_candidates ), filetype, filepath );
+  std::string& filetype,
+  std::string& filepath ) {
+  identifier_database_.ClearCandidatesStoredForFile( std::string( filetype ),
+                                                     std::string( filepath ) );
+  AddIdentifiersToDatabase( std::move( new_candidates ),
+                            filetype,
+                            filepath );
 }
 
 
 void IdentifierCompleter::AddIdentifiersToDatabaseFromTagFiles(
-  const std::vector< std::string > &absolute_paths_to_tag_files ) {
-  for( const std::string & path : absolute_paths_to_tag_files ) {
+  std::vector< std::string >& absolute_paths_to_tag_files ) {
+  for( auto&& path : absolute_paths_to_tag_files ) {
     identifier_database_.AddIdentifiers(
-      ExtractIdentifiersFromTagsFile( path ) );
+      ExtractIdentifiersFromTagsFile( std::move( path ) ) );
   }
 }
 
@@ -90,7 +93,7 @@ std::vector< std::string > IdentifierCompleter::CandidatesForQueryAndType(
   candidates.reserve( results.size() );
 
   for ( const Result & result : results ) {
-    candidates.push_back( result.Text() );
+    candidates.emplace_back( result.Text() );
   }
 
   return candidates;

--- a/cpp/ycm/IdentifierCompleter.h
+++ b/cpp/ycm/IdentifierCompleter.h
@@ -40,29 +40,23 @@ public:
     std::vector< std::string > candidates );
   YCM_EXPORT IdentifierCompleter(
                        std::vector< std::string >&& candidates,
-                       const std::string &filetype,
-                       const std::string &filepath );
+                       std::string&& filetype,
+                       std::string&& filepath );
 
   void AddIdentifiersToDatabase(
     std::vector< std::string > new_candidates,
-    const std::string &filetype,
-    const std::string &filepath );
+    std::string& filetype,
+    std::string& filepath );
 
   // Same as above, but clears all identifiers stored for the file before adding
   // new identifiers.
   void ClearForFileAndAddIdentifiersToDatabase(
     std::vector< std::string > new_candidates,
-    const std::string &filetype,
-    const std::string &filepath );
+    std::string& filetype,
+    std::string& filepath );
 
   YCM_EXPORT void AddIdentifiersToDatabaseFromTagFiles(
-    const std::vector< std::string > &absolute_paths_to_tag_files );
-
-  void AddIdentifiersToDatabaseFromBuffer(
-    const std::string &buffer_contents,
-    const std::string &filetype,
-    const std::string &filepath,
-    bool collect_from_comments_and_strings );
+    std::vector< std::string >& absolute_paths_to_tag_files );
 
   // Only provided for tests!
   YCM_EXPORT std::vector< std::string > CandidatesForQuery(

--- a/cpp/ycm/IdentifierDatabase.cpp
+++ b/cpp/ycm/IdentifierDatabase.cpp
@@ -118,14 +118,14 @@ std::vector< Result > IdentifierDatabase::ResultsForQueryAndType(
 std::set< const Candidate * > &IdentifierDatabase::GetCandidateSet(
   std::string&& filetype,
   std::string&& filepath ) {
-  std::shared_ptr< FilepathToCandidates > &path_to_candidates =
+  std::unique_ptr< FilepathToCandidates > &path_to_candidates =
     filetype_candidate_map_[ std::move( filetype ) ];
 
   if ( !path_to_candidates ) {
     path_to_candidates = std::make_unique< FilepathToCandidates >();
   }
 
-  std::shared_ptr< std::set< const Candidate * > > &candidates =
+  std::unique_ptr< std::set< const Candidate * > > &candidates =
     ( *path_to_candidates )[ std::move( filepath ) ];
 
   if ( !candidates ) {

--- a/cpp/ycm/IdentifierDatabase.cpp
+++ b/cpp/ycm/IdentifierDatabase.cpp
@@ -38,9 +38,11 @@ void IdentifierDatabase::AddIdentifiers(
 
   for ( auto&& filetype_and_map : filetype_identifier_map ) {
     for ( auto&& filepath_and_identifiers : filetype_and_map.second ) {
+      auto filetype = filetype_and_map.first;
+      auto filepath = filepath_and_identifiers.first;
       AddIdentifiersNoLock( std::move( filepath_and_identifiers.second ),
-                            filetype_and_map.first,
-                            filepath_and_identifiers.first );
+                            std::move( filetype ),
+                            std::move( filepath ) );
     }
   }
 }
@@ -48,18 +50,18 @@ void IdentifierDatabase::AddIdentifiers(
 
 void IdentifierDatabase::AddIdentifiers(
   std::vector< std::string >&& new_candidates,
-  const std::string &filetype,
-  const std::string &filepath ) {
+  std::string&& filetype,
+  std::string&& filepath ) {
   std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
-  AddIdentifiersNoLock( std::move( new_candidates ), filetype, filepath );
+  AddIdentifiersNoLock( std::move( new_candidates ), std::move( filetype ), std::move( filepath ) );
 }
 
 
 void IdentifierDatabase::ClearCandidatesStoredForFile(
-  const std::string &filetype,
-  const std::string &filepath ) {
+  std::string&& filetype,
+  std::string&& filepath ) {
   std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
-  GetCandidateSet( filetype, filepath ).clear();
+  GetCandidateSet( std::move( filetype ), std::move( filepath ) ).clear();
 }
 
 
@@ -113,17 +115,17 @@ std::vector< Result > IdentifierDatabase::ResultsForQueryAndType(
 // WARNING: You need to hold the filetype_candidate_map_mutex_ before calling
 // this function and while using the returned set.
 std::set< const Candidate * > &IdentifierDatabase::GetCandidateSet(
-  const std::string &filetype,
-  const std::string &filepath ) {
+  std::string&& filetype,
+  std::string&& filepath ) {
   std::shared_ptr< FilepathToCandidates > &path_to_candidates =
-    filetype_candidate_map_[ filetype ];
+    filetype_candidate_map_[ std::move( filetype ) ];
 
   if ( !path_to_candidates ) {
     path_to_candidates.reset( new FilepathToCandidates() );
   }
 
   std::shared_ptr< std::set< const Candidate * > > &candidates =
-    ( *path_to_candidates )[ filepath ];
+    ( *path_to_candidates )[ std::move( filepath ) ];
 
   if ( !candidates ) {
     candidates.reset( new std::set< const Candidate * >() );
@@ -137,10 +139,10 @@ std::set< const Candidate * > &IdentifierDatabase::GetCandidateSet(
 // this function and while using the returned set.
 void IdentifierDatabase::AddIdentifiersNoLock(
   std::vector< std::string >&& new_candidates,
-  const std::string &filetype,
-  const std::string &filepath ) {
+  std::string&& filetype,
+  std::string&& filepath ) {
   std::set< const Candidate *> &candidates =
-    GetCandidateSet( filetype, filepath );
+    GetCandidateSet( std::move( filetype ), std::move( filepath ) );
 
   std::vector< const Candidate * > repository_candidates =
     candidate_repository_.GetCandidatesForStrings(

--- a/cpp/ycm/IdentifierDatabase.cpp
+++ b/cpp/ycm/IdentifierDatabase.cpp
@@ -23,6 +23,7 @@
 #include "Result.h"
 #include "Utils.h"
 
+#include <memory>
 #include <unordered_set>
 
 namespace YouCompleteMe {
@@ -121,14 +122,14 @@ std::set< const Candidate * > &IdentifierDatabase::GetCandidateSet(
     filetype_candidate_map_[ std::move( filetype ) ];
 
   if ( !path_to_candidates ) {
-    path_to_candidates.reset( new FilepathToCandidates() );
+    path_to_candidates = std::make_unique< FilepathToCandidates >();
   }
 
   std::shared_ptr< std::set< const Candidate * > > &candidates =
     ( *path_to_candidates )[ std::move( filepath ) ];
 
   if ( !candidates ) {
-    candidates.reset( new std::set< const Candidate * >() );
+    candidates = std::make_unique< std::set< const Candidate * > >();
   }
 
   return *candidates;

--- a/cpp/ycm/IdentifierDatabase.cpp
+++ b/cpp/ycm/IdentifierDatabase.cpp
@@ -34,7 +34,7 @@ IdentifierDatabase::IdentifierDatabase()
 
 void IdentifierDatabase::AddIdentifiers(
   FiletypeIdentifierMap&& filetype_identifier_map ) {
-  std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
+  std::lock_guard locker( filetype_candidate_map_mutex_ );
 
   for ( auto&& filetype_and_map : filetype_identifier_map ) {
     for ( auto&& filepath_and_identifiers : filetype_and_map.second ) {
@@ -52,7 +52,7 @@ void IdentifierDatabase::AddIdentifiers(
   std::vector< std::string >&& new_candidates,
   std::string&& filetype,
   std::string&& filepath ) {
-  std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
+  std::lock_guard locker( filetype_candidate_map_mutex_ );
   AddIdentifiersNoLock( std::move( new_candidates ), std::move( filetype ), std::move( filepath ) );
 }
 
@@ -60,7 +60,7 @@ void IdentifierDatabase::AddIdentifiers(
 void IdentifierDatabase::ClearCandidatesStoredForFile(
   std::string&& filetype,
   std::string&& filepath ) {
-  std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
+  std::lock_guard locker( filetype_candidate_map_mutex_ );
   GetCandidateSet( std::move( filetype ), std::move( filepath ) ).clear();
 }
 
@@ -71,7 +71,7 @@ std::vector< Result > IdentifierDatabase::ResultsForQueryAndType(
   const size_t max_results ) const {
   FiletypeCandidateMap::const_iterator it;
   {
-    std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
+    std::shared_lock locker( filetype_candidate_map_mutex_ );
     it = filetype_candidate_map_.find( filetype );
 
     if ( it == filetype_candidate_map_.end() ) {
@@ -85,7 +85,7 @@ std::vector< Result > IdentifierDatabase::ResultsForQueryAndType(
   std::vector< Result > results;
 
   {
-    std::lock_guard< std::mutex > locker( filetype_candidate_map_mutex_ );
+    std::lock_guard locker( filetype_candidate_map_mutex_ );
     for ( const auto& path_and_candidates : *it->second ) {
       for ( const Candidate * candidate : *path_and_candidates.second ) {
         if ( ContainsKey( seen_candidates, candidate ) ) {

--- a/cpp/ycm/IdentifierDatabase.h
+++ b/cpp/ycm/IdentifierDatabase.h
@@ -20,8 +20,8 @@
 
 #include <map>
 #include <memory>
-#include <mutex>
 #include <set>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -95,7 +95,7 @@ private:
   CandidateRepository &candidate_repository_;
 
   FiletypeCandidateMap filetype_candidate_map_;
-  mutable std::mutex filetype_candidate_map_mutex_;
+  mutable std::shared_mutex filetype_candidate_map_mutex_;
 };
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/IdentifierDatabase.h
+++ b/cpp/ycm/IdentifierDatabase.h
@@ -60,11 +60,11 @@ public:
 
   void AddIdentifiers(
     std::vector< std::string >&& new_candidates,
-    const std::string &filetype,
-    const std::string &filepath );
+    std::string&& filetype,
+    std::string&& filepath );
 
-  void ClearCandidatesStoredForFile( const std::string &filetype,
-                                     const std::string &filepath );
+  void ClearCandidatesStoredForFile( std::string&& filetype,
+                                     std::string&& filepath );
 
   std::vector< Result > ResultsForQueryAndType(
     std::string&& query,
@@ -73,13 +73,13 @@ public:
 
 private:
   std::set< const Candidate * > &GetCandidateSet(
-    const std::string &filetype,
-    const std::string &filepath );
+    std::string&& filetype,
+    std::string&& filepath );
 
   void AddIdentifiersNoLock(
     std::vector< std::string >&& new_candidates,
-    const std::string &filetype,
-    const std::string &filepath );
+    std::string&& filetype,
+    std::string&& filepath );
 
 
   // filepath -> *( *candidate )

--- a/cpp/ycm/IdentifierDatabase.h
+++ b/cpp/ycm/IdentifierDatabase.h
@@ -85,11 +85,11 @@ private:
   // filepath -> *( *candidate )
   using FilepathToCandidates =
     std::unordered_map < std::string,
-                         std::shared_ptr< std::set< const Candidate * > > >;
+                         std::unique_ptr< std::set< const Candidate * > > >;
 
   // filetype -> *( filepath -> *( *candidate ) )
   using FiletypeCandidateMap =
-    std::unordered_map < std::string, std::shared_ptr< FilepathToCandidates > >;
+    std::unordered_map < std::string, std::unique_ptr< FilepathToCandidates > >;
 
 
   CandidateRepository &candidate_repository_;

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -18,11 +18,12 @@
 #include "IdentifierUtils.h"
 #include "Utils.h"
 
+#include <filesystem>
 #include <unordered_map>
 
 namespace YouCompleteMe {
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace {
 
@@ -191,7 +192,7 @@ FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
     }();
     auto identifier = line.substr( 0, id_end );
     fs::path path( line.substr( path_begin, path_end - path_begin ) );
-    path = NormalizePath( path, path_to_tag_file.parent_path() );
+    path = fs::weakly_canonical( path_to_tag_file.parent_path() / path );
     const auto language = line.substr( lang_begin, lang_end - lang_begin );
     std::string filetype = FindWithDefault( LANG_TO_FILETYPE,
                                             language.c_str(),

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -19,6 +19,7 @@
 #include "Utils.h"
 
 #include <filesystem>
+#include <string_view>
 #include <unordered_map>
 
 namespace YouCompleteMe {
@@ -30,10 +31,8 @@ namespace {
 // Only used as the equality comparer for the below unordered_map which stores
 // const char* pointers and not std::string but needs to hash based on string
 // values and not pointer values.
-// When passed a const char* this will create a temporary std::string for
-// comparison, but it's fast enough for our use case.
 struct StringEqualityComparer {
-  bool operator()( const std::string &a, const std::string &b ) const {
+  bool operator()( std::string_view a, std::string_view b ) const {
     return a == b;
   }
 };
@@ -44,10 +43,8 @@ struct StringEqualityComparer {
 //   :e $VIMRUNTIME/filetype.vim
 // This is a map of const char* and not std::string to prevent issues with
 // static initialization.
-const std::unordered_map < const char *,
-      const char *,
-      std::hash< std::string >,
-      StringEqualityComparer > LANG_TO_FILETYPE = {
+const std::unordered_map < std::string_view, std::string_view
+      > LANG_TO_FILETYPE = {
         { "Ada"                 , "ada"                 },
         { "AnsiblePlaybook"     , "ansibleplaybook"     },
         { "Ant"                 , "ant"                 },
@@ -190,15 +187,16 @@ FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
       }
       return end;
     }();
-    auto identifier = line.substr( 0, id_end );
-    fs::path path( line.substr( path_begin, path_end - path_begin ) );
+    std::string_view identifier(&line[ 0 ], id_end );
+    fs::path path( line.begin() + path_begin, line.begin() + path_end );
     path = fs::weakly_canonical( path_to_tag_file.parent_path() / path );
-    const auto language = line.substr( lang_begin, lang_end - lang_begin );
-    std::string filetype = FindWithDefault( LANG_TO_FILETYPE,
-                                            language.c_str(),
-                                            Lowercase( language ).c_str() );
-    filetype_identifier_map[ std::move( filetype ) ][ path.string() ]
-      .push_back( std::move( identifier ) );
+    std::string_view language( &line[ lang_begin ], lang_end - lang_begin );
+    std::string filetype( FindWithDefault( LANG_TO_FILETYPE,
+                                           language,
+                                           Lowercase( language ) ) );
+    filetype_identifier_map[ std::move( filetype ) ]
+                           [ std::move( path ).string() ]
+      .emplace_back( identifier );
   }
   return filetype_identifier_map;
 }

--- a/cpp/ycm/IdentifierUtils.h
+++ b/cpp/ycm/IdentifierUtils.h
@@ -20,12 +20,12 @@
 
 #include "IdentifierDatabase.h"
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 namespace YouCompleteMe {
 
 YCM_EXPORT FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
-  const boost::filesystem::path &path_to_tag_file );
+  const std::filesystem::path &path_to_tag_file );
 
 } // namespace YouCompleteMe
 

--- a/cpp/ycm/Utils.cpp
+++ b/cpp/ycm/Utils.cpp
@@ -17,14 +17,14 @@
 
 #include "Utils.h"
 
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
 #include <cmath>
+#include <filesystem>
+#include <fstream>
 #include <limits>
 #include <string>
 #include <vector>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace YouCompleteMe {
 
@@ -32,43 +32,13 @@ std::vector< std::string > ReadUtf8File( const fs::path &filepath ) {
   std::vector< std::string > contents;
   if ( !fs::is_empty( filepath ) && fs::is_regular_file( filepath ) ) {
     std::string line;
-    for( fs::ifstream file( filepath, std::ios::in | std::ios::binary );
+    for( std::ifstream file( filepath.string(),
+                             std::ios::in | std::ios::binary );
          std::getline( file, line ); ) {
       contents.push_back( std::move( line ) );
     }
   }
   return contents;
-}
-
-
-// Cannot use boost::filesystem::weakly_canonical because it raises an exception
-// for non-existing paths in some cases.
-fs::path NormalizePath( const fs::path &filepath, const fs::path &base ) {
-  // Absolutize the path relative to |base|.
-  fs::path absolute_path( fs::absolute( filepath, base ) );
-  fs::path normalized_path( absolute_path );
-
-  // Canonicalize the existing part of the path.
-  fs::path::iterator component( absolute_path.end() );
-  while ( !exists( normalized_path ) && !normalized_path.empty() ) {
-    normalized_path.remove_filename();
-    --component;
-  }
-  if ( !normalized_path.empty() ) {
-    normalized_path = fs::canonical( normalized_path );
-  }
-
-  // Remove '.' and '..' in the remaining part.
-  for ( ; component != absolute_path.end(); ++component ) {
-    if ( *component == ".." ) {
-      normalized_path = normalized_path.parent_path();
-    } else if ( *component != "." ) {
-      normalized_path /= *component;
-    }
-  }
-
-  // Finally, convert slashes into backslashes on Windows.
-  return normalized_path.make_preferred();
 }
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/Utils.h
+++ b/cpp/ycm/Utils.h
@@ -18,13 +18,14 @@
 #ifndef UTILS_H_KEPMRPBH
 #define UTILS_H_KEPMRPBH
 
-#include <boost/filesystem.hpp>
+#include <algorithm>
 #include <cmath>
+#include <filesystem>
 #include <limits>
 #include <string>
 #include <vector>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace YouCompleteMe {
 
@@ -55,14 +56,6 @@ YCM_EXPORT inline std::string Lowercase( const std::string &text ) {
 // Reads the entire contents of the specified file. If the file does not exist,
 // an exception is thrown.
 std::vector< std::string > ReadUtf8File( const fs::path &filepath );
-
-
-// Normalizes a path by making it absolute relative to |base|, resolving
-// symbolic links, removing '.' and '..' in the path, and converting slashes
-// into backslashes on Windows. Contrarily to boost::filesystem::canonical, this
-// works even if the file doesn't exist.
-YCM_EXPORT fs::path NormalizePath( const fs::path &filepath,
-                                   const fs::path &base = fs::current_path() );
 
 
 template <class Container, class Key>

--- a/cpp/ycm/Utils.h
+++ b/cpp/ycm/Utils.h
@@ -23,6 +23,8 @@
 #include <filesystem>
 #include <limits>
 #include <string>
+#include <string_view>
+#include <type_traits>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -44,8 +46,9 @@ YCM_EXPORT inline char Lowercase( uint8_t ascii_character ) {
 }
 
 
-YCM_EXPORT inline std::string Lowercase( const std::string &text ) {
+YCM_EXPORT inline std::string Lowercase( std::string_view text ) {
   std::string result;
+  result.reserve( text.size() );
   for ( auto ascii_character : text ) {
     result.push_back( Lowercase( static_cast< uint8_t >( ascii_character ) ) );
   }
@@ -74,13 +77,17 @@ bool ContainsKey( Container &container, const Key &key ) {
 }
 
 
-template <class Container, class Key>
-typename Container::mapped_type
+template <class Container, class Key, class Ret>
+Ret
 FindWithDefault( Container &container,
                  const Key &key,
-                 const typename Container::mapped_type &value ) {
+                 Ret&& value ) {
+  static_assert( std::is_constructible_v< Ret, typename Container::mapped_type > );
   typename Container::const_iterator it = container.find( key );
-  return it != container.end() ? it->second : value;
+  if ( it != container.end() ) {
+    return Ret{ it->second };
+  }
+  return std::move( value );
 }
 
 

--- a/cpp/ycm/benchmarks/CMakeLists.txt
+++ b/cpp/ycm/benchmarks/CMakeLists.txt
@@ -55,6 +55,5 @@ if( MSVC )
 endif()
 
 target_link_libraries( ${PROJECT_NAME}
-                       ${Boost_LIBRARIES}
                        ycm_core
                        ${BENCHMARK_LIBRARIES} )

--- a/cpp/ycm/tests/CMakeLists.txt
+++ b/cpp/ycm/tests/CMakeLists.txt
@@ -58,10 +58,7 @@ include_directories(
   ${GTEST_INCLUDE_DIRS}
   )
 
-link_directories(
-  ${Boost_LIBRARY_DIRS}
-  ${PYTHON_LIBRARIES}
-  )
+link_directories( ${PYTHON_LIBRARIES} )
 
 file( GLOB_RECURSE SOURCES *.h *.cpp )
 
@@ -107,9 +104,7 @@ if ( MSVC )
   endforeach()
 endif()
 
-# ycm_core must be linked after Boost libraries on Windows.
 target_link_libraries( ${PROJECT_NAME}
-                       ${Boost_LIBRARIES}
                        ycm_core
                        ${GTEST_LIBRARIES}
                        ${GMOCK_LIBRARIES} )

--- a/cpp/ycm/tests/IdentifierUtils_test.cpp
+++ b/cpp/ycm/tests/IdentifierUtils_test.cpp
@@ -21,11 +21,11 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 namespace YouCompleteMe {
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 using ::testing::ElementsAre;
 using ::testing::ContainerEq;
 using ::testing::IsEmpty;
@@ -37,7 +37,8 @@ using ::testing::UnorderedElementsAre;
 TEST( IdentifierUtilsTest, ExtractIdentifiersFromTagsFileWorks ) {
   fs::path root = fs::current_path().root_path();
   fs::path testfile = PathToTestFile( "basic.tags" );
-  fs::path testfile_parent = testfile.parent_path();
+  /* VS2017 returns C:\DIRECT~1\ paths without fs::weakly_canonical() */
+  fs::path testfile_parent = fs::weakly_canonical( testfile.parent_path() );
 
   EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ),
       UnorderedElementsAre(

--- a/cpp/ycm/tests/TestUtils.cpp
+++ b/cpp/ycm/tests/TestUtils.cpp
@@ -19,7 +19,7 @@
 
 #include <whereami.c>
 
-namespace boost {
+namespace std {
 
 namespace filesystem {
 
@@ -29,7 +29,7 @@ void PrintTo( const fs::path &path, std::ostream *os ) {
 
 } // namespace filesystem
 
-} // namespace boost
+} // namespace std
 
 namespace YouCompleteMe {
 

--- a/cpp/ycm/tests/TestUtils.cpp
+++ b/cpp/ycm/tests/TestUtils.cpp
@@ -103,7 +103,7 @@ std::ostream& operator<<( std::ostream& os, const fs::path *path ) {
 }
 
 
-fs::path PathToTestFile( const std::string &filepath ) {
+fs::path PathToTestFile( std::string_view filepath ) {
   int dirname_length;
   int exec_length = wai_getExecutablePath( NULL, 0, NULL );
   std::unique_ptr< char[] > executable( new char [ exec_length ] );

--- a/cpp/ycm/tests/TestUtils.h
+++ b/cpp/ycm/tests/TestUtils.h
@@ -22,26 +22,14 @@
 #include "CodePoint.h"
 #include "Word.h"
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <gmock/gmock.h>
 #include <string>
 #include <vector>
 
 using ::testing::PrintToString;
 
-namespace fs = boost::filesystem;
-
-// A segmentation fault occurs when gtest tries to print a
-// boost::filesystem::path. Teach gtest how to print it.
-namespace boost {
-
-namespace filesystem {
-
-void PrintTo( const fs::path &path, std::ostream *os );
-
-}
-
-}
+namespace fs = std::filesystem;
 
 namespace YouCompleteMe {
 

--- a/cpp/ycm/tests/TestUtils.h
+++ b/cpp/ycm/tests/TestUtils.h
@@ -52,9 +52,9 @@ struct CodePointTuple {
                       code_point.GetBreakProperty() ) {
   }
 
-  CodePointTuple( const std::string &normal,
-                  const std::string &folded_case,
-                  const std::string &swapped_case,
+  CodePointTuple( std::string_view normal,
+                  std::string_view folded_case,
+                  std::string_view swapped_case,
                   bool is_letter,
                   bool is_punctuation,
                   bool is_uppercase,
@@ -104,10 +104,10 @@ struct CharacterTuple {
                       character.IsUppercase() ) {
   }
 
-  CharacterTuple( const std::string &normal,
-                  const std::string &base,
-                  const std::string &folded_case,
-                  const std::string &swapped_case,
+  CharacterTuple( std::string_view normal,
+                  std::string_view base,
+                  std::string_view folded_case,
+                  std::string_view swapped_case,
                   bool is_base,
                   bool is_letter,
                   bool is_punctuation,
@@ -212,7 +212,7 @@ MATCHER_P( ContainsPointees, expected, PrintToString( expected ) ) {
 }
 
 
-fs::path PathToTestFile( const std::string &filepath );
+fs::path PathToTestFile( std::string_view filepath );
 
 } // namespace YouCompleteMe
 

--- a/cpp/ycm/tests/Utils_test.cpp
+++ b/cpp/ycm/tests/Utils_test.cpp
@@ -22,28 +22,7 @@
 
 namespace YouCompleteMe {
 
-class UtilsTest : public ::testing::Test {
-protected:
-  virtual void SetUp() {
-    // The returned temporary path is a symlink on macOS.
-    tmp_dir = fs::canonical( fs::temp_directory_path() ) / fs::unique_path();
-    existing_path = tmp_dir / "existing_path";
-    symlink = tmp_dir / "symlink";
-    fs::create_directories( existing_path );
-    fs::create_directory_symlink( existing_path, symlink );
-  }
-
-  virtual void TearDown() {
-    fs::remove_all( tmp_dir );
-  }
-
-  fs::path tmp_dir;
-  fs::path existing_path;
-  fs::path symlink;
-};
-
-
-TEST_F( UtilsTest, IsUppercase ) {
+TEST( UtilsTest, IsUppercase ) {
   EXPECT_TRUE( IsUppercase( 'A' ) );
   EXPECT_TRUE( IsUppercase( 'B' ) );
   EXPECT_TRUE( IsUppercase( 'Z' ) );
@@ -57,7 +36,7 @@ TEST_F( UtilsTest, IsUppercase ) {
   EXPECT_FALSE( IsUppercase( '~' ) );
 }
 
-TEST_F( UtilsTest, Lowercase ) {
+TEST( UtilsTest, Lowercase ) {
   EXPECT_EQ( Lowercase( 'a' ), 'a' );
   EXPECT_EQ( Lowercase( 'z' ), 'z' );
   EXPECT_EQ( Lowercase( 'A' ), 'a' );
@@ -65,29 +44,6 @@ TEST_F( UtilsTest, Lowercase ) {
   EXPECT_EQ( Lowercase( ';' ), ';' );
 
   EXPECT_EQ( Lowercase( "lOwER_CasE" ), "lower_case" );
-}
-
-
-TEST_F( UtilsTest, NormalizePath ) {
-  EXPECT_THAT( NormalizePath( "" ),   Equals( fs::current_path() ) );
-  EXPECT_THAT( NormalizePath( "." ),  Equals( fs::current_path() ) );
-  EXPECT_THAT( NormalizePath( "./" ), Equals( fs::current_path() ) );
-  EXPECT_THAT( NormalizePath( existing_path ),       Equals( existing_path ) );
-  EXPECT_THAT( NormalizePath( "", existing_path ),   Equals( existing_path ) );
-  EXPECT_THAT( NormalizePath( ".", existing_path ),  Equals( existing_path ) );
-  EXPECT_THAT( NormalizePath( "./", existing_path ), Equals( existing_path ) );
-  EXPECT_THAT( NormalizePath( symlink ),             Equals( existing_path ) );
-  EXPECT_THAT( NormalizePath( "", symlink ),         Equals( existing_path ) );
-  EXPECT_THAT( NormalizePath( ".", symlink ),        Equals( existing_path ) );
-  EXPECT_THAT( NormalizePath( "./", symlink ),       Equals( existing_path ) );
-  EXPECT_THAT( NormalizePath( existing_path / "foo/../bar/./xyz//" ),
-               Equals( existing_path / "bar" / "xyz" ) );
-  EXPECT_THAT( NormalizePath( "foo/../bar/./xyz//", existing_path ),
-               Equals( existing_path / "bar" / "xyz" ) );
-  EXPECT_THAT( NormalizePath( symlink / "foo/../bar/./xyz//" ),
-               Equals( existing_path / "bar" / "xyz" ) );
-  EXPECT_THAT( NormalizePath( "foo/../bar/./xyz//", symlink ),
-               Equals( existing_path / "bar" / "xyz" ) );
 }
 
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -242,8 +242,8 @@ def PytestValgrind( parsed_args, extra_pytests_args ):
           '--gen-suppressions=all',
           '--error-exitcode=1',
           '--leak-check=full',
-          '--show-leak-kinds=all',
-          '--show-reachable=no',
+          '--show-leak-kinds=definite,indirect',
+          '--errors-for-leak-kinds=definite,indirect',
           '--suppressions=' + p.join( DIR_OF_THIS_SCRIPT,
                                       'valgrind.suppressions' ) ]
   subprocess.check_call( cmd +

--- a/valgrind.suppressions
+++ b/valgrind.suppressions
@@ -1,484 +1,54 @@
+# Invalid conditional jumps
+
 {
-	Python default invocation - possibly lost
-	Memcheck:Leak
-	fun:malloc
-	fun:_PyLong_New
+   https://github.com/python/cpython/blob/v3.9.0/Objects/unicodeobject.c#L3443
+   Memcheck:Cond
+   fun:PyUnicode_Decode
+   fun:PyUnicode_Decode
 }
 {
-	Python default invocation - possibly lost
-	Memcheck:Leak
-	fun:malloc
-	fun:_PyBytes_FromSize
+   https://github.com/python/cpython/blob/v3.9.0/Objects/unicodeobject.c#L3731
+   Memcheck:Cond
+   fun:PyUnicode_AsEncodedString
+   fun:PyUnicode_AsEncodedString
+}
+# Definite leaks detected
+{
+   Pybind11 leak to prevent crashes due to CPython bug. Fixed in 3.9.1
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:_Znwm
+   fun:_ZN8pybind1112cpp_function18initialize_genericEPNS_6detail15function_recordEPKcPKPKSt9type_infom
 }
 {
-	Python default invocation - possibly lost
-	Memcheck:Leak
-	fun:malloc
-	fun:_PyObject_GC_Alloc
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:_dl_map_object_deps
+   fun:dl_open_worker
+   fun:_dl_catch_exception
+   fun:_dl_open
+   fun:dlopen_doit
+   fun:_dl_catch_exception
+   fun:_dl_catch_error
+   fun:_dlerror_run
+   fun:dlopen@@GLIBC_2.2.5
+   fun:_PyImport_FindSharedFuncptr
+   fun:_PyImport_LoadDynamicModuleWithSpec
 }
 {
-	Python default invocation - possibly lost
-	Memcheck:Leak
-	fun:malloc
-	fun:new_dict_with_shared_keys
-	fun:PyObject_GenericGetDict
-}
-{
-	Python default invocation - possibly lost
-	Memcheck:Leak
-	fun:malloc
-	fun:new_dict_with_shared_keys
-	fun:_PyObjectDict_SetItem
-}
-{
-	Python default invocation - possibly lost
-	Memcheck:Leak
-	fun:malloc
-	fun:new_keys_object
-	fun:dictresize
-	fun:insertion_resize
-	fun:insertdict
-}
-{
-	Python default invocation - possibly lost
-	Memcheck:Leak
-	fun:malloc
-	fun:new_keys_object
-	fun:insert_to_emptydict
-	fun:PyDict_SetItem
-}
-{
-	Python default invocation - possibly lost
-	Memcheck:Leak
-	fun:malloc
-	fun:PyFloat_FromDouble
-}
-{
-	Python default invocation - possibly lost
-	Memcheck:Leak
-	fun:malloc
-	fun:PyUnicode_New
-}
-{
-	Python default invocation - possibly lost
-	Memcheck:Leak
-	fun:malloc
-	fun:clone_combined_dict
-	fun:PyDict_Copy
-}
-{
-	Python default invocation - possibly lost
-	Memcheck:Leak
-	fun:realloc
-	fun:_PyObject_GC_Resize
-}
-{
-	Python default invocation - possibly lost
-	Memcheck:Leak
-	fun:malloc
-	fun:PyCode_NewWithPosOnlyArgs
-}
-{
-	Python default invocation - possibly lost
-	Memcheck:Leak
-	fun:malloc
-	fun:new_keys_object
-	fun:_PyDict_NewPresized
-}
-{
-	Python default invocation - possibly lost
-	Memcheck:Leak
-	fun:malloc
-	fun:new_keys_object
-	fun:dictresize
-	fun:insertion_resize
-	fun:PyDict_SetDefault
-}
-{
-	GTest use of uninitialized value of size 8
-	Memcheck:Value8
-	fun:_itoa_word
-	fun:vfprintf
-	fun:__vsnprintf_chk
-	fun:__snprintf_chk
-	fun:_ZN7testing12_GLOBAL__N_126PrintByteSegmentInObjectToEPKhmmPSo
-	fun:_ZN7testing9internal220PrintBytesInObjectToEPKhmPSo
-	fun:_ZN7testing8internal20MatchPrintAndExplainIKSt6vectorIN13YouCompleteMe14CompletionDataESaIS4_EERS7_EEbRT_RKNS_7MatcherIT0_EEPNS_19MatchResultListenerE
-	fun:_ZNK7testing8internal29PredicateFormatterFromMatcherINS0_15ContainsMatcherINS_18PolymorphicMatcherINS0_15PropertyMatcherIN13YouCompleteMe14CompletionDataESsEEEEEEEclISt6vectorIS6_SaIS6_EEEENS_15AssertionResultEPKcRKT_
-	fun:_ZN13YouCompleteMe42ClangCompleterTest_BufferTextNoParens_Test8TestBodyEv
-	fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
-	fun:_ZN7testing4Test3RunEv
-	fun:_ZN7testing8TestInfo3RunEv
-}
-{
-	GTest conditional jump depends on uninitialized variable
-	Memcheck:Cond
-	fun:vfprintf
-	fun:__vsnprintf_chk
-	fun:__snprintf_chk
-	fun:_ZN7testing12_GLOBAL__N_126PrintByteSegmentInObjectToEPKhmmPSo
-	fun:_ZN7testing9internal220PrintBytesInObjectToEPKhmPSo
-	fun:_ZN7testing8internal20MatchPrintAndExplainIKSt6vectorIN13YouCompleteMe14CompletionDataESaIS4_EERS7_EEbRT_RKNS_7MatcherIT0_EEPNS_19MatchResultListenerE
-	fun:_ZNK7testing8internal29PredicateFormatterFromMatcherINS0_15ContainsMatcherINS_18PolymorphicMatcherINS0_15PropertyMatcherIN13YouCompleteMe14CompletionDataESsEEEEEEEclISt6vectorIS6_SaIS6_EEEENS_15AssertionResultEPKcRKT_
-	fun:_ZN13YouCompleteMe42ClangCompleterTest_BufferTextNoParens_Test8TestBodyEv
-	fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
-	fun:_ZN7testing4Test3RunEv
-	fun:_ZN7testing8TestInfo3RunEv
-	fun:_ZN7testing8TestCase3RunEv
-}
-{
-	GTest conditional jump depends on uninitialized variable
-	Memcheck:Cond
-	fun:_itoa_word
-	fun:vfprintf
-	fun:__vsnprintf_chk
-	fun:__snprintf_chk
-	fun:_ZN7testing12_GLOBAL__N_126PrintByteSegmentInObjectToEPKhmmPSo
-	fun:_ZN7testing9internal220PrintBytesInObjectToEPKhmPSo
-	fun:_ZN7testing8internal20MatchPrintAndExplainIKSt6vectorIN13YouCompleteMe14CompletionDataESaIS4_EERS7_EEbRT_RKNS_7MatcherIT0_EEPNS_19MatchResultListenerE
-	fun:_ZNK7testing8internal29PredicateFormatterFromMatcherINS0_15ContainsMatcherINS_18PolymorphicMatcherINS0_15PropertyMatcherIN13YouCompleteMe14CompletionDataESsEEEEEEEclISt6vectorIS6_SaIS6_EEEENS_15AssertionResultEPKcRKT_
-	fun:_ZN13YouCompleteMe42ClangCompleterTest_BufferTextNoParens_Test8TestBodyEv
-	fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
-	fun:_ZN7testing4Test3RunEv
-	fun:_ZN7testing8TestInfo3RunEv
-}
-{
-	Pytest during collection
-	Memcheck:Addr8
-	fun:strncmp
-	fun:is_dst
-	fun:_dl_dst_count
-	fun:expand_dynamic_string_token
-	fun:fillin_rpath
-	fun:decompose_rpath.isra.0
-	fun:_dl_map_object
-	fun:openaux
-	fun:_dl_catch_exception
-	fun:_dl_map_object_deps
-	fun:dl_open_worker
-	fun:_dl_catch_exception
-}
-{
-	Pytest during collection
-	Memcheck:Addr8
-	fun:strncmp
-	fun:is_dst
-	fun:_dl_dst_substitute
-	fun:fillin_rpath
-	fun:decompose_rpath.isra.0
-	fun:_dl_map_object
-	fun:openaux
-	fun:_dl_catch_exception
-	fun:_dl_map_object_deps
-	fun:dl_open_worker
-	fun:_dl_catch_exception
-	fun:_dl_open
-}
-{
-	Pybind11 leak, see https://github.com/pybind/pybind11/pull/2024 - definitely lost
-	Memcheck:Leak
-	match-leak-kinds: definite
-	fun:_Znwm
-	fun:_ZN8pybind116moduleC1EPKcS2_
-	fun:PyInit_ycm_core
-	fun:_PyImport_LoadDynamicModuleWithSpec
-	fun:_imp_create_dynamic_impl
-	fun:_imp_create_dynamic
-	fun:cfunction_vectorcall_FASTCALL
-	fun:PyVectorcall_Call
-	fun:do_call_core
-	fun:_PyEval_EvalFrameDefault
-	fun:_PyEval_EvalCodeWithName
-	fun:_PyFunction_Vectorcall
-	fun:_PyObject_Vectorcall
-	fun:call_function
-	fun:_PyEval_EvalFrameDefault
-	fun:function_code_fastcall
-}
-{
-	Libclang leak? - definitely lost
-	Memcheck:Leak
-	fun:_ZnwmRKSt9nothrow_t
-	fun:_ZN4llvm20WritableMemoryBuffer21getNewUninitMemBufferEmRKNS_5TwineE
-	fun:_ZN4llvm12MemoryBuffer16getMemBufferCopyENS_9StringRefERKNS_5TwineE
-	fun:_ZN4llvm12function_refIFvvEE11callback_fnIZ35clang_parseTranslationUnit2FullArgvEUlvE_EEvl
-	fun:_ZN4llvm20CrashRecoveryContext9RunSafelyENS_12function_refIFvvEEE
-	fun:_ZL26RunSafelyOnThread_DispatchPv
-	fun:_ZL24ExecuteOnThread_DispatchPv
-	fun:start_thread
-}
-{
-	Pytest at shutdown?
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:malloc
-	fun:PyType_GenericAlloc
-	fun:s_new
-	fun:type_call
-	fun:_PyObject_MakeTpCall
-	fun:_PyObject_Vectorcall
-}
-{
-	Pytest at shutdown?
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:malloc
-	fun:prepare_s
-	fun:Struct___init___impl
-	fun:Struct___init__
-	fun:type_call
-	fun:_PyObject_MakeTpCall
-	fun:_PyObject_Vectorcall
-	fun:_PyObject_FastCall
-	fun:object_vacall
-	fun:PyObject_CallFunctionObjArgs
-	fun:cache_struct_converter
-	fun:pack
-	fun:cfunction_vectorcall_FASTCALL
-	fun:_PyObject_Vectorcall
-	fun:call_function
-	fun:_PyEval_EvalFrameDefault
-	fun:function_code_fastcall
-	fun:_PyObject_Vectorcall
-	fun:call_function
-	fun:_PyEval_EvalFrameDefault
-	fun:function_code_fastcall
-}
-{
-	Pytest at shutdown?
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:malloc
-	fun:PyType_GenericAlloc
-	fun:s_new
-	fun:type_call
-	fun:_PyObject_MakeTpCall
-	fun:_PyObject_Vectorcall
-	fun:_PyObject_FastCall
-	fun:object_vacall
-	fun:PyObject_CallFunctionObjArgs
-	fun:cache_struct_converter
-	fun:calcsize
-	fun:cfunction_vectorcall_O
-	fun:_PyObject_Vectorcall
-	fun:call_function
-	fun:_PyEval_EvalFrameDefault
-	fun:_PyEval_EvalCodeWithName
-	fun:PyEval_EvalCodeEx
-}
-{
-	Pytest at shutdown?
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:malloc
-	fun:prepare_s
-	fun:Struct___init___impl
-	fun:Struct___init__
-	fun:type_call
-	fun:_PyObject_MakeTpCall
-	fun:_PyObject_Vectorcall
-	fun:_PyObject_FastCall
-	fun:object_vacall
-	fun:PyObject_CallFunctionObjArgs
-	fun:cache_struct_converter
-	fun:calcsize
-	fun:cfunction_vectorcall_O
-	fun:_PyObject_Vectorcall
-	fun:call_function
-	fun:_PyEval_EvalFrameDefault
-	fun:_PyEval_EvalCodeWithName
-	fun:PyEval_EvalCodeEx
-	fun:PyEval_EvalCode
-}
-{
-	Pytest at shutdown
-	Memcheck:Leak
-	match-leak-kinds: definite
-	fun:malloc
-	fun:_dl_map_object_deps
-	fun:dl_open_worker
-	fun:_dl_catch_exception
-	fun:_dl_open
-	fun:dlopen_doit
-	fun:_dl_catch_exception
-	fun:_dl_catch_error
-	fun:_dlerror_run
-	fun:dlopen@@GLIBC_2.2.5
-	fun:_PyImport_FindSharedFuncptr
-	fun:_PyImport_LoadDynamicModuleWithSpec
-}
-{
-	Pytest at shutdown
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:realloc
-	fun:_PyBytes_Resize
-}
-{
-	Magically appeared when upgrading to Ubuntu 18.04
-	Memcheck:Cond
-	fun:__wcsnlen_avx2
-	fun:wcsrtombs
-	fun:wcstombs
-	fun:wcstombs
-	fun:encode_current_locale
-	fun:encode_locale_ex
-}
-{
-	Magically appeared when upgrading to Ubuntu 18.04
-	Memcheck:Cond
-	fun:internal_utf8_loop
-	fun:__gconv_transform_internal_utf8
-	fun:wcsrtombs
-	fun:wcstombs
-	fun:wcstombs
-	fun:encode_current_locale
-	fun:encode_locale_ex
-}
-{
-	Pytest at shutdown?
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:malloc
-	fun:PyUnicode_AsUnicodeAndSize
-}
-{
-	Pytest at shutdown?
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:calloc
-	fun:_PyCode_InitOpcache
-}
-{
-	Pytest at shutdown?
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:malloc
-	fun:PyComplex_FromCComplex
-}
-{
-	Pytest at shutdown?
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:calloc
-	fun:_PyCode_InitOpcache
-}
-{
-	Pytest at shutdown?
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:malloc
-	fun:new_keys_object
-	fun:_PyDict_NewKeysForClass
-}
-{
-	Pytest at shutdown?
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:malloc
-	fun:new_keys_object
-	fun:insert_to_emptydict
-	fun:PyDict_SetDefault
-}
-{
-	Pytest at shutdown?
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:realloc
-	fun:resize_compact
-	fun:unicode_resize
-	fun:PyUnicode_Append
-}
-{
-	Pytest at shutdown?
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:malloc
-	fun:new_keys_object
-	fun:dictresize
-	fun:dict_merge
-}
-{
-	Pytest at shutdown?
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:realloc
-	fun:resize_compact
-	fun:_PyUnicodeWriter_Finish
-}
-{
-	Libclang 10 new leak
-	Memcheck:Leak
-	fun:_ZnwmRKSt9nothrow_t
-	fun:_ZN4llvm20WritableMemoryBuffer21getNewUninitMemBufferEmRKNS_5TwineE
-	fun:_ZN4llvm12MemoryBuffer16getMemBufferCopyENS_9StringRefERKNS_5TwineE
-	fun:_ZL31clang_parseTranslationUnit_ImplPvPKcPKS1_iN4llvm8ArrayRefI13CXUnsavedFileEEjPP21CXTranslationUnitImpl
-	fun:_ZN4llvm12function_refIFvvEE11callback_fnIZ35clang_parseTranslationUnit2FullArgvEUlvE_EEvl
-	fun:_ZN4llvm20CrashRecoveryContext9RunSafelyENS_12function_refIFvvEEE
-	fun:_ZL26RunSafelyOnThread_DispatchPv
-	fun:_ZL14threadFuncSyncPv
-	fun:start_thread
-	fun:clone
-}
-{
-	<insert_a_suppression_name_here>
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:realloc
-	fun:_PyBytes_Resize
-	fun:assemble
-	fun:compiler_function
-	fun:compiler_function
-	fun:compiler_body
-	fun:compiler_class
-	fun:compiler_visit_stmt
-	fun:compiler_body
-	fun:compiler_mod
-	fun:PyAST_CompileObject
-}
-{
-	<insert_a_suppression_name_here>
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:malloc
-	fun:new_keys_object
-	fun:dict_new
-	fun:type_call
-}
-{
-	<insert_a_suppression_name_here>
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:malloc
-	fun:_sre_compile_impl
-	fun:_sre_compile
-	fun:cfunction_vectorcall_FASTCALL_KEYWORDS
-	fun:_PyObject_Vectorcall
-}
-{
-	<insert_a_suppression_name_here>
-	Memcheck:Leak
-	match-leak-kinds: possible
-	fun:malloc
-	fun:new_keys_object
-	fun:insert_to_emptydict
-	fun:_PyDict_SetItem_KnownHash
-	fun:bounded_lru_cache_wrapper
-	fun:_PyObject_MakeTpCall
-	fun:_PyObject_Vectorcall
-	fun:trace_call_function
-	fun:call_function
-	fun:_PyEval_EvalFrameDefault
-	fun:function_code_fastcall
-	fun:_PyObject_Vectorcall
-	fun:call_function
-	fun:_PyEval_EvalFrameDefault
-	fun:function_code_fastcall
-	fun:_PyObject_Vectorcall
-	fun:call_function
-	fun:_PyEval_EvalFrameDefault
-	fun:function_code_fastcall
-	fun:_PyObject_Vectorcall
-	fun:method_vectorcall
-	fun:PyVectorcall_Call
+   https://bugs.llvm.org/show_bug.cgi?id=47832
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:_ZnwmRKSt9nothrow_t
+   fun:_ZN4llvm20WritableMemoryBuffer21getNewUninitMemBufferEmRKNS_5TwineE
+   fun:_ZN4llvm12MemoryBuffer16getMemBufferCopyENS_9StringRefERKNS_5TwineE
+   fun:_ZL31clang_parseTranslationUnit_ImplPvPKcPKS1_iN4llvm8ArrayRefI13CXUnsavedFileEEjPP21CXTranslationUnitImpl
+   fun:_ZN4llvm12function_refIFvvEE11callback_fnIZ35clang_parseTranslationUnit2FullArgvEUlvE_EEvl
+   fun:_ZN4llvm20CrashRecoveryContext9RunSafelyENS_12function_refIFvvEEE
+   fun:_ZL26RunSafelyOnThread_DispatchPv
+   fun:_ZL14threadFuncSyncPv
+   fun:start_thread
+   fun:clone
 }

--- a/ycmd/tests/clang/get_completions_test.py
+++ b/ycmd/tests/clang/get_completions_test.py
@@ -797,7 +797,7 @@ def GetCompletions_QuotedInclude_AtStart_test( app ):
       'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
       'line_num'  : 11,
       'column_num': 11,
-      'compilation_flags': [ '-x', 'cpp', '-nostdinc', '-nobuiltininc' ]
+      'compilation_flags': [ '-x', 'c++', '-nostdinc', '-nobuiltininc' ]
     },
     'expect': {
       'response': requests.codes.ok,
@@ -828,7 +828,7 @@ def GetCompletions_QuotedInclude_UserIncludeFlag_test( app ):
       'line_num'  : 11,
       'column_num': 11,
       'compilation_flags': [
-        '-x', 'cpp', '-nostdinc', '-nobuiltininc',
+        '-x', 'c++', '-nostdinc', '-nobuiltininc',
         '-I', PathToTestFile( 'test-include', 'system' )
       ]
     },
@@ -863,7 +863,7 @@ def GetCompletions_QuotedInclude_SystemIncludeFlag_test( app ):
       'line_num'  : 11,
       'column_num': 11,
       'compilation_flags': [
-        '-x', 'cpp', '-nostdinc', '-nobuiltininc',
+        '-x', 'c++', '-nostdinc', '-nobuiltininc',
         '-isystem', PathToTestFile( 'test-include', 'system' )
       ]
     },
@@ -898,7 +898,7 @@ def GetCompletions_QuotedInclude_QuoteIncludeFlag_test( app ):
       'line_num'  : 11,
       'column_num': 11,
       'compilation_flags': [
-        '-x', 'cpp', '-nostdinc', '-nobuiltininc',
+        '-x', 'c++', '-nostdinc', '-nobuiltininc',
         '-iquote', PathToTestFile( 'test-include', 'quote' )
       ]
     },
@@ -932,7 +932,7 @@ def GetCompletions_QuotedInclude_MultipleIncludeFlags_test( app ):
       'line_num'  : 11,
       'column_num': 11,
       'compilation_flags': [
-        '-x', 'cpp', '-nostdinc', '-nobuiltininc',
+        '-x', 'c++', '-nostdinc', '-nobuiltininc',
         '-I', PathToTestFile( 'test-include', 'dir with spaces' ),
         '-I', PathToTestFile( 'test-include', 'quote' ),
         '-I', PathToTestFile( 'test-include', 'system' )
@@ -970,7 +970,7 @@ def GetCompletions_QuotedInclude_AfterDirectorySeparator_test( app ):
       'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
       'line_num'  : 11,
       'column_num': 27,
-      'compilation_flags': [ '-x', 'cpp', '-nostdinc', '-nobuiltininc' ]
+      'compilation_flags': [ '-x', 'c++', '-nostdinc', '-nobuiltininc' ]
     },
     'expect': {
       'response': requests.codes.ok,
@@ -994,7 +994,7 @@ def GetCompletions_QuotedInclude_AfterDot_test( app ):
       'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
       'line_num'  : 11,
       'column_num': 28,
-      'compilation_flags': [ '-x', 'cpp', '-nostdinc', '-nobuiltininc' ]
+      'compilation_flags': [ '-x', 'c++', '-nostdinc', '-nobuiltininc' ]
     },
     'expect': {
       'response': requests.codes.ok,
@@ -1018,7 +1018,7 @@ def GetCompletions_QuotedInclude_AfterSpace_test( app ):
       'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
       'line_num'  : 11,
       'column_num': 20,
-      'compilation_flags': [ '-x', 'cpp', '-nostdinc', '-nobuiltininc' ]
+      'compilation_flags': [ '-x', 'c++', '-nostdinc', '-nobuiltininc' ]
     },
     'expect': {
       'response': requests.codes.ok,
@@ -1042,7 +1042,7 @@ def GetCompletions_QuotedInclude_Invalid_test( app ):
       'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
       'line_num'  : 13,
       'column_num': 12,
-      'compilation_flags': [ '-x', 'cpp', '-nostdinc', '-nobuiltininc' ]
+      'compilation_flags': [ '-x', 'c++', '-nostdinc', '-nobuiltininc' ]
     },
     'expect': {
       'response': requests.codes.ok,
@@ -1065,7 +1065,7 @@ def GetCompletions_QuotedInclude_FrameworkHeader_test( app ):
       'line_num'  : 14,
       'column_num': 18,
       'compilation_flags': [
-        '-x', 'cpp', '-nostdinc', '-nobuiltininc',
+        '-x', 'c++', '-nostdinc', '-nobuiltininc',
         '-iframework', PathToTestFile( 'test-include', 'Frameworks' )
       ]
     },
@@ -1091,7 +1091,7 @@ def GetCompletions_BracketInclude_AtStart_test( app ):
       'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
       'line_num'  : 12,
       'column_num': 11,
-      'compilation_flags': [ '-x', 'cpp', '-nostdinc', '-nobuiltininc' ]
+      'compilation_flags': [ '-x', 'c++', '-nostdinc', '-nobuiltininc' ]
     },
     'expect': {
       'response': requests.codes.ok,
@@ -1114,7 +1114,7 @@ def GetCompletions_BracketInclude_UserIncludeFlag_test( app ):
       'line_num'  : 12,
       'column_num': 11,
       'compilation_flags': [
-        '-x', 'cpp', '-nostdinc', '-nobuiltininc',
+        '-x', 'c++', '-nostdinc', '-nobuiltininc',
         '-I', PathToTestFile( 'test-include', 'system' )
       ]
     },
@@ -1143,7 +1143,7 @@ def GetCompletions_BracketInclude_SystemIncludeFlag_test( app ):
       'line_num'  : 12,
       'column_num': 11,
       'compilation_flags': [
-        '-x', 'cpp', '-nostdinc', '-nobuiltininc',
+        '-x', 'c++', '-nostdinc', '-nobuiltininc',
         '-isystem', PathToTestFile( 'test-include', 'system' )
       ]
     },
@@ -1172,7 +1172,7 @@ def GetCompletions_BracketInclude_QuoteIncludeFlag_test( app ):
       'line_num'  : 12,
       'column_num': 11,
       'compilation_flags': [
-        '-x', 'cpp', '-nostdinc', '-nobuiltininc',
+        '-x', 'c++', '-nostdinc', '-nobuiltininc',
         '-iquote', PathToTestFile( 'test-include', 'quote' )
       ]
     },
@@ -1197,7 +1197,7 @@ def GetCompletions_BracketInclude_MultipleIncludeFlags_test( app ):
       'line_num'  : 12,
       'column_num': 11,
       'compilation_flags': [
-        '-x', 'cpp', '-nostdinc', '-nobuiltininc',
+        '-x', 'c++', '-nostdinc', '-nobuiltininc',
         '-I', PathToTestFile( 'test-include', 'dir with spaces' ),
         '-I', PathToTestFile( 'test-include', 'quote' ),
         '-I', PathToTestFile( 'test-include', 'system' )
@@ -1229,7 +1229,7 @@ def GetCompletions_BracketInclude_AtDirectorySeparator_test( app ):
       'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
       'line_num'  : 12,
       'column_num': 18,
-      'compilation_flags': [ '-x', 'cpp', '-nostdinc', '-nobuiltininc' ],
+      'compilation_flags': [ '-x', 'c++', '-nostdinc', '-nobuiltininc' ],
       # NOTE: when not forcing semantic, it falls back to the filename
       # completer and returns the root folder entries.
       'force_semantic': True
@@ -1255,7 +1255,7 @@ def GetCompletions_BracketInclude_FrameworkHeader_test( app ):
       'line_num'  : 15,
       'column_num': 18,
       'compilation_flags': [
-        '-x', 'cpp', '-nostdinc', '-nobuiltininc',
+        '-x', 'c++', '-nostdinc', '-nobuiltininc',
         '-iframework', PathToTestFile( 'test-include', 'Frameworks' )
       ]
     },
@@ -1283,7 +1283,7 @@ def GetCompletions_BracketInclude_FileAndDirectory_test( app ):
       'line_num'  : 12,
       'column_num': 11,
       'compilation_flags': [
-        '-x', 'cpp', '-nostdinc', '-nobuiltininc',
+        '-x', 'c++', '-nostdinc', '-nobuiltininc',
         '-isystem', PathToTestFile( 'test-include', 'system' ),
         '-isystem', PathToTestFile( 'test-include', 'system', 'common' )
       ]
@@ -1313,7 +1313,7 @@ def GetCompletions_BracketInclude_FileAndFramework_test( app ):
       'line_num'  : 12,
       'column_num': 11,
       'compilation_flags': [
-        '-x', 'cpp', '-nostdinc', '-nobuiltininc',
+        '-x', 'c++', '-nostdinc', '-nobuiltininc',
         '-iframework', PathToTestFile( 'test-include', 'Frameworks' ),
         '-isystem', PathToTestFile( 'test-include', 'system', 'common' )
       ]
@@ -1343,7 +1343,7 @@ def GetCompletions_BracketInclude_DirectoryAndFramework_test( app ):
       'line_num'  : 12,
       'column_num': 11,
       'compilation_flags': [
-        '-x', 'cpp', '-nostdinc', '-nobuiltininc',
+        '-x', 'c++', '-nostdinc', '-nobuiltininc',
         '-iframework', PathToTestFile( 'test-include', 'Frameworks' ),
         '-isystem', PathToTestFile( 'test-include', 'system' )
       ]
@@ -1375,7 +1375,7 @@ def GetCompletions_BracketInclude_FileAndDirectoryAndFramework_test( app ):
       'line_num'  : 12,
       'column_num': 11,
       'compilation_flags': [
-        '-x', 'cpp', '-nostdinc', '-nobuiltininc',
+        '-x', 'c++', '-nostdinc', '-nobuiltininc',
         '-iframework', PathToTestFile( 'test-include', 'Frameworks' ),
         '-isystem', PathToTestFile( 'test-include', 'system' ),
         '-isystem', PathToTestFile( 'test-include', 'system', 'common' )

--- a/ycmd/tests/clangd/get_completions_test.py
+++ b/ycmd/tests/clangd/get_completions_test.py
@@ -659,7 +659,7 @@ def GetCompletions_QuotedInclude_AfterDot_test( app ):
       'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
       'line_num'  : 9,
       'column_num': 28,
-      'compilation_flags': [ '-x', 'cpp' ]
+      'compilation_flags': [ '-x', 'c++' ]
     },
     'expect': {
       'response': requests.codes.ok,
@@ -755,7 +755,7 @@ def GetCompletions_BracketInclude_AtDirectorySeparator_test( app ):
       'filepath'  : PathToTestFile( 'test-include', 'main.cpp' ),
       'line_num'  : 10,
       'column_num': 18,
-      'compilation_flags': [ '-x', 'cpp' ],
+      'compilation_flags': [ '-x', 'c++' ],
       # NOTE: when not forcing semantic, it falls back to the filename
       # completer and returns the root folder entries.
       'force_semantic': True


### PR DESCRIPTION
List of changes:

- Switch to C++17
- Use `string_view` where appropriate
- Allow shared lock ownership
- Avoid raw new, with `make_unique`
- Avoid `shared_ptr` in the identifier database
- Do not show valgrind 'possibly lost' leak errors
- Avoid AST deserialization errors in libclang/clangd tests

The BoostParts removal is left out because it kills Reviewable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1489)
<!-- Reviewable:end -->
