### PR TITLE
[NOT READY] Package ycmd with setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,9 @@ third_party/generic_server/package-lock.json
 third_party/go
 
 third_party/regex-build
+
+# wheel build
+build/
+dist/
+.eggs/
+ycmd.egg-info/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,33 @@
+[metadata]
+name = ycmd
+version = 0.0.1
+author = ycmd contributors
+author_email = ycm-users@googlegroups.com
+description = A multi-language code comprehension and completion server
+url = https://github.com/ycm-core/ycmd
+license = GPLv3
+long_description =
+  file: README.md
+  COPYING.txt
+
+[options]
+zip_safe = False
+packages = find:
+python_requires = >= 3.6
+setup_requires =
+  wheel
+  setuptools
+install_requires =
+  waitress == 1.4.3
+  bottle == 0.12.18
+  requests == 2.22.0
+  regex == 2020.10.28
+  jedi == 0.17.2
+  watchdog == 0.10.2
+
+[options.packages.find]
+include = ycmd*
+exclude = ycmd.tests*
+
+[options.package_data]
+ycmd = default_settings.json

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,10 +14,9 @@ long_description =
 zip_safe = False
 packages = find:
 python_requires = >= 3.6
-setup_requires =
+install_requires =
   wheel
   setuptools
-install_requires =
   waitress == 1.4.3
   bottle == 0.12.18
   requests == 2.22.0

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,11 @@ def GetDirContents( data_files: list, root: pathlib.Path ):
 
 setuptools.setup(
   # project_urls = { TODO
-  #   'Documentation': 'https://packaging.python.org/tutorials/distributing-packages/',
-  #   'Funding': 'https://donate.pypi.org',
-  #   'Say Thanks!': 'http://saythanks.io/to/example',
-  #   'Source': 'https://github.com/pypa/sampleproject/',
-  #   'Tracker': 'https://github.com/pypa/sampleproject/issues',
+  #   'Documentation': '',
+  #   'Funding': '',
+  #   'Say Thanks!': '',
+  #   'Source': '',
+  #   'Tracker': '',
   # },
   # classifiers = [], TODO
   # keywords = [], TODO

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,54 @@
+import setuptools
+from distutils.core import Extension
+import pathlib
+import os
+
+with open( 'CORE_VERSION' ) as version:
+  YCMD_CORE_VERSION = version.read().rstrip()
+
+ycm_core = Extension(
+  'ycm_core',
+  sources = [
+      str( p ) for p in pathlib.Path( 'cpp/ycm' ).glob( '*.cpp' )
+  ],
+  define_macros = [
+    ( 'YCMD_CORE_VERSION', YCMD_CORE_VERSION ),
+    ( 'YCM_EXPORT', '' ),
+    # TODO: YCM_EXPORT
+    # TODO: /DUNICODE /MP /bigobj /utf-8
+  ],
+  extra_compile_args = [ '-std=c++17' ],
+  include_dirs = [ 'cpp/pybind11' ],
+  language = 'c++'
+)
+
+
+def GetDirContents( data_files: list, root: pathlib.Path ):
+  files = []
+  for f in root.iterdir():
+    if f.is_dir():
+      GetDirContents( data_files, f )
+    else:
+      files.append( str( f ) )
+
+  rel_path = os.path.relpath( str( root ) )
+  data_files.append( ( os.path.join( 'ycmd', rel_path ), files ) )
+  return data_files
+
+
+setuptools.setup(
+  # project_urls = { TODO
+  #   'Documentation': 'https://packaging.python.org/tutorials/distributing-packages/',
+  #   'Funding': 'https://donate.pypi.org',
+  #   'Say Thanks!': 'http://saythanks.io/to/example',
+  #   'Source': 'https://github.com/pypa/sampleproject/',
+  #   'Tracker': 'https://github.com/pypa/sampleproject/issues',
+  # },
+  # classifiers = [], TODO
+  # keywords = [], TODO
+
+  data_files = [
+    ( 'ycmd', [ 'CORE_VERSION' ] ),
+  ] + GetDirContents( [], pathlib.Path( 'third_party/clang/lib' ) ),
+  ext_modules = [ ycm_core ]
+)

--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -25,7 +25,7 @@ from ycmd.completers.cpp.flags import ( AddMacIncludePaths,
                                         ShouldAllowWinStyleFlags )
 from ycmd.completers.language_server import language_server_completer
 from ycmd.completers.language_server import language_server_protocol as lsp
-from ycmd.utils import ( CLANG_RESOURCE_DIR,
+from ycmd.utils import ( GetClangResourceDir,
                          GetExecutable,
                          ExpandVariablesInPath,
                          FindExecutable,
@@ -116,7 +116,7 @@ def GetClangdExecutableAndResourceDir( user_options ):
     if not third_party_clangd:
       return None, None
     clangd = third_party_clangd
-    resource_dir = CLANG_RESOURCE_DIR
+    resource_dir = GetClangResourceDir()
 
   LOGGER.info( 'Using Clangd from %s', clangd )
   return clangd, resource_dir

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -25,7 +25,7 @@ from ycmd.utils import ( AbsolutePath,
                          PathsToAllParentFolders,
                          re,
                          ToUnicode,
-                         CLANG_RESOURCE_DIR )
+                         GetClangResourceDir )
 from ycmd.responses import NoExtraConfDetected
 ycm_core = ImportCore()
 
@@ -287,7 +287,7 @@ def PrepareFlagsForClang( flags,
   flags = RemoveUnusedFlags( flags, filename, enable_windows_style_flags )
   if add_extra_clang_flags:
     # This flag tells libclang where to find the builtin includes.
-    flags.append( '-resource-dir=' + CLANG_RESOURCE_DIR )
+    flags.append( '-resource-dir=' + GetClangResourceDir() )
     # On Windows, parsing of templates is delayed until instantiation time.
     # This makes GetType and GetParent commands fail to return the expected
     # result when the cursor is in a template.
@@ -565,7 +565,7 @@ def AddMacIncludePaths( flags ):
 
   if use_builtin_includes:
     flags.extend( [
-      '-isystem', os.path.join( CLANG_RESOURCE_DIR, 'include' ) ] )
+      '-isystem', os.path.join( GetClangResourceDir(), 'include' ) ] )
 
   if use_standard_system_includes:
     if toolchain:

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -114,12 +114,19 @@ def ShouldEnableJavaCompleter( user_options ):
     LOGGER.warning( "Not enabling java completion: Couldn't find java 11" )
     return False
 
+  # TODO: Is this the canonical way to do this ?
+  if 'jdtls_repository_path' in user_options:
+    global LANGUAGE_SERVER_HOME
+    LANGUAGE_SERVER_HOME = user_options[ 'jdtls_repository_path' ]
+
   if not os.path.exists( LANGUAGE_SERVER_HOME ):
-    LOGGER.warning( 'Not using java completion: jdt.ls is not installed' )
+    LOGGER.warning( 'Not using java completion: jdt.ls is not installed at ' +
+                    LANGUAGE_SERVER_HOME )
     return False
 
   if not _PathToLauncherJar():
-    LOGGER.warning( 'Not using java completion: jdt.ls is not built' )
+    LOGGER.warning( 'Not using java completion: jdt.ls is not built in ' +
+                    LANGUAGE_SERVER_HOME )
     return False
 
   return True
@@ -299,10 +306,11 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
     if not isinstance( self._extension_path, list ):
       raise ValueError( f'{ EXTENSION_PATH_OPTION } option must be a list' )
 
-    if not self._extension_path:
-      self._extension_path = [ DEFAULT_EXTENSION_PATH ]
-    else:
-      self._extension_path.append( DEFAULT_EXTENSION_PATH )
+    if os.path.isdir( DEFAULT_EXTENSION_PATH ):
+      if not self._extension_path:
+        self._extension_path = [ DEFAULT_EXTENSION_PATH ]
+      else:
+        self._extension_path.append( DEFAULT_EXTENSION_PATH )
 
     self._bundles = ( _CollectExtensionBundles( self._extension_path )
                       if self._extension_path else [] )

--- a/ycmd/server_utils.py
+++ b/ycmd/server_utils.py
@@ -33,6 +33,11 @@ PYTHON_STDLIB_ZIP_REGEX = re.compile( 'python3[0-9]\\.zip' )
 
 
 def SetUpPythonPath():
+  if not p.isdir( DIR_OF_THIRD_PARTY ):
+    # Must be a setuptools/package install, assume sys path is correct
+    return
+
+  # Standalone/classic install
   sys.path[ 0:0 ] = [ p.join( ROOT_DIR ),
                       p.join( DIR_OF_THIRD_PARTY, 'bottle' ),
                       p.join( DIR_OF_THIRD_PARTY, 'regex-build' ),

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -31,7 +31,7 @@ from ycmd.completers.cpp import flags
 from ycmd.completers.cpp.flags import ShouldAllowWinStyleFlags, INCLUDE_FLAGS
 from ycmd.tests.test_utils import ( MacOnly, TemporaryTestDir, WindowsOnly,
                                     TemporaryClangProject )
-from ycmd.utils import CLANG_RESOURCE_DIR
+from ycmd.utils import GetClangResourceDir
 from ycmd.responses import NoExtraConfDetected
 
 
@@ -199,10 +199,10 @@ def FlagsForFile_AddMacIncludePaths_SysRoot_Default_test():
     flags_list, _ = flags_object.FlagsForFile( '/foo' )
     assert_that( flags_list, contains_exactly(
       '-Wall',
-      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-resource-dir=' + GetClangResourceDir(),
       '-isystem',    '/usr/include/c++/v1',
       '-isystem',    '/usr/local/include',
-      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    os.path.join( GetClangResourceDir(), 'include' ),
       '-isystem',    '/usr/include',
       '-iframework', '/System/Library/Frameworks',
       '-iframework', '/Library/Frameworks',
@@ -226,7 +226,7 @@ def FlagsForFile_AddMacIncludePaths_SysRoot_Xcode_test():
     flags_list, _ = flags_object.FlagsForFile( '/foo' )
     assert_that( flags_list, contains_exactly(
       '-Wall',
-      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-resource-dir=' + GetClangResourceDir(),
       '-isystem',    '/Applications/Xcode.app/Contents/Developer/Platforms'
                      '/MacOSX.platform/Developer/SDKs/MacOSX.sdk'
                      '/usr/include/c++/v1',
@@ -234,7 +234,7 @@ def FlagsForFile_AddMacIncludePaths_SysRoot_Xcode_test():
                      '/MacOSX.platform/Developer/SDKs/MacOSX.sdk'
                      '/usr/local/include',
       '-isystem',    '/usr/local/include',
-      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    os.path.join( GetClangResourceDir(), 'include' ),
       '-isystem',    '/Applications/Xcode.app/Contents/Developer/Platforms'
                      '/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include',
       '-iframework', '/Applications/Xcode.app/Contents/Developer/Platforms'
@@ -262,13 +262,13 @@ def FlagsForFile_AddMacIncludePaths_SysRoot_CommandLine_test():
     flags_list, _ = flags_object.FlagsForFile( '/foo' )
     assert_that( flags_list, contains_exactly(
       '-Wall',
-      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-resource-dir=' + GetClangResourceDir(),
       '-isystem',    '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
                      '/usr/include/c++/v1',
       '-isystem',    '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
                      '/usr/local/include',
       '-isystem',    '/usr/local/include',
-      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    os.path.join( GetClangResourceDir(), 'include' ),
       '-isystem',    '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
                      '/usr/include',
       '-iframework', '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
@@ -300,11 +300,11 @@ def FlagsForFile_AddMacIncludePaths_Sysroot_Custom_test():
       '-isysroot', '/path/to/second/sys/root/',
       '--sysroot=/path/to/third/sys/root',
       '--sysroot', '/path/to/fourth/sys/root',
-      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-resource-dir=' + GetClangResourceDir(),
       '-isystem',    '/path/to/second/sys/root/usr/include/c++/v1',
       '-isystem',    '/path/to/second/sys/root/usr/local/include',
       '-isystem',    '/usr/local/include',
-      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    os.path.join( GetClangResourceDir(), 'include' ),
       '-isystem',    '/path/to/second/sys/root/usr/include',
       '-iframework', '/path/to/second/sys/root/System/Library/Frameworks',
       '-iframework', '/path/to/second/sys/root/Library/Frameworks',
@@ -327,12 +327,12 @@ def FlagsForFile_AddMacIncludePaths_Toolchain_Xcode_test():
     flags_list, _ = flags_object.FlagsForFile( '/foo' )
     assert_that( flags_list, contains_exactly(
       '-Wall',
-      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-resource-dir=' + GetClangResourceDir(),
       '-isystem',    '/Applications/Xcode.app/Contents/Developer/Toolchains'
                      '/XcodeDefault.xctoolchain/usr/include/c++/v1',
       '-isystem',    '/usr/include/c++/v1',
       '-isystem',    '/usr/local/include',
-      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    os.path.join( GetClangResourceDir(), 'include' ),
       '-isystem',    '/Applications/Xcode.app/Contents/Developer/Toolchains'
                      '/XcodeDefault.xctoolchain/usr/include',
       '-isystem',    '/usr/include',
@@ -356,11 +356,11 @@ def FlagsForFile_AddMacIncludePaths_Toolchain_CommandLine_test():
     flags_list, _ = flags_object.FlagsForFile( '/foo' )
     assert_that( flags_list, contains_exactly(
       '-Wall',
-      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-resource-dir=' + GetClangResourceDir(),
       '-isystem',    '/Library/Developer/CommandLineTools/usr/include/c++/v1',
       '-isystem',    '/usr/include/c++/v1',
       '-isystem',    '/usr/local/include',
-      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    os.path.join( GetClangResourceDir(), 'include' ),
       '-isystem',    '/Library/Developer/CommandLineTools/usr/include',
       '-isystem',    '/usr/include',
       '-iframework', '/System/Library/Frameworks',
@@ -384,10 +384,10 @@ def FlagsForFile_AddMacIncludePaths_ObjCppLanguage_test():
       '-Wall',
       '-x', 'c',
       '-xobjective-c++',
-      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-resource-dir=' + GetClangResourceDir(),
       '-isystem',    '/usr/include/c++/v1',
       '-isystem',    '/usr/local/include',
-      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    os.path.join( GetClangResourceDir(), 'include' ),
       '-isystem',    '/usr/include',
       '-iframework', '/System/Library/Frameworks',
       '-iframework', '/Library/Frameworks',
@@ -410,10 +410,10 @@ def FlagsForFile_AddMacIncludePaths_CppLanguage_test():
       '-Wall',
       '-x', 'c',
       '-xc++',
-      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-resource-dir=' + GetClangResourceDir(),
       '-isystem',    '/usr/include/c++/v1',
       '-isystem',    '/usr/local/include',
-      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    os.path.join( GetClangResourceDir(), 'include' ),
       '-isystem',    '/usr/include',
       '-iframework', '/System/Library/Frameworks',
       '-iframework', '/Library/Frameworks',
@@ -436,9 +436,9 @@ def FlagsForFile_AddMacIncludePaths_CLanguage_test():
       '-Wall',
       '-xc++',
       '-xc',
-      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-resource-dir=' + GetClangResourceDir(),
       '-isystem',    '/usr/local/include',
-      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    os.path.join( GetClangResourceDir(), 'include' ),
       '-isystem',    '/usr/include',
       '-iframework', '/System/Library/Frameworks',
       '-iframework', '/Library/Frameworks',
@@ -461,9 +461,9 @@ def FlagsForFile_AddMacIncludePaths_NoLibCpp_test():
       '-Wall',
       '-stdlib=libc++',
       '-stdlib=libstdc++',
-      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-resource-dir=' + GetClangResourceDir(),
       '-isystem',    '/usr/local/include',
-      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    os.path.join( GetClangResourceDir(), 'include' ),
       '-isystem',    '/usr/include',
       '-iframework', '/System/Library/Frameworks',
       '-iframework', '/Library/Frameworks',
@@ -485,9 +485,9 @@ def FlagsForFile_AddMacIncludePaths_NoStandardCppIncludes_test():
     assert_that( flags_list, contains_exactly(
       '-Wall',
       '-nostdinc++',
-      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-resource-dir=' + GetClangResourceDir(),
       '-isystem',    '/usr/local/include',
-      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    os.path.join( GetClangResourceDir(), 'include' ),
       '-isystem',    '/usr/include',
       '-iframework', '/System/Library/Frameworks',
       '-iframework', '/Library/Frameworks',
@@ -509,8 +509,8 @@ def FlagsForFile_AddMacIncludePaths_NoStandardSystemIncludes_test():
     assert_that( flags_list, contains_exactly(
       '-Wall',
       '-nostdinc',
-      '-resource-dir=' + CLANG_RESOURCE_DIR,
-      '-isystem', os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-resource-dir=' + GetClangResourceDir(),
+      '-isystem', os.path.join( GetClangResourceDir(), 'include' ),
       '-fspell-checking' ) )
 
 
@@ -529,7 +529,7 @@ def FlagsForFile_AddMacIncludePaths_NoBuiltinIncludes_test():
     assert_that( flags_list, contains_exactly(
       '-Wall',
       '-nobuiltininc',
-      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-resource-dir=' + GetClangResourceDir(),
       '-isystem',    '/usr/include/c++/v1',
       '-isystem',    '/usr/local/include',
       '-isystem',    '/usr/include',

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -22,13 +22,32 @@ import os
 import socket
 import subprocess
 import sys
+import site
 import tempfile
 import time
 import threading
 
+
+def FindRootDirs():
+  root = os.path.normpath( os.path.join( os.path.dirname( __file__ ), '..' ) )
+  tp = os.path.join( root, 'third_party' )
+
+  if os.path.isdir( tp ):
+    # Standalone/classic install
+    return root, tp
+
+  # setuptools package install
+  for pfx in ( site.getuserbase(), sys.exec_prefix, sys.prefix ):
+    root = os.path.join( pfx, 'ycmd' )
+    tp = os.path.join( root, 'third_party' )
+    if os.path.isdir( tp ):
+      return root, tp
+
+  raise RuntimeError( "Unable to find ROOT_DIR, DIR_OF_THIRD_PARTY" )
+
+
 LOGGER = logging.getLogger( 'ycmd' )
-ROOT_DIR = os.path.normpath( os.path.join( os.path.dirname( __file__ ), '..' ) )
-DIR_OF_THIRD_PARTY = os.path.join( ROOT_DIR, 'third_party' )
+ROOT_DIR, DIR_OF_THIRD_PARTY = FindRootDirs()
 LIBCLANG_DIR = os.path.join( DIR_OF_THIRD_PARTY, 'clang', 'lib' )
 if hasattr( os, 'add_dll_directory' ):
   os.add_dll_directory( LIBCLANG_DIR )


### PR DESCRIPTION
Just opening this for visibility.

You can use it with `python3 setup.py bdist_wheel` then pip install the wheel in a virtualenv, then using [this](https://github.com/puremourning/YouCompleteMe/tree/packageing) branch of YCM, you can make it work with:

```
" TODO: set to the venv 
let s:env = '/path/to/the/venv'
let g:ycm_server_python_interpreter = s:env . '/bin/python'
let g:ycm_ycmd_package_path = s:env . '/env/lib/python3.8/site-packages'

" TODO set to an existing ycmd with all the deps, or set them individually
let s:ycmd_tp = expand( '$HOME/.vim/bundle/YouCompleteMe'
                      \ . '/third_party/ycmd/third_party' )
let g:ycm_clangd_binary_path = s:ycmd_tp . '/clangd/output/bin/clangd'
let g:ycm_tsserver_binary_path = s:ycmd_tp . '/tsserver/node_modules/.bin/tsserver'
let g:ycm_rust_toolchain_root = s:ycmd_tp . '/rust-analyzer'
let g:ycm_roslyn_binary_path = s:ycmd_tp . '/omnisharp-roslyn/omnisharp/OmniSharp.exe'

let g:ycm_java_jdtls_extension_path = [ expand( '$HOME/.ycmd/java/extensions' ) ]
let g:ycm_java_jdtls_workspace_root_path = expand( '$HOME/.ycmd/java/Workspace' )
let g:ycm_jdtls_repository_path = s:ycmd_tp . '/eclipse.jdt.ls/target/repository'
```

NOTE: *libclang is not supported*, only clangd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1502)
<!-- Reviewable:end -->
