### PR TITLE
[RFC] Allow clients to send incremental file updates

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3898,7 +3898,6 @@
                                                     <span class="json-property-type">string[]</span>
                                                     <span class="json-property-range" title="Value limits"></span>
                                                     
-                                                        <span class="json-property-required"></span>
                                                 </dt>
                                                 <dd>
                                                     
@@ -3920,7 +3919,6 @@
                                                     <span class="json-property-type">string</span>
                                                     <span class="json-property-range" title="Value limits"></span>
                                                     
-                                                        <span class="json-property-required"></span>
                                                 </dt>
                                                 <dd>
                                                     <p>The entire contents of the buffer encoded as UTF-8.</p>
@@ -3928,6 +3926,62 @@
                                                     <div class="json-inner-schema">
                                                         
                                                     </div>
+                                                </dd>
+                                                <dt data-property-name="changes">
+                                                    <span class="json-property-name">changes:</span>
+                                                    
+                                                    <span class="json-property-type">object[]</span>
+                                                    <span class="json-property-range" title="Value limits"></span>
+                                                    
+                                                </dt>
+                                                <dd>
+                                                    <p>The list of incremental changes.</p>
+                                    
+                                                    <div class="json-inner-schema">
+                                                        
+                                                                        <section class="json-schema-array-items">
+                                                                            
+                                                                            <span class="json-property-type">object</span>
+                                                                            <span class="json-property-range" title="Value limits"></span>
+                                                                            
+                                                                            <div class="json-inner-schema">
+                                                                                
+                                                                                        <section class="json-schema-properties">
+                                                                                            <dl>
+                                                                                                    <dt data-property-name="replacement_text">
+                                                                                                        <span class="json-property-name">replacement_text:</span>
+                                                                                                        
+                                                                                                        <span class="json-property-type">string</span>
+                                                                                                        <span class="json-property-range" title="Value limits"></span>
+                                                                                                        
+                                                                                                            <span class="json-property-required"></span>
+                                                                                                    </dt>
+                                                                                                    <dd>
+                                                                                                        <p>The text with which to replace the range identified by <code>range</code>.</p>
+                                                                                        
+                                                                                                        <div class="json-inner-schema">
+                                                                                                            
+                                                                                                        </div>
+                                                                                                    </dd>
+                                                                                                    <dt data-property-name="range">
+                                                                                                        <span class="json-property-name">range:</span>
+                                                                                                        
+                                                                                                        <span class="json-property-type">    <a class="json-schema-ref" href="#/definitions/Range">Range</a>
+                                                                                                        </span>
+                                                                                                        <span class="json-property-range" title="Value limits"></span>
+                                                                                                        
+                                                                                                            <span class="json-property-required"></span>
+                                                                                                    </dt>
+                                                                                                    <dd>
+                                                                                                        
+                                                                                                        <div class="json-inner-schema">
+                                                                                                            
+                                                                                                        </div>
+                                                                                                    </dd>
+                                                                                            </dl>
+                                                                                        </section>
+                                                                            </div>
+                                                                        </section>                </div>
                                                 </dd>
                                         </dl>
                                     </section>

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -160,9 +160,6 @@ definitions:
     type: object
     description: |-
       Contents and details of a dirty buffer.
-    required:
-      - filetypes
-      - contents
     properties:
       filetypes:
         type: array
@@ -171,6 +168,21 @@ definitions:
       contents:
         type: string
         description: The entire contents of the buffer encoded as UTF-8.
+      changes:
+        type: array
+        description: The list of incremental changes.
+        items:
+          type: object
+          required:
+            - replacement_text
+            - range
+          properties:
+            replacement_text:
+              type: string
+              description: |-
+                The text with which to replace the range identified by `range`.
+            range:
+              $ref: "#/definitions/Range"
   FileDataMap:
     type: object
     description: |-

--- a/ycmd/completers/completer_utils.py
+++ b/ycmd/completers/completer_utils.py
@@ -17,8 +17,9 @@
 
 # Must not import ycm_core here! Vim imports completer, which imports this file.
 # We don't want ycm_core inside Vim.
+import hashlib
 from collections import defaultdict
-from ycmd.utils import LOGGER, ToUnicode, re, ReadFile, SplitLines
+from ycmd.utils import LOGGER, ToBytes, ToUnicode, re, ReadFile, SplitLines
 
 
 class PreparedTriggers:
@@ -237,3 +238,92 @@ def GetFileLines( request_data, filename ):
   if filename == request_data[ 'filepath' ]:
     return request_data[ 'lines' ]
   return SplitLines( GetFileContents( request_data, filename ) )
+
+
+class ServerFileStateStore( dict ):
+  """Trivial default-dict-like class to hold ServerFileState for a given
+  filepath. Language server clients must maintain one of these for each language
+  server connection."""
+  def __missing__( self, key ):
+    self[ key ] = ServerFileState( key )
+    return self[ key ]
+
+
+class ServerFileState:
+  """State machine for a particular file from the server's perspective,
+  including version."""
+
+  # States
+  OPEN = 'Open'
+  CLOSED = 'Closed'
+
+  # Actions
+  CLOSE_FILE = 'Close'
+  NO_ACTION = 'None'
+  OPEN_FILE = 'Open'
+  CHANGE_FILE = 'Change'
+
+  def __init__( self, filename ):
+    self.filename = filename
+    self.version = 0
+    self.state = ServerFileState.CLOSED
+    self.checksum = None
+    self.contents = ''
+
+
+  def GetDirtyFileAction( self, contents ):
+    """Progress the state for a file to be updated due to being supplied in the
+    dirty buffers list. Returns any one of the Actions to perform."""
+    new_checksum = self._CalculateCheckSum( contents )
+
+    if ( self.state == ServerFileState.OPEN and
+         self.checksum.digest() == new_checksum.digest() ):
+      return ServerFileState.NO_ACTION
+    elif self.state == ServerFileState.CLOSED:
+      self.version = 0
+      action = ServerFileState.OPEN_FILE
+    else:
+      action = ServerFileState.CHANGE_FILE
+
+    return self._SendNewVersion( new_checksum, action, contents )
+
+
+  def GetSavedFileAction( self, contents ):
+    """Progress the state for a file to be updated due to having previously been
+    opened, but no longer supplied in the dirty buffers list. Returns one of the
+    Actions to perform: either NO_ACTION or CHANGE_FILE."""
+    # We only need to update if the server state is open
+    if self.state != ServerFileState.OPEN:
+      return ServerFileState.NO_ACTION
+
+    new_checksum = self._CalculateCheckSum( contents )
+    if self.checksum.digest() == new_checksum.digest():
+      return ServerFileState.NO_ACTION
+
+    return self._SendNewVersion( new_checksum,
+                                 ServerFileState.CHANGE_FILE,
+                                 contents )
+
+
+  def GetFileCloseAction( self ):
+    """Progress the state for a file which was closed in the client. Returns one
+    of the actions to perform: either NO_ACTION or CLOSE_FILE."""
+    if self.state == ServerFileState.OPEN:
+      self.state = ServerFileState.CLOSED
+      return ServerFileState.CLOSE_FILE
+
+    self.state = ServerFileState.CLOSED
+    return ServerFileState.NO_ACTION
+
+
+  def _SendNewVersion( self, new_checksum, action, contents ):
+    self.checksum = new_checksum
+    self.version = self.version + 1
+    self.state = ServerFileState.OPEN
+    self.contents = contents
+
+    return action
+
+
+  def _CalculateCheckSum( self, contents ):
+    return hashlib.sha1( ToBytes( contents ) )

--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -222,8 +222,8 @@ class ClangdCompleter( language_server_completer.LanguageServerCompleter ):
     )
 
 
-  def _Reset( self ):
-    super()._Reset()
+  def Reset( self ):
+    super().Reset()
     self._compilation_commands = {}
 
 

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -310,7 +310,7 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
     self._connection = None
     self._server_handle = None
     self._stderr_file = None
-    self._Reset()
+    self.Reset()
     self._command = []
 
 
@@ -408,7 +408,7 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
     self._RestartServer( request_data, project_directory = project_directory )
 
 
-  def _Reset( self ):
+  def Reset( self ):
     if self._workspace_path and self._use_clean_workspace:
       try:
         shutil.rmtree( self._workspace_path )
@@ -425,7 +425,7 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
 
     self._started_message_sent = False
 
-    super()._Reset()
+    super().Reset()
 
 
   def _GetJvmArgs( self, request_data ):
@@ -476,7 +476,7 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
           '-data', self._workspace_path,
         ]
 
-        return super( JavaCompleter, self )._StartServerNoLock( request_data )
+        return super()._StartServerNoLock( request_data )
     except language_server_completer.LanguageServerConnectionTimeout:
       LOGGER.error( '%s failed to start, or did not connect successfully',
                     self.GetServerName() )

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -32,7 +32,9 @@ from watchdog.observers import Observer
 
 from ycmd import extra_conf_store, responses, utils
 from ycmd.completers.completer import Completer, CompletionsCache
-from ycmd.completers.completer_utils import GetFileContents, GetFileLines
+from ycmd.completers.completer_utils import ( GetFileContents,
+                                              GetFileLines,
+                                              ServerFileState )
 from ycmd.utils import LOGGER
 
 from ycmd.completers.language_server import language_server_protocol as lsp
@@ -1011,10 +1013,10 @@ class LanguageServerCompleter( Completer ):
     self._stderr_file = None
     self._server_started = False
 
-    self._Reset()
+    self.Reset()
 
 
-  def _Reset( self ):
+  def Reset( self ):
     self.ServerReset()
     self._connection = None
     self._server_handle = None
@@ -1024,13 +1026,13 @@ class LanguageServerCompleter( Completer ):
     if not self._server_keep_logfiles and self._stderr_file:
       utils.RemoveIfExists( self._stderr_file )
       self._stderr_file = None
+    super().Reset()
 
 
   def ServerReset( self ):
     """Clean up internal state related to the running server instance.
     Implementations are required to call this after disconnection and killing
     the downstream server."""
-    self._server_file_state = lsp.ServerFileStateStore()
     self._latest_diagnostics_mutex = threading.Lock()
     self._latest_diagnostics = collections.defaultdict( list )
     self._sync_type = 'Full'
@@ -1137,7 +1139,7 @@ class LanguageServerCompleter( Completer ):
 
       if not self.ServerIsHealthy():
         LOGGER.info( '%s is not running', self.GetServerName() )
-        self._Reset()
+        self.Reset()
         return
 
       if self._server_handle:
@@ -1187,7 +1189,7 @@ class LanguageServerCompleter( Completer ):
     with self._server_info_mutex:
       # Tidy up our internal state, even if the completer server didn't close
       # down cleanly.
-      self._Reset()
+      self.Reset()
 
 
   def ShutdownServer( self ):
@@ -1984,11 +1986,33 @@ class LanguageServerCompleter( Completer ):
     return None
 
 
-  def _AnySupportedFileType( self, file_types ):
-    for supported in self.SupportedFiletypes():
-      if supported in file_types:
-        return True
-    return False
+  def OpenFileHandler( self, file_state, filetypes, changes ):
+    msg = lsp.DidOpenTextDocument( file_state, filetypes )
+    self.GetConnection().SendNotification( msg )
+
+
+  def ChangeFileHandler( self, file_state, filetypes, changes ):
+    def FixItChunkToContentChangeEvent( fix_it_chunk ):
+      range = fix_it_chunk[ 'range' ]
+      start = range[ 'start' ]
+      end = range[ 'end' ]
+      lsp_range = {
+        'start': { 'line': start[ 'line_num' ] - 1,
+                   'character': start[ 'column_num' ] - 1 },
+        'end': { 'line': end[ 'line_num' ] - 1,
+                 'character': end[ 'column_num' ] - 1 },
+      }
+      return {
+        'text': fix_it_chunk[ 'replacement_text' ],
+        'range': lsp_range
+      }
+    if self._sync_type == 'Incremental' and changes is not None:
+      diff = [ FixItChunkToContentChangeEvent( change )
+               for change in changes ]
+    else:
+      diff = [ { 'text': file_state.contents } ]
+    msg = lsp.DidChangeTextDocument( file_state, diff )
+    self.GetConnection().SendNotification( msg )
 
 
   def _UpdateServerWithFileContents( self, request_data ):
@@ -1999,43 +2023,9 @@ class LanguageServerCompleter( Completer ):
     synchronous operation."""
     with self._server_info_mutex:
       self._UpdateDirtyFilesUnderLock( request_data )
+      # TODO: Consider doing this in self.OnBufferUnload()
       files_to_purge = self._UpdateSavedFilesUnderLock( request_data )
-      self._PurgeMissingFilesUnderLock( files_to_purge )
-
-
-  def _UpdateDirtyFilesUnderLock( self, request_data ):
-    for file_name, file_data in request_data[ 'file_data' ].items():
-      if not self._AnySupportedFileType( file_data[ 'filetypes' ] ):
-        LOGGER.debug( 'Not updating file %s, it is not a supported filetype: '
-                       '%s not in %s',
-                       file_name,
-                       file_data[ 'filetypes' ],
-                       self.SupportedFiletypes() )
-        continue
-
-      file_state = self._server_file_state[ file_name ]
-      action = file_state.GetDirtyFileAction( file_data[ 'contents' ] )
-
-      LOGGER.debug( 'Refreshing file %s: State is %s/action %s',
-                    file_name,
-                    file_state.state,
-                    action )
-
-      if action == lsp.ServerFileState.OPEN_FILE:
-        msg = lsp.DidOpenTextDocument( file_state,
-                                       file_data[ 'filetypes' ],
-                                       file_data[ 'contents' ] )
-
-        self.GetConnection().SendNotification( msg )
-      elif action == lsp.ServerFileState.CHANGE_FILE:
-        # FIXME: DidChangeTextDocument doesn't actually do anything
-        # different from DidOpenTextDocument other than send the right
-        # message, because we don't actually have a mechanism for generating
-        # the diffs. This isn't strictly necessary, but might lead to
-        # performance problems.
-        msg = lsp.DidChangeTextDocument( file_state, file_data[ 'contents' ] )
-
-        self.GetConnection().SendNotification( msg )
+      self._PurgeMissingFilesUnderLock( files_to_purge, request_data )
 
 
   def _UpdateSavedFilesUnderLock( self, request_data ):
@@ -2072,18 +2062,18 @@ class LanguageServerCompleter( Completer ):
         continue
 
       action = file_state.GetSavedFileAction( contents )
-      if action == lsp.ServerFileState.CHANGE_FILE:
-        msg = lsp.DidChangeTextDocument( file_state, contents )
+      if action == ServerFileState.CHANGE_FILE:
+        msg = lsp.DidChangeTextDocument( file_state, [ { 'text': contents } ] )
         self.GetConnection().SendNotification( msg )
 
     return files_to_purge
 
 
-  def _PurgeMissingFilesUnderLock( self, files_to_purge ):
+  def _PurgeMissingFilesUnderLock( self, files_to_purge, request_data ):
     # ycmd clients only send buffers which have changed, and are required to
     # send BufferUnload autocommand when files are closed.
     for file_name in files_to_purge:
-      self._PurgeFileFromServer( file_name )
+      self._PurgeFileFromServer( file_name, request_data )
 
 
   def OnFileSave( self, request_data ):
@@ -2093,13 +2083,9 @@ class LanguageServerCompleter( Completer ):
     if 'textDocumentSync' in self._server_capabilities:
       sync = self._server_capabilities[ 'textDocumentSync' ]
       if isinstance( sync, dict ) and sync.get( 'save' ) not in [ None, False ]:
-        save = sync[ 'save' ]
         file_name = request_data[ 'filepath' ]
-        contents = None
-        if isinstance( save, dict ) and save.get( 'includeText' ):
-          contents = request_data[ 'file_data' ][ file_name ][ 'contents' ]
         file_state = self._server_file_state[ file_name ]
-        msg = lsp.DidSaveTextDocument( file_state, contents )
+        msg = lsp.DidSaveTextDocument( file_state )
         self.GetConnection().SendNotification( msg )
 
 
@@ -2114,20 +2100,21 @@ class LanguageServerCompleter( Completer ):
     # must keep the server synchronized.
     if not self._initialize_event.is_set():
       self._OnInitializeComplete(
-        lambda self: self._PurgeFileFromServer( request_data[ 'filepath' ] ) )
+        lambda self: self._PurgeFileFromServer( request_data[ 'filepath' ],
+                                                request_data ) )
       return
 
-    self._PurgeFileFromServer( request_data[ 'filepath' ] )
+    self._PurgeFileFromServer( request_data[ 'filepath' ], request_data )
 
 
-  def _PurgeFileFromServer( self, file_path ):
+  def _PurgeFileFromServer( self, file_path, request_data ):
     file_state = self._server_file_state[ file_path ]
     action = file_state.GetFileCloseAction()
-    if action == lsp.ServerFileState.CLOSE_FILE:
+    if action == ServerFileState.CLOSE_FILE:
       msg = lsp.DidCloseTextDocument( file_state )
       self.GetConnection().SendNotification( msg )
 
-    del self._server_file_state[ file_state.filename ]
+    super().OnBufferUnload( request_data )
 
 
   def GetProjectRootFiles( self ):

--- a/ycmd/completers/python/python_completer.py
+++ b/ycmd/completers/python/python_completer.py
@@ -164,8 +164,9 @@ class PythonCompleter( Completer ):
 
 
   def _GetJediScript( self, request_data ):
+    self._UpdateDirtyFilesUnderLock( request_data )
     path = request_data[ 'filepath' ]
-    source = request_data[ 'file_data' ][ path ][ 'contents' ]
+    source = self._server_file_state[ path ].contents
     environment = self._EnvironmentForRequest( request_data )
     jedi_project = self._JediProjectForFile( request_data, environment )
     return jedi.Script( source,

--- a/ycmd/completers/rust/rust_completer.py
+++ b/ycmd/completers/rust/rust_completer.py
@@ -83,9 +83,9 @@ class RustCompleter( language_server_completer.LanguageServerCompleter ):
         os.path.join( self._rust_root, 'bin', 'rust-analyzer' ) )
 
 
-  def _Reset( self ):
+  def Reset( self ):
     self._server_progress = 'Not started'
-    super()._Reset()
+    super().Reset()
 
 
   def GetServerName( self ):

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -352,7 +352,8 @@ class TypeScriptCompleter( Completer ):
     """
 
     filename = request_data[ 'filepath' ]
-    contents = request_data[ 'file_data' ][ filename ][ 'contents' ]
+    self._UpdateDirtyFilesUnderLock( request_data )
+    contents = self._server_file_state[ filename ].contents
     tmpfile = NamedTemporaryFile( delete = False )
     tmpfile.write( utils.ToBytes( contents ) )
     tmpfile.close()


### PR DESCRIPTION
As discussed in #1480, this time ycmd keeps the state of all files, on a per-completer bases. It definitely needs more testing and, like I mentioned in gitter, this doesn't really take care of "what's the filetype of current buffer" - that's still fetched from `request_data[ 'file_data' ]`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1506)
<!-- Reviewable:end -->
