### PR TITLE
[READY] Drop waitress in favour of the standard library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "third_party/bottle"]
 	path = third_party/bottle
 	url = https://github.com/defnull/bottle
-[submodule "third_party/waitress"]
-	path = third_party/waitress
-	url = https://github.com/Pylons/waitress
 [submodule "third_party/jedi"]
 	path = third_party/jedi_deps/jedi
 	url = https://github.com/davidhalter/jedi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 bottle   >= 0.12.18
 regex    >= 2020.2.20
 jedi     >= 0.16.0
-requests >= 2.22.0
-waitress >= 1.4.3
 watchdog >= 0.10.2

--- a/ycmd/__main__.py
+++ b/ycmd/__main__.py
@@ -200,9 +200,13 @@ def Main():
   CloseStdin()
   handlers.wsgi_server = StoppableWSGIServer( handlers.app,
                                               host = args.host,
-                                              port = args.port,
-                                              threads = 30 )
-  handlers.wsgi_server.Run()
+                                              port = args.port )
+  if sys.stdin is not None:
+    print( f'serving on http://{ handlers.wsgi_server.server_name }:'
+           f'{ handlers.wsgi_server.server_port }' )
+  handlers.wsgi_server.serve_forever()
+  handlers.wsgi_server.server_close()
+  handlers.ServerCleanup()
 
 
 if __name__ == "__main__":

--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -306,7 +306,6 @@ def DebugInfo():
 def Shutdown():
   LOGGER.info( 'Received shutdown request' )
   ServerShutdown()
-
   return _JsonResponse( True )
 
 
@@ -369,7 +368,7 @@ def _GetCompleterForRequestData( request_data ):
 def ServerShutdown():
   def Terminator():
     if wsgi_server:
-      wsgi_server.Shutdown()
+      wsgi_server.shutdown()
 
   # Use a separate thread to let the server send the response before shutting
   # down.

--- a/ycmd/wsgi_server.py
+++ b/ycmd/wsgi_server.py
@@ -15,44 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-from waitress.server import TcpWSGIServer
-import select
-import sys
+from wsgiref.simple_server import WSGIServer, WSGIRequestHandler
+from socketserver import ThreadingMixIn
 
 
-class StoppableWSGIServer( TcpWSGIServer ):
-  """StoppableWSGIServer is a subclass of the TcpWSGIServer Waitress server
-  with a shutdown method. It is based on StopableWSGIServer class from webtest:
-  https://github.com/Pylons/webtest/blob/master/webtest/http.py"""
+class StoppableWSGIServer( ThreadingMixIn, WSGIServer ):
+  daemon_threads = False
 
-  shutdown_requested = False
-
-  def Run( self ):
-    """Wrapper of TcpWSGIServer run method. It prevents a traceback from
-    asyncore."""
-
-    # Message for compatibility with clients who expect the output from
-    # waitress.serve here
-    if sys.stdin is not None:
-      print( f'serving on http://{ self.effective_host }:'
-             f'{ self.effective_port }' )
-
-    try:
-      self.run()
-    except select.error:
-      if not self.shutdown_requested:
-        raise
-
-
-  def Shutdown( self ):
-    """Properly shutdown the server."""
-    self.shutdown_requested = True
-    # Shutdown waitress threads.
-    self.task_dispatcher.shutdown()
-    # Close asyncore channels.
-    # We use list() here because _map is modified while looping through it.
-    # NOTE: _map is an attribute from the asyncore.dispatcher class, which is a
-    # base class of TcpWSGIServer. This may change in future versions of
-    # waitress so extra care should be taken when updating waitress.
-    for channel in list( self._map.values() ):
-      channel.close()
+  def __init__( self, app, host, port ):
+    super().__init__( ( host, port ), WSGIRequestHandler )
+    self.set_app( app )


### PR DESCRIPTION
I'll make some more benchmarks tomorrow, but even if there's no difference between waitress and the standard library, dropping an external dependency would be nice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1509)
<!-- Reviewable:end -->
