### PR TITLE
[READY] Refactor cmake files and require cmake 3.14

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -15,13 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-if ( APPLE )
-  # OSX requires CMake >= 2.8.12, see YCM issue #1439
-  cmake_minimum_required( VERSION 2.8.12 )
-else()
-  # CMake 2.8.11 is the latest available version on RHEL/CentOS 7
-  cmake_minimum_required( VERSION 2.8.11 )
-endif()
+cmake_minimum_required( VERSION 3.14 )
 
 project( YouCompleteMe )
 
@@ -97,12 +91,8 @@ endif()
 
 #############################################################################
 
-# To shut up the warning about CMake policy CMP0042
-set( CMAKE_MACOSX_RPATH ON )
-
-#############################################################################
-
-if ( CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )
+if ( CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
+     CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" )
   set( COMPILER_IS_CLANG true )
 
   # Linux machines don't necessarily have libc++ installed alongside clang,
@@ -127,9 +117,7 @@ endif()
 # set the visibility to hidden to achieve the same result and then manually
 # expose what we need. This results in smaller ycm_core dynamic library and thus
 # a shorter loading time and higher performance.
-if( CMAKE_COMPILER_IS_GNUCXX OR COMPILER_IS_CLANG )
-  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden" )
-endif()
+set( CMAKE_CXX_VISIBILITY_PRESET hidden )
 
 if ( DEFINED ENV{YCM_BENCHMARK} OR DEFINED ENV{YCM_TESTRUN})
   if ( MSVC )
@@ -162,12 +150,18 @@ endif()
 
 # Determining the presence of C++17 support in the compiler
 set( CPP17_AVAILABLE false )
-if ( CMAKE_COMPILER_IS_GNUCXX )
+if ( CMAKE_CXX_COMPILER_ID STREQUAL "GNU"  )
   if ( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8 )
     set( CPP17_AVAILABLE true )
   endif()
-elseif( COMPILER_IS_CLANG )
+elseif( CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )
   if ( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7 )
+    set( CPP17_AVAILABLE true )
+    set( CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++17" )
+    set( CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++" )
+  endif()
+elseif( CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" )
+  if ( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11 )
     set( CPP17_AVAILABLE true )
     set( CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++17" )
     set( CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++" )
@@ -196,16 +190,10 @@ endif()
 
 #############################################################################
 
-if ( CPP17_AVAILABLE )
-  # Cygwin needs its hand held a bit; see issue #473
-  if ( CYGWIN AND CMAKE_COMPILER_IS_GNUCXX )
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17" )
-  elseif( NOT MSVC )
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17" )
-  elseif( MSVC )
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17" )
-  endif()
-else()
+set( CMAKE_CXX_STANDARD 17 )
+set( CMAKE_CXX_STANDARD_REQUIRED ON )
+set( CMAKE_CXX_EXTENSIONS OFF )
+if ( NOT CPP17_AVAILABLE )
   # Platform-specific advice goes here. In particular, we have plenty of users
   # in corporate environments on RHEL/CentOS, where the default system compiler
   # is too old.
@@ -232,8 +220,7 @@ else()
   message( FATAL_ERROR "Your C++ compiler does NOT fully support C++17." )
 endif()
 
-set( Python_ADDITIONAL_VERSIONS 3.10 3.9 3.8 3.7 3.6 )
-find_package( PythonLibs 3.6 REQUIRED )  # 3.6 is ONLY the minimum
+find_package( Python3 3.6...3.10 REQUIRED COMPONENTS Interpreter Development )
 
 #############################################################################
 

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required( VERSION 2.8.7 )
+cmake_minimum_required( VERSION 3.14 )
 
 project( ycm_core )
 
@@ -185,57 +185,19 @@ if ( NOT EXTERNAL_LIBCLANG_PATH AND PATH_TO_LLVM_ROOT )
   set( EXTERNAL_LIBCLANG_PATH ${TEMP} )
 endif()
 
-# This is a workaround for a CMake bug with include_directories(SYSTEM ...)
-# on Mac OS X. Bug report: http://public.kitware.com/Bug/view.php?id=10837
-if ( APPLE )
-  set( CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem " )
-endif()
-
 set( PYBIND11_INCLUDES_DIR "${CMAKE_SOURCE_DIR}/pybind11" )
 
-# Makes MSVC conform to the standard
-if ( MSVC )
-  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-" )
-endif()
+file( GLOB SERVER_SOURCES *.h *.cpp )
 
-file( GLOB_RECURSE SERVER_SOURCES *.h *.cpp )
-
-# The test and benchmark sources are a part of a different target, so we remove
-# them. The CMakeFiles cpp file is picked up when the user creates an in-source
-# build, and we don't want that. We also remove client-specific code.
-file( GLOB_RECURSE to_remove tests/*.h tests/*.cpp benchmarks/*.h
-                             benchmarks/*.cpp CMakeFiles/*.cpp *client* )
-
-if( to_remove )
-  list( REMOVE_ITEM SERVER_SOURCES ${to_remove} )
-endif()
-
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR} )
 if ( USE_CLANG_COMPLETER )
   include_directories(
-    ${CMAKE_CURRENT_SOURCE_DIR}
     "${CMAKE_CURRENT_SOURCE_DIR}/ClangCompleter" )
   add_definitions( -DUSE_CLANG_COMPLETER )
-else()
-  file( GLOB_RECURSE to_remove_clang ClangCompleter/*.h ClangCompleter/*.cpp )
-
-  if( to_remove_clang )
-    list( REMOVE_ITEM SERVER_SOURCES ${to_remove_clang} )
-  endif()
+  file( GLOB add_clang ClangCompleter/*.h ClangCompleter/*.cpp )
+  list( APPEND SERVER_SOURCES ${add_clang} )
 endif()
-
-# The SYSTEM flag makes sure that -isystem[header path] is passed to the
-# compiler instead of the standard -I[header path]. Headers included with
-# -isystem do not generate warnings (and they shouldn't; e.g. pybind11 warnings
-# are just noise for us since we won't be changing them).
-# Since there is no -isystem flag equivalent on Windows, headers from external
-# projects may conflict with our headers and override them. We prevent that by
-# including these directories after ours.
-include_directories(
-  SYSTEM
-  ${PYBIND11_INCLUDES_DIR}
-  ${PYTHON_INCLUDE_DIRS}
-  ${CLANG_INCLUDES_DIR}
-  )
 
 #############################################################################
 
@@ -315,23 +277,25 @@ if ( UNIX AND NOT ( APPLE OR SYSTEM_IS_OPENBSD OR HAIKU ) )
 endif()
 
 # Check if we need to add -lstdc++fs or -lc++fs or nothing
-if( MSVC )
-  set( STD_FS_NO_LIB_NEEDED TRUE )
-else()
-  file( WRITE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp "#include <filesystem>\nint main( int argc, char ** argv ) {\n  std::filesystem::path p( argv[ 0 ] );\n  return p.string().length();\n}" )
-  try_compile( STD_FS_NO_LIB_NEEDED ${CMAKE_CURRENT_BINARY_DIR}
-               SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
-               COMPILE_DEFINITIONS -std=c++17 )
-  try_compile( STD_FS_NEEDS_STDCXXFS ${CMAKE_CURRENT_BINARY_DIR}
-               SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
-               COMPILE_DEFINITIONS -std=c++17
-               LINK_LIBRARIES stdc++fs )
-  try_compile( STD_FS_NEEDS_CXXFS ${CMAKE_CURRENT_BINARY_DIR}
-               SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
-               COMPILE_DEFINITIONS -std=c++17
-               LINK_LIBRARIES c++fs )
-  file( REMOVE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp )
-endif()
+file( WRITE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp "#include <filesystem>\nint main( int argc, char ** argv ) {\n  std::filesystem::path p( argv[ 0 ] );\n  return p.string().length();\n}" )
+try_compile( STD_FS_NO_LIB_NEEDED ${CMAKE_CURRENT_BINARY_DIR}
+             SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+	     CXX_STANDARD 17
+	     CXX_STANDARD_REQUIRED TRUE
+	     CXX_EXTENSIONS FALSE )
+try_compile( STD_FS_NEEDS_STDCXXFS ${CMAKE_CURRENT_BINARY_DIR}
+             SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+	     CXX_STANDARD 17
+	     CXX_STANDARD_REQUIRED TRUE
+	     CXX_EXTENSIONS FALSE
+             LINK_LIBRARIES stdc++fs )
+try_compile( STD_FS_NEEDS_CXXFS ${CMAKE_CURRENT_BINARY_DIR}
+             SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+	     CXX_STANDARD 17
+	     CXX_STANDARD_REQUIRED TRUE
+	     CXX_EXTENSIONS FALSE
+             LINK_LIBRARIES c++fs )
+file( REMOVE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp )
 
 if( ${STD_FS_NEEDS_STDCXXFS} )
   set( STD_FS_LIB stdc++fs )
@@ -340,8 +304,7 @@ elseif( ${STD_FS_NEEDS_CXXFS} )
 elseif( ${STD_FS_NO_LIB_NEEDED} )
   set( STD_FS_LIB "" )
 else()
-  message( WARNING "Unknown compiler - not passing -lstdc++fs" )
-  set( STD_FS_LIB "" )
+  message( FATAL_ERROR "Unknown compiler - C++17 filesystem library missing" )
 endif()
 
 #############################################################################
@@ -350,6 +313,19 @@ add_library( ${PROJECT_NAME} SHARED
              ${SERVER_SOURCES}
            )
 
+# Makes MSVC conform to the standard
+if ( MSVC )
+  target_compile_options( ${PROJECT_NAME} PRIVATE "/permissive-" )
+endif()
+
+target_include_directories(
+  ${PROJECT_NAME}
+  SYSTEM
+  PUBLIC ${PYBIND11_INCLUDES_DIR}
+  PUBLIC ${Python3_INCLUDE_DIRS}
+  PUBLIC ${CLANG_INCLUDES_DIR}
+  )
+
 if ( USE_CLANG_COMPLETER AND NOT LIBCLANG_TARGET )
      message( FATAL_ERROR "Using Clang completer, but no libclang found. "
                           "Try setting EXTERNAL_LIBCLANG_PATH or revise "
@@ -357,10 +333,10 @@ if ( USE_CLANG_COMPLETER AND NOT LIBCLANG_TARGET )
 endif()
 
 target_link_libraries( ${PROJECT_NAME}
-                       ${PYTHON_LIBRARIES}
-                       ${LIBCLANG_TARGET}
-                       ${STD_FS_LIB}
-                       ${EXTRA_LIBS}
+                       PUBLIC ${Python3_LIBRARIES}
+                       PUBLIC ${LIBCLANG_TARGET}
+                       PUBLIC ${STD_FS_LIB}
+                       PUBLIC ${EXTRA_LIBS}
                      )
 
 if( LIBCLANG_TARGET )
@@ -391,7 +367,14 @@ endif()
 
 # We don't want the "lib" prefix, it can screw up python when it tries to search
 # for our module
-set_target_properties( ${PROJECT_NAME} PROPERTIES PREFIX "")
+execute_process( COMMAND
+  "${Python3_EXECUTABLE}" "-c"
+  "print(__import__('sysconfig').get_config_var('EXT_SUFFIX'))"
+  OUTPUT_VARIABLE PYTHON_EXTENSION
+  OUTPUT_STRIP_TRAILING_WHITESPACE )
+set_target_properties( ${PROJECT_NAME} PROPERTIES
+                        PREFIX ""
+                        SUFFIX "${PYTHON_EXTENSION}" )
 
 if ( WIN32 OR CYGWIN OR MSYS )
   # DLL platforms put dlls in the RUNTIME_OUTPUT_DIRECTORY
@@ -404,19 +387,6 @@ if ( WIN32 OR CYGWIN OR MSYS )
     set_target_properties( ${PROJECT_NAME} PROPERTIES
       RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${PROJECT_SOURCE_DIR}/../.. )
   endforeach()
-
-  if ( WIN32 )
-    # This is the extension for compiled Python modules on Windows
-    set_target_properties( ${PROJECT_NAME} PROPERTIES SUFFIX ".pyd")
-  elseif ( CYGWIN OR MSYS )
-    # This is the extension for compiled Python modules in Cygwin and msys
-    set_target_properties( ${PROJECT_NAME} PROPERTIES SUFFIX ".dll")
-  endif()
-else()
-  # Even on macs, we want a .so extension instead of a .dylib which is what
-  # cmake would give us by default. Python won't recognize a .dylib as a module,
-  # but it will recognize a .so
-  set_target_properties( ${PROJECT_NAME} PROPERTIES SUFFIX ".so")
 endif()
 
 set_target_properties( ${PROJECT_NAME} PROPERTIES
@@ -426,18 +396,18 @@ set_target_properties( ${PROJECT_NAME} PROPERTIES
 
 if ( USE_DEV_FLAGS AND ( CMAKE_COMPILER_IS_GNUCXX OR COMPILER_IS_CLANG ) )
   # We want all warnings, and warnings should be treated as errors
-  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror" )
+  target_compile_options( ${PROJECT_NAME} PUBLIC "-Wall" "-Wextra" "-Werror" )
 endif()
 
 #############################################################################
 
 if( SYSTEM_IS_SUNOS )
   # SunOS needs this setting for thread support
-  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthreads" )
+  target_compile_options( ${PROJECT_NAME} PUBLIC "-pthreads" )
 endif()
 
 if( SYSTEM_IS_OPENBSD OR SYSTEM_IS_FREEBSD )
-  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread" )
+  target_compile_options( ${PROJECT_NAME} PUBLIC "-pthread" )
 endif()
 
 if ( DEFINED ENV{YCM_TESTRUN} )

--- a/cpp/ycm/benchmarks/CMakeLists.txt
+++ b/cpp/ycm/benchmarks/CMakeLists.txt
@@ -16,7 +16,7 @@
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
 project( ycm_core_benchmarks )
-cmake_minimum_required( VERSION 2.8 )
+cmake_minimum_required( VERSION 3.14 )
 
 # We don't want to test the benchmark library.
 set( BENCHMARK_ENABLE_TESTING
@@ -27,20 +27,12 @@ add_subdirectory( benchmark )
 set( BENCHMARK_INCLUDE_DIRS ${benchmark_SOURCE_DIR}/include )
 set( BENCHMARK_LIBRARIES benchmark )
 
-include_directories( ${ycm_core_SOURCE_DIR}
-                     ${BENCHMARK_INCLUDE_DIRS} )
-
-file( GLOB_RECURSE SOURCES *.h *.cpp )
-
-# We don't want benchmark sources in this target.
-file( GLOB_RECURSE to_remove benchmark/*.h benchmark/*.cpp CMakeFiles/*.cpp )
-
-if( to_remove )
-  list( REMOVE_ITEM SOURCES ${to_remove} )
-endif()
+file( GLOB SOURCES *.h *.cpp )
 
 add_executable( ${PROJECT_NAME}
                 ${SOURCES} )
+
+target_include_directories( ${PROJECT_NAME} PRIVATE ${BENCHMARK_INCLUDE_DIRS} )
 
 if( MSVC )
   # Build benchmark and ycm_core_benchmarks targets in cmake ycm/benchmarks
@@ -55,5 +47,5 @@ if( MSVC )
 endif()
 
 target_link_libraries( ${PROJECT_NAME}
-                       ycm_core
-                       ${BENCHMARK_LIBRARIES} )
+                       PRIVATE ycm_core
+                       PRIVATE ${BENCHMARK_LIBRARIES} )

--- a/cpp/ycm/tests/CMakeLists.txt
+++ b/cpp/ycm/tests/CMakeLists.txt
@@ -16,7 +16,7 @@
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 
 project( ycm_core_tests )
-cmake_minimum_required( VERSION 2.8 )
+cmake_minimum_required( VERSION 3.14 )
 
 # The gtest library triggers warnings, so we turn them off; it's not up to us to
 # fix gtest warnings, it's up to upstream.
@@ -47,40 +47,28 @@ else()
   set( GMOCK_LIBRARIES gmock )
 endif()
 
-include_directories(
-  ${ycm_core_SOURCE_DIR}
-  ${ycm_core_SOURCE_DIR}/../whereami
-  )
+file( GLOB SOURCES *.h *.cpp )
 
-include_directories(
-  SYSTEM
-  ${GMOCK_INCLUDE_DIRS}
-  ${GTEST_INCLUDE_DIRS}
-  )
+if ( USE_CLANG_COMPLETER )
+  file( GLOB_RECURSE add_clang ClangCompleter/*.h ClangCompleter/*.cpp )
 
-link_directories( ${PYTHON_LIBRARIES} )
-
-file( GLOB_RECURSE SOURCES *.h *.cpp )
-
-# We don't want gmock sources in this target
-file( GLOB_RECURSE to_remove gmock/*.h gmock/*.cpp CMakeFiles/*.cpp
-  testdata/*.cpp testdata/*.h )
-
-if( to_remove )
-  list( REMOVE_ITEM SOURCES ${to_remove} )
-endif()
-
-if ( NOT USE_CLANG_COMPLETER )
-  file( GLOB_RECURSE to_remove_clang ClangCompleter/*.h ClangCompleter/*.cpp )
-
-  if( to_remove_clang )
-    list( REMOVE_ITEM SOURCES ${to_remove_clang} )
+  if( add_clang )
+    list( APPEND SOURCES ${add_clang} )
   endif()
 endif()
 
-add_executable( ${PROJECT_NAME}
-                ${SOURCES}
-              )
+add_executable( ${PROJECT_NAME} ${SOURCES} )
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PRIVATE ${ycm_core_SOURCE_DIR}/../whereami )
+
+target_include_directories(
+  ${PROJECT_NAME}
+  SYSTEM
+  PRIVATE ${GMOCK_INCLUDE_DIRS}
+  PRIVATE ${GTEST_INCLUDE_DIRS}
+  )
 
 if ( MSVC )
   # This is needed to compile tests with the gtest shared library
@@ -88,11 +76,6 @@ if ( MSVC )
                          PROPERTIES
                          COMPILE_DEFINITIONS
                          "GTEST_LINKED_AS_SHARED_LIBRARY=1" )
-
-  # Fix gtest build on MSVC 11.  See: http://stackoverflow.com/a/8274747
-  if ( MSVC_VERSION EQUAL 1700 )
-    add_definitions( /D _VARIADIC_MAX=10 )
-  endif()
 
   # Build gmock and ycm_core_tests targets in cmake ycm/tests folder
   foreach( OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES} )
@@ -105,9 +88,9 @@ if ( MSVC )
 endif()
 
 target_link_libraries( ${PROJECT_NAME}
-                       ycm_core
-                       ${GTEST_LIBRARIES}
-                       ${GMOCK_LIBRARIES} )
+                       PRIVATE ycm_core
+                       PRIVATE ${GTEST_LIBRARIES}
+                       PRIVATE ${GMOCK_LIBRARIES} )
 
 if ( NOT CMAKE_GENERATOR_IS_XCODE )
   # There is no portable way of discovering the absolute path of the executable,


### PR DESCRIPTION
Cmake deprecated support for cmake2 and RHEL7 has cmake 3.14 available.
Besides that, the `FindPythonLibs.cmake` is also replaced with `FindPython3.cmake`, because the former is also deprecated.

With cmake3, it's possible to not use `CMAKE_CXX_FLAGS` global variable and stick to target based commands. This is what I've done for the most part. The only file that doesn't fit this is the top level `cpp/CMakeLists.txt`.

One thing to note, regarding `target_whatever()` are all the `PUBLIC`/`INTERFACE`/`PRIVATE` modifiers. Here's what they mean:

- `PRIVATE` - the dependency is "local" to the specified target. Targets that depend on this target don't have the specified dependency.
- `INTERFACE` - the specified dependency is not directly applied to the specified target. However, targets that depend on this target also depend on the specified dependency.
- `PUBLIC` - the dependency is applied to the specified target. Also, every target that depends on this target also depends on the specified dependency.

There's probably more stuff that can be cleaned up, but this seems to work so far.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1513)
<!-- Reviewable:end -->
