### PR TITLE
[READY] Use raw CPython API in PythonSupport.cpp

### DIFF
--- a/cpp/ycm/PythonSupport.h
+++ b/cpp/ycm/PythonSupport.h
@@ -29,15 +29,15 @@ namespace YouCompleteMe {
 /// |max_candidates|. If |max_candidates| is omitted or 0, all candidates are
 /// sorted.
 YCM_EXPORT pybind11::list FilterAndSortCandidates(
-  pybind11::list candidates,
-  const std::string &candidate_property,
-  std::string query,
+  const pybind11::list& candidates,
+  pybind11::str candidate_property,
+  std::string& query,
   const size_t max_candidates = 0 );
 
 /// Given a Python object that's supposed to be "string-like", returns a UTF-8
 /// encoded std::string. Raises an exception if the object can't be converted to
 /// a string.
-std::string GetUtf8String( const pybind11::object &value );
+std::string GetUtf8String( pybind11::handle value );
 
 } // namespace YouCompleteMe
 

--- a/cpp/ycm/benchmarks/PythonSupport_bench.cpp
+++ b/cpp/ycm/benchmarks/PythonSupport_bench.cpp
@@ -22,6 +22,7 @@
 #include "PythonSupport.h"
 
 #include <benchmark/benchmark_api.h>
+#include <string>
 
 namespace YouCompleteMe {
 
@@ -50,12 +51,14 @@ BENCHMARK_DEFINE_F( PythonSupportFixture,
     candidates.append( candidate );
   }
 
+  pybind11::str candidate_property("insertion_text");
   while ( state.KeepRunning() ) {
     state.PauseTiming();
     CharacterRepository::Instance().ClearCharacters();
     CandidateRepository::Instance().ClearCandidates();
+    std::string query = "aA";
     state.ResumeTiming();
-    FilterAndSortCandidates( candidates, "insertion_text", "aA",
+    FilterAndSortCandidates( candidates, candidate_property, query,
                              state.range( 1 ) );
   }
 
@@ -78,12 +81,15 @@ BENCHMARK_DEFINE_F( PythonSupportFixture,
     candidates.append( candidate );
   }
 
+  pybind11::str candidate_property("insertion_text");
   // Store the candidates in the repository.
-  FilterAndSortCandidates( candidates, "insertion_text", "aA",
+  std::string query = "aA";
+  FilterAndSortCandidates( candidates, candidate_property, query,
                            state.range( 1 ) );
 
   while ( state.KeepRunning() ) {
-    FilterAndSortCandidates( candidates, "insertion_text", "aA",
+    std::string query = "aA";
+    FilterAndSortCandidates( candidates, candidate_property, query,
                              state.range( 1 ) );
   }
 


### PR DESCRIPTION
Using the raw C API allows access to objects internals without checking
for errors. This is fine, because ycmd already checks everything
necessary. Plus, pybind11 can easily fall back to generic
implementations - for example, `len()` is `PyObject_Len()`, even if we
know that the object is `PyListObject*`. The C API, thus, allows us to
exploit the knowledge of types that pybind11 doesn't have.

And yes, I understand that this might be a controversial pull request. The performance improvements are from 3% to 10%, depending on the specific benchmark.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1515)
<!-- Reviewable:end -->
