### PR TITLE
[READY] Optimize IdentifierCompleter

### DIFF
--- a/cpp/ycm/IdentifierCompleter.cpp
+++ b/cpp/ycm/IdentifierCompleter.cpp
@@ -42,7 +42,7 @@ IdentifierCompleter::IdentifierCompleter(
 
 
 void IdentifierCompleter::AddIdentifiersToDatabase(
-  std::vector< std::string > new_candidates,
+  std::vector< std::string >& new_candidates,
   std::string& filetype,
   std::string& filepath ) {
   identifier_database_.AddIdentifiers( std::move( new_candidates ),
@@ -52,12 +52,12 @@ void IdentifierCompleter::AddIdentifiersToDatabase(
 
 
 void IdentifierCompleter::ClearForFileAndAddIdentifiersToDatabase(
-  std::vector< std::string > new_candidates,
+  std::vector< std::string >& new_candidates,
   std::string& filetype,
   std::string& filepath ) {
   identifier_database_.ClearCandidatesStoredForFile( std::string( filetype ),
                                                      std::string( filepath ) );
-  AddIdentifiersToDatabase( std::move( new_candidates ),
+  AddIdentifiersToDatabase( new_candidates,
                             filetype,
                             filepath );
 }
@@ -75,12 +75,12 @@ void IdentifierCompleter::AddIdentifiersToDatabaseFromTagFiles(
 std::vector< std::string > IdentifierCompleter::CandidatesForQuery(
   std::string&& query,
   const size_t max_candidates ) const {
-  return CandidatesForQueryAndType( std::move( query ), "", max_candidates );
+  return CandidatesForQueryAndType( query, "", max_candidates );
 }
 
 
 std::vector< std::string > IdentifierCompleter::CandidatesForQueryAndType(
-  std::string query,
+  std::string& query,
   const std::string &filetype,
   const size_t max_candidates ) const {
 

--- a/cpp/ycm/IdentifierCompleter.h
+++ b/cpp/ycm/IdentifierCompleter.h
@@ -44,14 +44,14 @@ public:
                        std::string&& filepath );
 
   void AddIdentifiersToDatabase(
-    std::vector< std::string > new_candidates,
+    std::vector< std::string >& new_candidates,
     std::string& filetype,
     std::string& filepath );
 
   // Same as above, but clears all identifiers stored for the file before adding
   // new identifiers.
   void ClearForFileAndAddIdentifiersToDatabase(
-    std::vector< std::string > new_candidates,
+    std::vector< std::string >& new_candidates,
     std::string& filetype,
     std::string& filepath );
 
@@ -64,7 +64,7 @@ public:
     const size_t max_candidates = 0 ) const;
 
   YCM_EXPORT std::vector< std::string > CandidatesForQueryAndType(
-    std::string query,
+    std::string& query,
     const std::string &filetype,
     const size_t max_candidates = 0 ) const;
 

--- a/cpp/ycm/tests/IdentifierCompleter_test.cpp
+++ b/cpp/ycm/tests/IdentifierCompleter_test.cpp
@@ -270,10 +270,9 @@ TEST( IdentifierCompleterTest, LotOfCandidates ) {
   // Generate a lot of candidates of the form [a-z]{5} in reverse order.
   std::vector< std::string > candidates;
   for ( int i = 0; i < 2048; ++i ) {
-    std::string candidate = "";
-    int letter = i;
-    for ( int pos = 0; pos < 5; letter /= 26, ++pos ) {
-      candidate = std::string( 1, letter % 26 + 'a' ) + candidate;
+    std::string candidate;
+    for ( int pos = 0, letter = i; pos < 5; letter /= 26, ++pos ) {
+      candidate.insert( size_t{ 0 }, 1, letter % 26 + 'a' );
     }
     candidates.insert( candidates.begin(), candidate );
   }
@@ -297,7 +296,8 @@ TEST( IdentifierCompleterTest, TagsEndToEndWorks ) {
 
   completer.AddIdentifiersToDatabaseFromTagFiles( tag_files );
 
-  EXPECT_THAT( completer.CandidatesForQueryAndType( "fo", "cpp" ),
+  std::string query = "fo";
+  EXPECT_THAT( completer.CandidatesForQueryAndType( query, "cpp" ),
                ElementsAre( "foosy",
                             "fooaaa" ) );
 
@@ -307,11 +307,12 @@ TEST( IdentifierCompleterTest, TagsEndToEndWorks ) {
 // Filetype checking
 TEST( IdentifierCompleterTest, ManyCandidateSimpleFileType ) {
   IdentifierCompleter completer;
+  std::string query = "fbr";
   EXPECT_THAT( IdentifierCompleter( {
                  "foobar",
                  "foobartest",
                  "Foobartest"
-               }, "c", "foo" ).CandidatesForQueryAndType( "fbr", "c" ),
+               }, "c", "foo" ).CandidatesForQueryAndType( query, "c" ),
                WhenSorted( ElementsAre( "Foobartest",
                                         "foobar",
                                         "foobartest" ) ) );
@@ -320,11 +321,12 @@ TEST( IdentifierCompleterTest, ManyCandidateSimpleFileType ) {
 
 TEST( IdentifierCompleterTest, ManyCandidateSimpleWrongFileType ) {
   IdentifierCompleter completer;
+  std::string query = "fbr";
   EXPECT_THAT( IdentifierCompleter( {
                  "foobar",
                  "foobartest",
                  "Foobartest"
-               }, "c", "foo" ).CandidatesForQueryAndType( "fbr", "cpp" ),
+               }, "c", "foo" ).CandidatesForQueryAndType( query, "cpp" ),
                IsEmpty() );
 }
 

--- a/ycmd/completers/all/identifier_completer.py
+++ b/ycmd/completers/all/identifier_completer.py
@@ -65,11 +65,9 @@ class IdentifierCompleter( GeneralCompleter ):
     if not filetype or not filepath or not identifier:
       return
 
-    vector = ycm_core.StringVector()
-    vector.append( identifier )
     LOGGER.info( 'Adding ONE buffer identifier for file: %s', filepath )
     self._completer.AddIdentifiersToDatabase(
-      vector,
+      ycm_core.StringVector( [ identifier ] ),
       filetype,
       filepath )
 
@@ -130,25 +128,15 @@ class IdentifierCompleter( GeneralCompleter ):
 
 
   def _AddIdentifiersFromTagFiles( self, tag_files ):
-    absolute_paths_to_tag_files = ycm_core.StringVector()
-    for tag_file in self._FilterUnchangedTagFiles( tag_files ):
-      absolute_paths_to_tag_files.append( tag_file )
-
-    if not absolute_paths_to_tag_files:
-      return
-
     self._completer.AddIdentifiersToDatabaseFromTagFiles(
-      absolute_paths_to_tag_files )
+      ycm_core.StringVector(
+        self._FilterUnchangedTagFiles( tag_files ) ) )
 
 
   def _AddIdentifiersFromSyntax( self, keyword_list, filetype ):
-    keyword_vector = ycm_core.StringVector()
-    for keyword in keyword_list:
-      keyword_vector.append( keyword )
-
     filepath = SYNTAX_FILENAME + filetype
     self._completer.AddIdentifiersToDatabase(
-      keyword_vector,
+      ycm_core.StringVector( keyword_list ),
       filetype,
       filepath )
 
@@ -241,10 +229,7 @@ def _IdentifiersFromBuffer( text,
   if not collect_from_comments_and_strings:
     text = identifier_utils.RemoveIdentifierFreeText( text, filetype )
   idents = identifier_utils.ExtractIdentifiersFromText( text, filetype )
-  vector = ycm_core.StringVector()
-  for ident in idents:
-    vector.append( ident )
-  return vector
+  return ycm_core.StringVector( idents )
 
 
 def _SanitizeQuery( query ):

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -305,7 +305,7 @@ def PrepareFlagsForClang( flags,
   vector = ycm_core.StringVector()
   for flag in flags:
     vector.append( flag )
-  return vector
+  return ycm_core.StringVector( flags )
 
 
 def _RemoveXclangFlags( flags ):


### PR DESCRIPTION
With this PR we can avoid some additional copies. The changes in the
python files allow pybind to preallocate `StringVector` objects.

NOTE: We are now moving the contents of `StringVector` objects once we
call into `ycm_core.so`. This doesn't make stuff blow up, but python
code should be aware that `StringVector` objects are mutable, just like
python lists.

A really ugly part of this PR is the use of mutable l-value references
to move data. This makes the code harder to reason about, but the reason
for it is that pybind11 doesn't support r-value reference parameters.
A possible solution would be:

```c++
template <typename T>
using force_rvalue_to_lvalue_conversion = std::conditional_t<std::is_rvalue_reference<T>, T&, T>;

template <typename Return, typename... Args>
constexpr auto steal_rvalues(Return (*f)(Args...)) {
        return [f](force_lvalue_to_rvalue_conversion<Args> &&... args) { return f(std::move(args)...); };
}
```

And then changing the bindings to:

    m.def("FilterAndSortCandidates", steal_rvalues(FilterAndSortCandidates));

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1519)
<!-- Reviewable:end -->
