### PR TITLE
[READY] More C++17 niceties

### DIFF
--- a/cpp/ycm/IdentifierDatabase.cpp
+++ b/cpp/ycm/IdentifierDatabase.cpp
@@ -37,13 +37,11 @@ void IdentifierDatabase::AddIdentifiers(
   FiletypeIdentifierMap&& filetype_identifier_map ) {
   std::lock_guard locker( filetype_candidate_map_mutex_ );
 
-  for ( auto&& filetype_and_map : filetype_identifier_map ) {
-    for ( auto&& filepath_and_identifiers : filetype_and_map.second ) {
-      auto filetype = filetype_and_map.first;
-      auto filepath = filepath_and_identifiers.first;
-      AddIdentifiersNoLock( std::move( filepath_and_identifiers.second ),
-                            std::move( filetype ),
-                            std::move( filepath ) );
+  for ( auto&& [ filetype, paths_to_candidates ] : filetype_identifier_map ) {
+    for ( auto&& [ filepath, identifiers ] : paths_to_candidates ) {
+      AddIdentifiersNoLock( std::move( identifiers ),
+                            std::string( filetype ),
+                            std::string( filepath ) );
     }
   }
 }
@@ -88,8 +86,8 @@ std::vector< Result > IdentifierDatabase::ResultsForQueryAndType(
   {
     std::lock_guard locker( filetype_candidate_map_mutex_ );
     auto& paths_to_candidates = *it->second;
-    for ( const auto& path_and_candidates : paths_to_candidates ) {
-      for ( const Candidate * candidate : *path_and_candidates.second ) {
+    for ( const auto& [ _, candidates ] : paths_to_candidates ) {
+      for ( const Candidate * candidate : *candidates ) {
         if ( !seen_candidates.insert( candidate ).second ) {
           continue;
         }

--- a/cpp/ycm/IdentifierDatabase.cpp
+++ b/cpp/ycm/IdentifierDatabase.cpp
@@ -87,12 +87,12 @@ std::vector< Result > IdentifierDatabase::ResultsForQueryAndType(
 
   {
     std::lock_guard locker( filetype_candidate_map_mutex_ );
-    for ( const auto& path_and_candidates : *it->second ) {
+    auto& paths_to_candidates = *it->second;
+    for ( const auto& path_and_candidates : paths_to_candidates ) {
       for ( const Candidate * candidate : *path_and_candidates.second ) {
-        if ( ContainsKey( seen_candidates, candidate ) ) {
+        if ( !seen_candidates.insert( candidate ).second ) {
           continue;
         }
-        seen_candidates.insert( candidate );
 
         if ( candidate->IsEmpty() ||
              !candidate->ContainsBytes( query_object ) ) {

--- a/cpp/ycm/Utils.h
+++ b/cpp/ycm/Utils.h
@@ -61,19 +61,13 @@ YCM_EXPORT inline std::string Lowercase( std::string_view text ) {
 std::vector< std::string > ReadUtf8File( const fs::path &filepath );
 
 
-template <class Container, class Key>
+template <class Container, class Key, typename Value>
 typename Container::mapped_type &
 GetValueElseInsert( Container &container,
-                    const Key &key,
-                    typename Container::mapped_type &&value ) {
-  return container.insert(
-    typename Container::value_type( key, std::move( value ) ) ).first->second;
-}
-
-
-template <class Container, class Key>
-bool ContainsKey( Container &container, const Key &key ) {
-  return container.find( key ) != container.end();
+                    Key&& key,
+                    Value&& value ) {
+  return container.try_emplace(
+    std::forward< Key >( key ), std::forward< Value >( value ) ).first->second;
 }
 
 


### PR DESCRIPTION
Three small changes:

1. `GetValueElseInsert` now uses `try_emplace` instead of `insert`. This has two benefits:
1.1. We're not constructing a `pair<K,V>` before moving it into the map. The arguments are passed directly to placement `new`, so there are fewer copies.
1.2. We can `std::move()` the key as well, because `try_emplace` is nice enough not to move before checking that the key is actually not in the map already.
2. `Result` now has padding bytes at the end. That means we can potentially reclaim the padding bytes for `other_object` in `ResultAnd<T>` with `[[no_unique_address]]`.
2.1. To actually see the benefits of this, `vector<ResultAnd<size_t>>` in `PythonSupport.cpp` was changed to `vector<ResultAnd<uint32_t>>`. The size of `ResultAnd<uint32_t>` drops from 48 bytes to 40 bytes.
3. The only use of `ContainsKey` is dropped, because we were looking up a value in an `unordered_set` *twice*.
4. Finally, `IdentifierDatabase` got a few structured bindings.
4.1. Take a look at these more closely. I'm not sure all of them improve readability. Specifically, the one that says:

      auto&& [ _, paths_to_candidates ] = *it;

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1523)
<!-- Reviewable:end -->
