### PR TITLE
Update compiler requirements README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ instructions][ycm-install] (ignore the Vim-specific parts).
 Supported compilers
 -------------------
 
-- GCC 4.8 and later
-- Clang 3.3 and later
-- Microsoft Visual Studio 2015 Update 3 and later
+- GCC 8 and later
+- Clang 7 and later
+- Microsoft Visual Studio 2017 v 15.7 and later
 
 API notes
 ---------


### PR DESCRIPTION
Since I notice we are using #include<filesystem> which is boost independent, but requires updated compilers as per the c++ compiler support info [here](https://en.cppreference.com/w/cpp/compiler_support)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1527)
<!-- Reviewable:end -->
