### PR TITLE
Ubuntu 18.04 clang/gcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ instructions][ycm-install] (ignore the Vim-specific parts).
 Supported compilers
 -------------------
 
-- GCC 8 and later
+- GCC 7.5 and later
 - Clang 7 and later
 - Microsoft Visual Studio 2017 v 15.7 and later
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -155,7 +155,7 @@ endif()
 # Determining the presence of C++17 support in the compiler
 set( CPP17_AVAILABLE false )
 if ( CMAKE_CXX_COMPILER_ID STREQUAL "GNU"  )
-  if ( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8 )
+  if ( NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7 )
     set( CPP17_AVAILABLE true )
   endif()
 elseif( CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -15,13 +15,17 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required( VERSION 3.14 )
+cmake_minimum_required( VERSION 3.10 )
 
 project( YouCompleteMe )
 
 # Get the core version
 file( STRINGS "../CORE_VERSION" YCMD_CORE_VERSION )
 add_definitions( -DYCMD_CORE_VERSION=${YCMD_CORE_VERSION} )
+
+if ( CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+    add_compile_options("-stdlib=libc++")
+endif()
 
 option( UNIVERSAL "Build universal mac binary" OFF )
 
@@ -220,7 +224,10 @@ if ( NOT CPP17_AVAILABLE )
   message( FATAL_ERROR "Your C++ compiler does NOT fully support C++17." )
 endif()
 
-find_package( Python3 3.6...3.10 REQUIRED COMPONENTS Interpreter Development )
+find_package( PythonLibs 3.6...3.10 REQUIRED COMPONENTS Interpreter Development )
+set(Python3_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
+set(Python3_LIBRARIES ${PYTHON_LIBRARIES})
+set(Python3_EXECUTABLE /usr/bin/python3)
 
 #############################################################################
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -23,10 +23,6 @@ project( YouCompleteMe )
 file( STRINGS "../CORE_VERSION" YCMD_CORE_VERSION )
 add_definitions( -DYCMD_CORE_VERSION=${YCMD_CORE_VERSION} )
 
-if ( CMAKE_CXX_COMPILER_ID STREQUAL Clang)
-    add_compile_options("-stdlib=libc++")
-endif()
-
 option( UNIVERSAL "Build universal mac binary" OFF )
 
 if ( CMAKE_GENERATOR STREQUAL Xcode )

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -310,10 +310,21 @@ elseif( ${STD_FS_NEEDS_CXXFS} )
 elseif( ${STD_FS_NO_LIB_NEEDED} )
   set( STD_FS_LIB "" )
 elseif( ${STD_FS_CLANG_FS})
-    message(" I am in bitches!!!")
     set(STD_FS_LIB c++ c++abi)
 else()
-  message( FATAL_ERROR "Unknown compiler - C++17 filesystem library missing" )
+    file( WRITE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp "#include <experimental/filesystem>\nint main( int argc, char ** argv ) {\n  std::experimental::filesystem::path p( argv[ 0 ] );\n  return p.string().length();\n}" )
+    try_compile(STD_OLD_GCC_7_UBUNTU_1804 ${CMAKE_BINARY_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+	     CXX_STANDARD 17
+         CXX_EXTENSIONS TRUE
+         LINK_LIBRARIES stdc++fs
+        )
+    if(${STD_OLD_GCC_7_UBUNTU_1804})
+        set(STD_FS_LIB stdc++fs)
+        add_definitions(-DSTD_OLD_GCC_7_UBUNTU_1804)
+    else()
+      message( FATAL_ERROR "Unknown compiler - C++17 filesystem library missing" )
+    endif()
 endif()
 
 #############################################################################

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required( VERSION 3.14 )
+cmake_minimum_required( VERSION 3.10 )
 
 project( ycm_core )
 
@@ -295,6 +295,12 @@ try_compile( STD_FS_NEEDS_CXXFS ${CMAKE_CURRENT_BINARY_DIR}
 	     CXX_STANDARD_REQUIRED TRUE
 	     CXX_EXTENSIONS FALSE
              LINK_LIBRARIES c++fs )
+try_compile( STD_FS_CLANG_FS ${CMAKE_CURRENT_BINARY_DIR}
+             SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+	     CXX_STANDARD 17
+         COMPILE_DEFINITIONS -stdlib=libc++
+         CXX_EXTENSIONS TRUE
+         LINK_LIBRARIES c++ c++abi)
 file( REMOVE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp )
 
 if( ${STD_FS_NEEDS_STDCXXFS} )
@@ -303,6 +309,9 @@ elseif( ${STD_FS_NEEDS_CXXFS} )
   set( STD_FS_LIB c++fs )
 elseif( ${STD_FS_NO_LIB_NEEDED} )
   set( STD_FS_LIB "" )
+elseif( ${STD_FS_CLANG_FS})
+    message(" I am in bitches!!!")
+    set(STD_FS_LIB c++ c++abi)
 else()
   message( FATAL_ERROR "Unknown compiler - C++17 filesystem library missing" )
 endif()

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -18,13 +18,10 @@
 #include "IdentifierUtils.h"
 #include "Utils.h"
 
-#include <filesystem>
 #include <string_view>
 #include <unordered_map>
 
 namespace YouCompleteMe {
-
-namespace fs = std::filesystem;
 
 namespace {
 
@@ -189,7 +186,12 @@ FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
     }();
     std::string_view identifier(&line[ 0 ], id_end );
     fs::path path( line.begin() + path_begin, line.begin() + path_end );
+
+#ifdef STD_OLD_GCC_7_UBUNTU_1804
+    path = fs::canonical( path_to_tag_file.parent_path() / path );
+#else
     path = fs::weakly_canonical( path_to_tag_file.parent_path() / path );
+#endif
     std::string_view language( &line[ lang_begin ], lang_end - lang_begin );
     std::string filetype( FindWithDefault( LANG_TO_FILETYPE,
                                            language,

--- a/cpp/ycm/IdentifierUtils.h
+++ b/cpp/ycm/IdentifierUtils.h
@@ -20,12 +20,18 @@
 
 #include "IdentifierDatabase.h"
 
+#ifdef STD_OLD_GCC_7_UBUNTU_1804
+#include <experimental/filesystem>
+namespace fs= std::experimental::filesystem;
+#else
 #include <filesystem>
+namespace fs= std::filesystem;
+#endif
 
 namespace YouCompleteMe {
 
 YCM_EXPORT FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
-  const std::filesystem::path &path_to_tag_file );
+  const fs::path &path_to_tag_file );
 
 } // namespace YouCompleteMe
 

--- a/cpp/ycm/Utils.cpp
+++ b/cpp/ycm/Utils.cpp
@@ -18,13 +18,10 @@
 #include "Utils.h"
 
 #include <cmath>
-#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <string>
 #include <vector>
-
-namespace fs = std::filesystem;
 
 namespace YouCompleteMe {
 

--- a/cpp/ycm/Utils.h
+++ b/cpp/ycm/Utils.h
@@ -20,14 +20,19 @@
 
 #include <algorithm>
 #include <cmath>
+#ifdef STD_OLD_GCC_7_UBUNTU_1804
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
 #include <filesystem>
+namespace fs = std::filesystem;
+#endif
 #include <limits>
 #include <string>
 #include <string_view>
 #include <type_traits>
 #include <vector>
 
-namespace fs = std::filesystem;
 
 namespace YouCompleteMe {
 

--- a/cpp/ycm/tests/CMakeLists.txt
+++ b/cpp/ycm/tests/CMakeLists.txt
@@ -16,7 +16,7 @@
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 
 project( ycm_core_tests )
-cmake_minimum_required( VERSION 3.14 )
+cmake_minimum_required( VERSION 3.10 )
 
 # The gtest library triggers warnings, so we turn them off; it's not up to us to
 # fix gtest warnings, it's up to upstream.

--- a/cpp/ycm/tests/IdentifierUtils_test.cpp
+++ b/cpp/ycm/tests/IdentifierUtils_test.cpp
@@ -21,11 +21,9 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
-#include <filesystem>
 
 namespace YouCompleteMe {
 
-namespace fs = std::filesystem;
 using ::testing::ElementsAre;
 using ::testing::ContainerEq;
 using ::testing::IsEmpty;
@@ -38,7 +36,11 @@ TEST( IdentifierUtilsTest, ExtractIdentifiersFromTagsFileWorks ) {
   fs::path root = fs::current_path().root_path();
   fs::path testfile = PathToTestFile( "basic.tags" );
   /* VS2017 returns C:\DIRECT~1\ paths without fs::weakly_canonical() */
+#ifdef STD_OLD_GCC_7_UBUNTU_1804
+  fs::path testfile_parent = fs::canonical( testfile.parent_path() );
+#else
   fs::path testfile_parent = fs::weakly_canonical( testfile.parent_path() );
+#endif
 
   EXPECT_THAT( ExtractIdentifiersFromTagsFile( testfile ),
       UnorderedElementsAre(

--- a/cpp/ycm/tests/TestUtils.h
+++ b/cpp/ycm/tests/TestUtils.h
@@ -22,14 +22,19 @@
 #include "CodePoint.h"
 #include "Word.h"
 
+#ifdef STD_OLD_GCC_7_UBUNTU_1804
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
 #include <filesystem>
+namespace fs = std::filesystem;
+#endif
 #include <gmock/gmock.h>
 #include <string>
 #include <vector>
 
 using ::testing::PrintToString;
 
-namespace fs = std::filesystem;
 
 namespace YouCompleteMe {
 


### PR DESCRIPTION
Add support for building ycmd with normal gcc 7.5 or clang-10, as tested and works if on ubuntu 18.04 LTS.... Appears to work on my machine.  :smile:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1528)
<!-- Reviewable:end -->
