### PR TITLE
[RFC] Do not touch stdin/stdout when they are redirected by the shell  

### DIFF
--- a/ycmd/__main__.py
+++ b/ycmd/__main__.py
@@ -152,7 +152,8 @@ def SetupOptions( options_file ):
 
 
 def CloseStdin():
-  sys.stdin.close()
+  if sys.stdin is not None:
+    sys.stdin.close()
   os.close( 0 )
 
 

--- a/ycmd/wsgi_server.py
+++ b/ycmd/wsgi_server.py
@@ -17,6 +17,7 @@
 
 from waitress.server import TcpWSGIServer
 import select
+import sys
 
 
 class StoppableWSGIServer( TcpWSGIServer ):
@@ -32,7 +33,9 @@ class StoppableWSGIServer( TcpWSGIServer ):
 
     # Message for compatibility with clients who expect the output from
     # waitress.serve here
-    print( f'serving on http://{ self.effective_host }:{self.effective_port}' )
+    if sys.stdin is not None:
+      print( f'serving on http://{ self.effective_host }:'
+             f'{ self.effective_port }' )
 
     try:
       self.run()


### PR DESCRIPTION
If stdin and/or stdout is redirected by the shell, `sys.stdin` and `sys.stdout` will be `None` and `print()` won't work. The `sys.stdin` part is easy, because we never redirect it. However, we attempt to redirect `sys.stdout` to our log file. Python thinks that succeeds and then we're left with no way to check if we're allowed to call `print()` in `wsgi_server.py`. A workaround is to check if `sys.stdout` is `None` and skip the pointless redirection - `print()` will fail anyway.

Fixes #1525

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1534)
<!-- Reviewable:end -->
