### PR TITLE
[READY] Clean up C++ warnings

### DIFF
--- a/cpp/ycm/CodePoint.cpp
+++ b/cpp/ycm/CodePoint.cpp
@@ -57,7 +57,7 @@ RawCodePoint FindCodePoint( std::string_view text ) {
 
   auto it = std::lower_bound( original.begin(), original.end(), text );
   if ( it != original.end() && text == *it ) {
-    size_t index = std::distance( original.begin(), it );
+    auto index = static_cast< size_t >( std::distance( original.begin(), it ) );
     return { *it,
              code_points.normal[ index ],
              code_points.folded_case[ index ],
@@ -111,6 +111,6 @@ CodePointSequence BreakIntoCodePoints( std::string_view text ) {
 
 const char* UnicodeDecodeError::what() const noexcept {
   return std::runtime_error::what();
-};
+}
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/PythonSupport.cpp
+++ b/cpp/ycm/PythonSupport.cpp
@@ -61,9 +61,11 @@ pybind11::list FilterAndSortCandidates(
   std::string& query,
   const size_t max_candidates ) {
 
-  size_t num_candidates = PyList_GET_SIZE( candidates.ptr() );
+  auto num_candidates = size_t( PyList_GET_SIZE( candidates.ptr() ) );
   std::vector< const Candidate * > repository_candidates =
-    CandidatesFromObjectList( candidates, std::move( candidate_property ), num_candidates );
+    CandidatesFromObjectList( candidates,
+                              std::move( candidate_property ),
+                              num_candidates );
 
   std::vector< ResultAnd< size_t > > result_and_objects;
   {
@@ -89,8 +91,9 @@ pybind11::list FilterAndSortCandidates(
 
   pybind11::list filtered_candidates( result_and_objects.size() );
   for ( size_t i = 0; i < result_and_objects.size(); ++i ) {
-    auto new_candidate = 
-        PyList_GET_ITEM( candidates.ptr(), result_and_objects[ i ].extra_object_ );
+    auto new_candidate = PyList_GET_ITEM(
+        candidates.ptr(),
+        result_and_objects[ i ].extra_object_ );
     Py_INCREF( new_candidate );
     PyList_SET_ITEM( filtered_candidates.ptr(), i, new_candidate );
   }
@@ -107,13 +110,13 @@ std::string GetUtf8String( pybind11::handle value ) {
     ssize_t size = 0;
     const char* buffer = nullptr;
     buffer = PyUnicode_AsUTF8AndSize( value.ptr(), &size );
-    return { buffer, (size_t)size };
+    return { buffer, static_cast< size_t >( size ) };
   }
   if ( PyBytes_CheckExact( value.ptr() ) ) {
     ssize_t size = 0;
     char* buffer = nullptr;
     PyBytes_AsStringAndSize( value.ptr(), &buffer, &size );
-    return { buffer, (size_t)size };
+    return { buffer, static_cast< size_t >( size ) };
   }
 
   // Otherwise go through Python's built-in `str`.
@@ -121,7 +124,7 @@ std::string GetUtf8String( pybind11::handle value ) {
   ssize_t size = 0;
   const char* buffer =
       PyUnicode_AsUTF8AndSize( keep_alive.ptr(), &size );
-  return { buffer, (size_t)size };
+  return { buffer, static_cast< size_t >( size ) };
 }
 
 } // namespace YouCompleteMe

--- a/cpp/ycm/ycm_core.cpp
+++ b/cpp/ycm/ycm_core.cpp
@@ -37,7 +37,7 @@
 namespace py = pybind11;
 using namespace YouCompleteMe;
 
-bool HasClangSupport() {
+static bool HasClangSupport() {
 #ifdef USE_CLANG_COMPLETER
   return true;
 #else
@@ -45,14 +45,14 @@ bool HasClangSupport() {
 #endif // USE_CLANG_COMPLETER
 }
 
-PYBIND11_MAKE_OPAQUE( std::vector< std::string > );
+PYBIND11_MAKE_OPAQUE( std::vector< std::string > )
 #ifdef USE_CLANG_COMPLETER
-PYBIND11_MAKE_OPAQUE( std::vector< UnsavedFile > );
-PYBIND11_MAKE_OPAQUE( std::vector< Range > );
-PYBIND11_MAKE_OPAQUE( std::vector< CompletionData > );
-PYBIND11_MAKE_OPAQUE( std::vector< Diagnostic > );
-PYBIND11_MAKE_OPAQUE( std::vector< FixIt > );
-PYBIND11_MAKE_OPAQUE( std::vector< FixItChunk > );
+PYBIND11_MAKE_OPAQUE( std::vector< UnsavedFile > )
+PYBIND11_MAKE_OPAQUE( std::vector< Range > )
+PYBIND11_MAKE_OPAQUE( std::vector< CompletionData > )
+PYBIND11_MAKE_OPAQUE( std::vector< Diagnostic > )
+PYBIND11_MAKE_OPAQUE( std::vector< FixIt > )
+PYBIND11_MAKE_OPAQUE( std::vector< FixItChunk > )
 #endif // USE_CLANG_COMPLETER
 
 PYBIND11_MODULE( ycm_core, mod )


### PR DESCRIPTION
Nothing too special. Most noteworthy changes are in `IdentifierUtils.cpp`:

1. Remove unused `StringCompare` class.
2. Remove pairs from `LANG_TO_FILETYPE` where the value is just a lowercase version of the key - that's covered by the fallback branch.
3. To avoid the constructor at global scope, `LANG_TO_FILETYPE`'s type is now `array<pair<string_view, string_view>, N>` and is `constexpr`.
3.1. As a result, `FindWithDefault` had to be rewritten to work with `unordered_map::find` and `std::find`. Damn you libclang completer.
4. The main loop in `IdentifierUtils.cpp` is changed to use iterators instead of indices, which helps with warnings. Also, it allows us to use `std::default_searcher()` which means we don't have to use magic `index + 9` to skip over `"language:"`.
5. The rest are just minor `-Wextra-semi` and `-Wsign-conversion` things. Some of which could be solved nicer with `std::ssize()`, but that's C++20.

That leaves us with the following warnings:

1. `-Wc++98-compat` - yeah, we're at C++17.
2. `-Wc++98-compat-pedantic` - I thought I said C++17?
3. `-Wexit-time-destructor` - the repository singletons are destroyed at exit time. No way around that except leaking them, Google style.
4. `-Wpadding` - yeeeah...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1535)
<!-- Reviewable:end -->
