### PR TITLE
[READY] Avoid 'localhost' in C# URLs

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -837,7 +837,7 @@ class CsharpSolutionCompleter( object ):
   def _ServerLocation( self ):
     # We cannot use 127.0.0.1 like we do in other places because OmniSharp
     # server only listens on localhost.
-    return 'http://localhost:' + str( self._omnisharp_port )
+    return f'http://127.0.0.1:{ self._omnisharp_port }'
 
 
   def _GetResponse( self, handler, parameters = {}, timeout = None ):


### PR DESCRIPTION
I have just remembered that we've had a user with a broken `/etc/hosts` and so he couldn't resolve `localhost`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1537)
<!-- Reviewable:end -->
