### PR TITLE
[READY] Optionally enable Link Time Optimisation (LTO)

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -242,10 +242,4 @@ else()
   add_subdirectory( absl )
 endif()
 
-# Optionally enable link time optimization (LTO) by adding the `-flto` flag.
-# This provides smaller, faster executables/DSOs, and improves GCC
-# diagnostics.
-include(CheckIPOSupported)
-check_ipo_supported( RESULT LTOAvailable )
-
 add_subdirectory( ycm )

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -242,4 +242,10 @@ else()
   add_subdirectory( absl )
 endif()
 
+# Optionally enable link time optimization (LTO) by adding the `-flto` flag.
+# This provides smaller, faster executables/DSOs, and improves GCC
+# diagnostics.
+include(CheckIPOSupported)
+check_ipo_supported( RESULT LTOAvailable )
+
 add_subdirectory( ycm )

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -443,3 +443,10 @@ if( USE_CLANG_TIDY )
 else()
   message( STATUS "NOT using clang-tidy for static analysis." )
 endif()
+
+###############################################################################
+
+if ( LTOAvailable )
+  message( STATUS "Link-time optimization enabled" )
+  set_target_properties( ycm_core PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -446,7 +446,9 @@ endif()
 
 ###############################################################################
 
-if ( LTOAvailable )
+if ( ${CMAKE_BUILD_TYPE} STREQUAL "Release" )
   message( STATUS "Link-time optimization enabled" )
   set_target_properties( ycm_core PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+else()
+  message( STATUS "Link-time optimization disabled" )
 endif()


### PR DESCRIPTION
LTO provides smaller, faster executables / DSOs, and improves GCC diagnostics.

https://llvm.org/docs/LinkTimeOptimization.html
https://gcc.gnu.org/wiki/LinkTimeOptimization
https://cmake.org/cmake/help/latest/module/CheckIPOSupported.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1540)
<!-- Reviewable:end -->
