### PR TITLE
Fix compiler warnings from -Wreadability-redundant-string-init

### DIFF
--- a/cpp/ycm/ClangCompleter/Location.h
+++ b/cpp/ycm/ClangCompleter/Location.h
@@ -27,9 +27,7 @@ namespace YouCompleteMe {
 
 struct Location {
   // Creates an invalid location
-  Location()
-    : line_number_( 0 ),
-      column_number_( 0 ) {
+  Location() {
   }
 
   Location( const std::string &filename,
@@ -61,8 +59,8 @@ struct Location {
     return !filename_.empty();
   }
 
-  unsigned int line_number_;
-  unsigned int column_number_;
+  unsigned int line_number_{ 0 };
+  unsigned int column_number_{ 0 };
 
   // The full, absolute path
   std::string filename_;

--- a/cpp/ycm/ClangCompleter/Location.h
+++ b/cpp/ycm/ClangCompleter/Location.h
@@ -29,8 +29,7 @@ struct Location {
   // Creates an invalid location
   Location()
     : line_number_( 0 ),
-      column_number_( 0 ),
-      filename_( "" ) {
+      column_number_( 0 ) {
   }
 
   Location( const std::string &filename,

--- a/cpp/ycm/ClangCompleter/Location.h
+++ b/cpp/ycm/ClangCompleter/Location.h
@@ -27,8 +27,7 @@ namespace YouCompleteMe {
 
 struct Location {
   // Creates an invalid location
-  Location() {
-  }
+  Location() = default;
 
   Location( const std::string &filename,
             unsigned int line,

--- a/cpp/ycm/ClangCompleter/UnsavedFile.h
+++ b/cpp/ycm/ClangCompleter/UnsavedFile.h
@@ -21,7 +21,7 @@
 #include <string>
 
 struct UnsavedFile {
-  UnsavedFile() : filename_( "" ), contents_( "" ), length_( 0 ) {}
+  UnsavedFile() : length_( 0 ) {}
 
   std::string filename_;
   std::string contents_;

--- a/cpp/ycm/ClangCompleter/UnsavedFile.h
+++ b/cpp/ycm/ClangCompleter/UnsavedFile.h
@@ -21,7 +21,7 @@
 #include <string>
 
 struct UnsavedFile {
-  UnsavedFile() {}
+  UnsavedFile() = default;
 
   std::string filename_;
   std::string contents_;

--- a/cpp/ycm/ClangCompleter/UnsavedFile.h
+++ b/cpp/ycm/ClangCompleter/UnsavedFile.h
@@ -21,11 +21,11 @@
 #include <string>
 
 struct UnsavedFile {
-  UnsavedFile() : length_( 0 ) {}
+  UnsavedFile() {}
 
   std::string filename_;
   std::string contents_;
-  unsigned long length_;
+  unsigned long length_ { 0 };
 };
 
 


### PR DESCRIPTION
dunno if this is desired or not but here it is-- default initializers are redundant for `std::string`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1542)
<!-- Reviewable:end -->
