### PR TITLE
[READY] Use C++17 parallel algorithms for filtering and sorting of candidates

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -280,20 +280,20 @@ endif()
 file( WRITE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp "#include <filesystem>\nint main( int argc, char ** argv ) {\n  std::filesystem::path p( argv[ 0 ] );\n  return p.string().length();\n}" )
 try_compile( STD_FS_NO_LIB_NEEDED ${CMAKE_CURRENT_BINARY_DIR}
              SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
-	     CXX_STANDARD 17
-	     CXX_STANDARD_REQUIRED TRUE
-	     CXX_EXTENSIONS FALSE )
+             CXX_STANDARD 17
+             CXX_STANDARD_REQUIRED TRUE
+             CXX_EXTENSIONS FALSE )
 try_compile( STD_FS_NEEDS_STDCXXFS ${CMAKE_CURRENT_BINARY_DIR}
              SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
-	     CXX_STANDARD 17
-	     CXX_STANDARD_REQUIRED TRUE
-	     CXX_EXTENSIONS FALSE
+             CXX_STANDARD 17
+             CXX_STANDARD_REQUIRED TRUE
+             CXX_EXTENSIONS FALSE
              LINK_LIBRARIES stdc++fs )
 try_compile( STD_FS_NEEDS_CXXFS ${CMAKE_CURRENT_BINARY_DIR}
              SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
-	     CXX_STANDARD 17
-	     CXX_STANDARD_REQUIRED TRUE
-	     CXX_EXTENSIONS FALSE
+             CXX_STANDARD 17
+             CXX_STANDARD_REQUIRED TRUE
+             CXX_EXTENSIONS FALSE
              LINK_LIBRARIES c++fs )
 file( REMOVE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp )
 
@@ -305,6 +305,25 @@ elseif( ${STD_FS_NO_LIB_NEEDED} )
   set( STD_FS_LIB "" )
 else()
   message( FATAL_ERROR "Unknown compiler - C++17 filesystem library missing" )
+endif()
+
+if ( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 9 )
+  file( WRITE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp "int main(){}" )
+  set( EXECUTION_SUPPORT_LIBS tbb )
+  try_compile( HAS_TBB ${CMAKE_CURRENT_BINARY_DIR}
+               SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+               CXX_STANDARD 17
+               CXX_STANDARD_REQUIRED TRUE
+               CXX_EXTENSIONS FALSE
+               LINK_LIBRARIES tbb )
+  file( REMOVE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp )
+  if ( NOT ${HAS_TBB} )
+    message( FATAL_ERROR "Intel TBB is required with GCC 9 and newer." )
+  else()
+    set( TBB_LIB tbb )
+  endif()
+else()
+  set( TBB_LIB "" )
 endif()
 
 #############################################################################
@@ -337,6 +356,7 @@ target_link_libraries( ${PROJECT_NAME}
                        PUBLIC ${LIBCLANG_TARGET}
                        PUBLIC ${STD_FS_LIB}
                        PUBLIC ${EXTRA_LIBS}
+                       PUBLIC ${TBB_LIB}
                      )
 
 if( LIBCLANG_TARGET )

--- a/cpp/ycm/Result.h
+++ b/cpp/ycm/Result.h
@@ -100,6 +100,7 @@ private:
 
 template< class T >
 struct ResultAnd {
+  ResultAnd() = default; // Needed for parallel algos
   ResultAnd( const Result &result, T extra_object )
     : extra_object_( extra_object ),
       result_( result ) {

--- a/cpp/ycm/Utils.h
+++ b/cpp/ycm/Utils.h
@@ -20,6 +20,9 @@
 
 #include <algorithm>
 #include <cmath>
+#if __has_include( <execution> )
+#  include <execution>
+#endif
 #include <filesystem>
 #include <limits>
 #include <string>
@@ -141,6 +144,16 @@ void PartialSort( std::vector< Element > &elements,
     std::partial_sort( elements.begin(),
                        elements.begin() + static_cast< diff >( max_elements ),
                        elements.end() );
+#if __has_include( <execution> )
+  } else if ( 256 <= std::min( nb_elements, max_elements ) ) {
+    std::nth_element( std::execution::par_unseq,
+                      elements.begin(),
+                      elements.begin() + max_elements,
+                      elements.end() );
+    std::sort( std::execution::par_unseq,
+               elements.begin(),
+               elements.begin() + max_elements );
+#endif
   } else {
     std::nth_element( elements.begin(),
                       elements.begin() + static_cast< diff >( max_elements ),


### PR DESCRIPTION
Like I said in gitter, GCC 9+ needs Intel TBB for the parallel algorithms.
On the other hand, clang 9+ supports these C++17 additions, but only runs sequentially.
MSVC, for once, is the easier to deal with. It actually works out of the box.

That should explain the decisions in the PR:

- The usage of `std::execution::par_unseq` is guarded by `__has_include(<execution>)`, which makes clang 7 and clang 8 work.
- For gcc 9+, there's a check in the CMakeLists.txt to see if `-ltbb` is valid. If it isn't, we fail the build.
  - That last sentence is seriously questionable. Should we make parallel algorithms opt-in? Opt-out? Should we fetch TBB with `FetchContent` and provide `USE_SYSTEM_TBB`?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1545)
<!-- Reviewable:end -->
