### PR TITLE
[READY] Fix wrong offset when calculating parameter offsets in /signature_help

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1529,8 +1529,8 @@ class LanguageServerCompleter( Completer ):
         else:
           begin, end = arg_label
         arg[ 'label' ] = [
-          utils.CodepointOffsetToByteOffset( sig_label, begin ),
-          utils.CodepointOffsetToByteOffset( sig_label, end ) ]
+          utils.CodepointOffsetToByteOffset( sig_label, begin + 1 ) - 1,
+          utils.CodepointOffsetToByteOffset( sig_label, end + 1 ) - 1 ]
     result.setdefault( 'activeParameter', 0 )
     result.setdefault( 'activeSignature', 0 )
     return result


### PR DESCRIPTION
Before this commit, we were passing 0-based columns into
`CodepointOffsetToByteOffset` in LSP completer, when constructing the
`/signature_help` response.

That's clearly a violation of `CodepointOffsetToByteOffset`'s API, which
expects 1-based input. The solution is to adjust the offsets on input,
by adding 1, then subtract one from the return value so that we still
return 0-based offsets, as promised in ycmd's API.

This should be our side of https://github.com/ycm-core/YouCompleteMe/issues/3870.
The other part is in https://github.com/phpactor/phpactor/issues/1235

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1554)
<!-- Reviewable:end -->
