### PR TITLE
[READY] Do not use Abseil on unsupported environments

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -55,6 +55,7 @@ flags = [
 # only the YCM source code needs it.
 '-DUSE_CLANG_COMPLETER',
 '-DYCM_EXPORT=',
+'-DYCM_ABSEIL_SUPPORTED',
 # THIS IS IMPORTANT! Without the '-x' flag, Clang won't know which language to
 # use when compiling headers. So it will guess. Badly. So C++ headers will be
 # compiled as C headers. You don't want that so ALWAYS specify the '-x' flag.

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -188,11 +188,18 @@ if( WIN32 OR CYGWIN OR MSYS AND NOT MSVC AND 64_BIT_PLATFORM )
   add_definitions( -DMS_WIN64 )
 endif()
 
+# CYGWIN needs handholding...
+if( CYGWIN )
+  set( NEEDS_EXTENSIONS ON )
+else()
+  set( NEEDS_EXTENSIONS OFF )
+endif()
+
 #############################################################################
 
 set( CMAKE_CXX_STANDARD 17 )
 set( CMAKE_CXX_STANDARD_REQUIRED ON )
-set( CMAKE_CXX_EXTENSIONS OFF )
+set( CMAKE_CXX_EXTENSIONS ${NEEDS_EXTENSIONS} )
 if ( NOT CPP17_AVAILABLE )
   # Platform-specific advice goes here. In particular, we have plenty of users
   # in corporate environments on RHEL/CentOS, where the default system compiler

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -282,18 +282,18 @@ try_compile( STD_FS_NO_LIB_NEEDED ${CMAKE_CURRENT_BINARY_DIR}
              SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
              CXX_STANDARD 17
              CXX_STANDARD_REQUIRED TRUE
-             CXX_EXTENSIONS FALSE )
+             CXX_EXTENSIONS ${NEEDS_EXTENSIONS} )
 try_compile( STD_FS_NEEDS_STDCXXFS ${CMAKE_CURRENT_BINARY_DIR}
              SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
              CXX_STANDARD 17
              CXX_STANDARD_REQUIRED TRUE
-             CXX_EXTENSIONS FALSE
+             CXX_EXTENSIONS ${NEEDS_EXTENSIONS}
              LINK_LIBRARIES stdc++fs )
 try_compile( STD_FS_NEEDS_CXXFS ${CMAKE_CURRENT_BINARY_DIR}
              SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
              CXX_STANDARD 17
              CXX_STANDARD_REQUIRED TRUE
-             CXX_EXTENSIONS FALSE
+             CXX_EXTENSIONS ${NEEDS_EXTENSIONS}
              LINK_LIBRARIES c++fs )
 file( REMOVE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp )
 
@@ -307,15 +307,34 @@ else()
   message( FATAL_ERROR "Unknown compiler - C++17 filesystem library missing" )
 endif()
 
+# Check if Abseil supports this environment
+file( WRITE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp "#include <absl/base/policy_checks.h>\nint main() {}" )
+try_compile( ABSL_SUPPORTED ${CMAKE_CURRENT_BINARY_DIR}
+             SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+             CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${CMAKE_SOURCE_DIR}/absl
+             CXX_STANDARD 17
+             CXX_STANDARD_REQUIRED TRUE
+             CXX_EXTENSIONS ${NEEDS_EXTENSIONS} )
+file( REMOVE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp )
+
+if( ${ABSL_SUPPORTED} )
+  message( STATUS "Using Abseil hash tables" )
+  set( EXTRA_LIBS ${EXTRA_LIBS} absl::flat_hash_map absl::flat_hash_set )
+else()
+  message( STATUS "Using STL hash tables" )
+endif()
+
 #############################################################################
 
-add_library( ${PROJECT_NAME} SHARED
-             ${SERVER_SOURCES}
-           )
+add_library( ${PROJECT_NAME} SHARED ${SERVER_SOURCES})
+
+if ( ${ABSL_SUPPORTED} )
+  target_compile_definitions( ${PROJECT_NAME} PUBLIC YCM_ABSEIL_SUPPORTED )
+endif()
 
 # Makes MSVC conform to the standard
 if ( MSVC )
-  target_compile_options( ${PROJECT_NAME} PRIVATE "/permissive-" )
+  target_compile_options( ${PROJECT_NAME} PUBLIC "/permissive-" )
 endif()
 
 target_include_directories(
@@ -338,8 +357,6 @@ target_link_libraries( ${PROJECT_NAME}
                        PUBLIC ${LIBCLANG_TARGET}
                        PUBLIC ${STD_FS_LIB}
                        PUBLIC ${EXTRA_LIBS}
-                       PUBLIC absl::flat_hash_map
-                       PUBLIC absl::flat_hash_set
                      )
 
 if( LIBCLANG_TARGET )

--- a/cpp/ycm/IdentifierDatabase.cpp
+++ b/cpp/ycm/IdentifierDatabase.cpp
@@ -23,7 +23,22 @@
 #include "Result.h"
 #include "Utils.h"
 
+#ifdef YCM_ABSEIL_SUPPORTED
 #include <absl/container/flat_hash_set.h>
+namespace YouCompleteMe {
+template< typename T, typename H, typename Eq >
+using HashSet = absl::flat_hash_set< T, H, Eq >;
+template< typename T > using Hash = absl::Hash< T >;
+} // namespace YouCompleteMe
+#else
+#include <unordered_set>
+namespace YouCompleteMe {
+template< typename T, typename H, typename Eq >
+using HashSet = std::unordered_set< T, H, Eq >;
+template< typename T >
+using Hash = std::hash< T >;
+} // namespace YouCompleteMe
+#endif
 #include <memory>
 
 namespace YouCompleteMe {
@@ -31,7 +46,7 @@ namespace YouCompleteMe {
 namespace {
 struct CandidateHasher {
   size_t operator() ( const Candidate* c ) const noexcept {
-    static absl::Hash< std::string > h;
+    static Hash< std::string > h;
     return h(c->Text());
   }
 };
@@ -110,9 +125,9 @@ std::vector< Result > IdentifierDatabase::ResultsForQueryAndType(
   }
   Word query_object( std::move( query ) );
 
-  absl::flat_hash_set< const Candidate *,
-                       CandidateHasher,
-                       CandidateCompareEq > seen_candidates;
+  HashSet< const Candidate *,
+           CandidateHasher,
+           CandidateCompareEq > seen_candidates;
   seen_candidates.reserve( candidate_repository_.NumStoredElements() );
   std::vector< Result > results;
 

--- a/cpp/ycm/IdentifierDatabase.h
+++ b/cpp/ycm/IdentifierDatabase.h
@@ -18,7 +18,19 @@
 #ifndef IDENTIFIERDATABASE_H_ZESX3CVR
 #define IDENTIFIERDATABASE_H_ZESX3CVR
 
+#ifdef YCM_ABSEIL_SUPPORTED
 #include <absl/container/flat_hash_map.h>
+namespace YouCompleteMe {
+template< typename K, typename V >
+using HashMap = absl::flat_hash_map< K, V >;
+} // namespace YouCompleteMe
+#else
+#include <unordered_map>
+namespace YouCompleteMe {
+template< typename K, typename V >
+using HashMap = std::unordered_map< K, V >;
+} // namespace YouCompleteMe
+#endif
 #include <memory>
 #include <shared_mutex>
 #include <string>
@@ -33,11 +45,10 @@ class Repository;
 
 
 // filepath -> identifiers
-using FilepathToIdentifiers = absl::flat_hash_map< std::string,
-                                        std::vector< std::string > >;
+using FilepathToIdentifiers = HashMap< std::string, std::vector< std::string > >;
 
 // filetype -> (filepath -> identifiers)
-using FiletypeIdentifierMap = absl::flat_hash_map< std::string, FilepathToIdentifiers >;
+using FiletypeIdentifierMap = HashMap< std::string, FilepathToIdentifiers >;
 
 
 // This class stores the database of identifiers the identifier completer has

--- a/cpp/ycm/Repository.h
+++ b/cpp/ycm/Repository.h
@@ -23,7 +23,19 @@
 #include "CodePoint.h"
 #include "Utils.h"
 
+#ifdef YCM_ABSEIL_SUPPORTED
 #include <absl/container/flat_hash_map.h>
+namespace YouCompleteMe {
+template< typename K, typename V >
+using HashMap = absl::flat_hash_map< K, V >;
+} // namespace YouCompleteMe
+#else
+#include <unordered_map>
+namespace YouCompleteMe {
+template< typename K, typename V >
+using HashMap = std::unordered_map< K, V >;
+} // namespace YouCompleteMe
+#endif
 #include <memory>
 #include <shared_mutex>
 #include <string>
@@ -38,7 +50,7 @@ namespace YouCompleteMe {
 template< typename T >
 class Repository {
 public:
-  using Holder = absl::flat_hash_map< std::string, std::unique_ptr< T > >;
+  using Holder = HashMap< std::string, std::unique_ptr< T > >;
   using Sequence = std::vector< const T* >;
   static Repository &Instance() {
     static Repository repo;


### PR DESCRIPTION
Instead of checking for `__CYGWIN__`, I decided to `try_compile()` `absl/base/policy_checks.h` to know if Abseil can be used.

The preprocessor blocks seem to have a lot of repetition. Not sure where to draw the line between readability and smaller diffs.

The `-DYCM_ABSEIL_SUPPORTED` in the extra conf is debatable. If someone on cygwin decides to edit ycmd's code, there will be errors. If we remove the flag from the extra conf, *we* will see `YouCompleteMe::HashMap` as an alias of `std::unordered_map` instead of `absl::flat_hash_map`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1557)
<!-- Reviewable:end -->
