### PR TITLE
Require maintainer approval for merging

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,6 +2,7 @@ pull_request_rules:
   - name: Automatic merge on Azure Pipelines and Reviewable successes
     conditions:
       - base=master
+      - "#approved-reviews-by>=2"
       - status-success=ycm-core.ycmd
       - status-success=code-review/reviewable
     actions:


### PR DESCRIPTION
> approved-reviews-by | list of string | The list of GitHub user or team login that approved the pull request. Team logins are prefixed with the @ character and must belong to the repository organization. This only matches reviewers with admin, write or maintain permission on the repository.
-- | -- | --


Previoulsy we were requiring only that reviewable was happy. Now we require that, but also 2x approving reviews (which are restricted to admin, write, maintain) users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1560)
<!-- Reviewable:end -->
