### PR TITLE
Fix quiet printing on a single line

### DIFF
--- a/build.py
+++ b/build.py
@@ -46,7 +46,7 @@ def CheckCall( args, **kwargs ):
 
 def _CheckCallQuiet( args, status_message, **kwargs ):
   if status_message:
-    print( status_message + '...', flush = True )
+    print( status_message + '...', flush = True, end = '' )
 
   with tempfile.NamedTemporaryFile() as temp_file:
     _CheckCall( args, stdout=temp_file, stderr=subprocess.STDOUT, **kwargs )


### PR DESCRIPTION
At some point this broke, and we ended up with:

```
nothing to commit, working tree clean
ben@BenMBP YouCompleteMe-Clean % ./install.py --quiet --ninja --all
Generating ycmd build configuration...
OK
Compiling ycmd target: ycm_core...
OK
Building regex module...
OK
Building watchdog module...
OK
Installing Omnisharp for C# support...OK
Building gopls for go completion...
OK
Setting up Tern for JavaScript completion...
OK
Installing rust-analyzer for Rust support...OK
Installing jdt.ls for Java support...OK
Setting up TSserver for TypeScript completion...
OK
Setting up Clangd completer...OK
ben@BenMBP YouCompleteMe-Clean % ./install.py --quiet --ninja --all
```

This fixes it:

```
ben@BenMBP ycmd % ./build.py --all --quiet --ninja
Generating ycmd build configuration...OK
Compiling ycmd target: ycm_core...OK
Building regex module...OK
Building watchdog module...OK
Installing Omnisharp for C# support...OK
Building gopls for go completion...OK
Setting up Tern for JavaScript completion...OK
Installing rust-analyzer for Rust support...OK
Installing jdt.ls for Java support...OK
Setting up TSserver for TypeScript completion...OK
Setting up Clangd completer...OK
ben@BenMBP ycmd % git add --patch
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1564)
<!-- Reviewable:end -->
