### PR TITLE
[READY] Silence MSVC warnings

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -182,6 +182,11 @@ if ( MSVC )
   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /bigobj /utf-8" )
 endif()
 
+# Makes MSVC conform to the standard
+if ( MSVC )
+  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive- /Zc:__cplusplus /Zc:externConstexpr /Zc:inline /Zc:throwingNew" )
+endif()
+
 # Enables Python compilation for 64-bit Windows. Already defined by Python
 # headers when compiling with MSVC.
 if( WIN32 OR CYGWIN OR MSYS AND NOT MSVC AND 64_BIT_PLATFORM )

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -332,11 +332,6 @@ if ( ${ABSL_SUPPORTED} )
   target_compile_definitions( ${PROJECT_NAME} PUBLIC YCM_ABSEIL_SUPPORTED )
 endif()
 
-# Makes MSVC conform to the standard
-if ( MSVC )
-  target_compile_options( ${PROJECT_NAME} PUBLIC "/permissive-" )
-endif()
-
 target_include_directories(
   ${PROJECT_NAME}
   SYSTEM


### PR DESCRIPTION
Abseil produces ~40'000 lines of warnings when ycmd is compiled on Windows. This should silence them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1566)
<!-- Reviewable:end -->
