### PR TITLE
[READY] Fix Standard library includes with Xcode 12.5

### DIFF
--- a/third_party/generic_server/client/package-lock.json
+++ b/third_party/generic_server/client/package-lock.json
@@ -1,8 +1,264 @@
 {
 	"name": "lsp-sample-client",
 	"version": "0.0.1",
-	"lockfileVersion": 1,
+	"lockfileVersion": 2,
 	"requires": true,
+	"packages": {
+		"": {
+			"name": "lsp-sample-client",
+			"version": "0.0.1",
+			"license": "MIT",
+			"dependencies": {
+				"vscode-languageclient": "^6.1.3"
+			},
+			"devDependencies": {
+				"@types/vscode": "1.43.0",
+				"vscode-test": "^1.3.0"
+			},
+			"engines": {
+				"vscode": "^1.43.0"
+			}
+		},
+		"node_modules/@types/vscode": {
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.43.0.tgz",
+			"integrity": "sha512-kIaR9qzd80rJOxePKpCB/mdy00mz8Apt2QA5Y6rdrKFn13QNFNeP3Hzmsf37Bwh/3cS7QjtAeGSK7wSqAU0sYQ==",
+			"dev": true
+		},
+		"node_modules/agent-base": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"dev": true,
+			"dependencies": {
+				"es6-promisify": "^5.0.0"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"node_modules/debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/es6-promise": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+			"dev": true
+		},
+		"node_modules/es6-promisify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"dev": true,
+			"dependencies": {
+				"es6-promise": "^4.0.3"
+			}
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"node_modules/glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "4",
+				"debug": "3.1.0"
+			},
+			"engines": {
+				"node": ">= 4.5.0"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "^4.3.0",
+				"debug": "^3.1.0"
+			},
+			"engines": {
+				"node": ">= 4.5.0"
+			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"node_modules/minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/rimraf": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"dev": true,
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			}
+		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+			"integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==",
+			"engines": {
+				"node": ">=8.0.0 || >=10.0.0"
+			}
+		},
+		"node_modules/vscode-languageclient": {
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-6.1.3.tgz",
+			"integrity": "sha512-YciJxk08iU5LmWu7j5dUt9/1OLjokKET6rME3cI4BRpiF6HZlusm2ZwPt0MYJ0lV5y43sZsQHhyon2xBg4ZJVA==",
+			"dependencies": {
+				"semver": "^6.3.0",
+				"vscode-languageserver-protocol": "^3.15.3"
+			},
+			"engines": {
+				"vscode": "^1.41.0"
+			}
+		},
+		"node_modules/vscode-languageclient/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol": {
+			"version": "3.15.3",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
+			"integrity": "sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==",
+			"dependencies": {
+				"vscode-jsonrpc": "^5.0.1",
+				"vscode-languageserver-types": "3.15.1"
+			}
+		},
+		"node_modules/vscode-languageserver-types": {
+			"version": "3.15.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+			"integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
+		},
+		"node_modules/vscode-test": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.3.0.tgz",
+			"integrity": "sha512-LddukcBiSU2FVTDr3c1D8lwkiOvwlJdDL2hqVbn6gIz+rpTqUCkMZSKYm94Y1v0WXlHSDQBsXyY+tchWQgGVsw==",
+			"dev": true,
+			"dependencies": {
+				"http-proxy-agent": "^2.1.0",
+				"https-proxy-agent": "^2.2.4",
+				"rimraf": "^2.6.3"
+			},
+			"engines": {
+				"node": ">=8.9.3"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		}
+	},
 	"dependencies": {
 		"@types/vscode": {
 			"version": "1.43.0",

--- a/third_party/generic_server/package.json
+++ b/third_party/generic_server/package.json
@@ -54,10 +54,10 @@
 	},
 	"devDependencies": {
 		"@types/mocha": "^8.0.3",
-		"mocha": "^8.1.1",
 		"@types/node": "^12.12.0",
-		"eslint": "^6.4.0",
 		"@typescript-eslint/parser": "^2.3.0",
+		"eslint": "^6.4.0",
+		"mocha": "^8.1.1",
 		"typescript": "^3.9.4"
 	}
 }

--- a/third_party/generic_server/server/package-lock.json
+++ b/third_party/generic_server/server/package-lock.json
@@ -1,8 +1,60 @@
 {
 	"name": "lsp-sample-server",
 	"version": "1.0.0",
-	"lockfileVersion": 1,
+	"lockfileVersion": 2,
 	"requires": true,
+	"packages": {
+		"": {
+			"name": "lsp-sample-server",
+			"version": "1.0.0",
+			"license": "MIT",
+			"dependencies": {
+				"vscode-languageserver": "^6.1.1",
+				"vscode-languageserver-textdocument": "^1.0.1"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+			"integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==",
+			"engines": {
+				"node": ">=8.0.0 || >=10.0.0"
+			}
+		},
+		"node_modules/vscode-languageserver": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-6.1.1.tgz",
+			"integrity": "sha512-DueEpkUAkD5XTR4MLYNr6bQIp/UFR0/IPApgXU3YfCBCB08u2sm9hRCs6DxYZELkk++STPjpcjksR2H8qI3cDQ==",
+			"dependencies": {
+				"vscode-languageserver-protocol": "^3.15.3"
+			},
+			"bin": {
+				"installServerIntoExtension": "bin/installServerIntoExtension"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol": {
+			"version": "3.15.3",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
+			"integrity": "sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==",
+			"dependencies": {
+				"vscode-jsonrpc": "^5.0.1",
+				"vscode-languageserver-types": "3.15.1"
+			}
+		},
+		"node_modules/vscode-languageserver-textdocument": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
+			"integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA=="
+		},
+		"node_modules/vscode-languageserver-types": {
+			"version": "3.15.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+			"integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
+		}
+	},
 	"dependencies": {
 		"vscode-jsonrpc": {
 			"version": "5.0.1",

--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -549,11 +549,15 @@ def AddMacIncludePaths( flags ):
        use_standard_cpp_includes and
        use_standard_system_includes and
        use_libcpp ):
-    if toolchain:
+    # Sometimes apple puts the stdlib in the platform, but it's also always in
+    # the toolchain. Pickt he platform one if it's there, else the toolchain
+    # one.
+    platform_stdlib = os.path.join( sysroot, 'usr/include/c++/v1' )
+    if os.path.exists( platform_stdlib ):
+      flags.extend( [ '-isystem', platform_stdlib ] )
+    elif toolchain:
       flags.extend( [
         '-isystem', os.path.join( toolchain, 'usr/include/c++/v1' ) ] )
-    flags.extend( [
-      '-isystem', os.path.join( sysroot, 'usr/include/c++/v1' ) ] )
 
   if use_standard_system_includes:
     flags.extend( [

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -356,6 +356,7 @@ def FlagsForFile_AddMacIncludePaths_SysRoot_CommandLine_NoStdlib_test():
                      '/Library/Frameworks',
       '-fspell-checking' ) )
 
+
 @MacOnly
 @patch( 'os.path.exists', lambda path:
         path in [
@@ -390,6 +391,7 @@ def FlagsForFile_AddMacIncludePaths_Sysroot_Custom_WithStdlib_test():
       '-iframework', '/path/to/second/sys/root/System/Library/Frameworks',
       '-iframework', '/path/to/second/sys/root/Library/Frameworks',
       '-fspell-checking' ) )
+
 
 @MacOnly
 @patch( 'os.path.exists', lambda path: False )

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -186,7 +186,10 @@ def FlagsForFile_MakeRelativePathsAbsoluteIfOptionSpecified_test():
 
 @MacOnly
 @patch( 'os.path.exists', lambda path:
-  path == '/System/Library/Frameworks/Foundation.framework/Headers' )
+  path in [
+    '/usr/include/c++/v1',
+    '/System/Library/Frameworks/Foundation.framework/Headers'
+  ] )
 def FlagsForFile_AddMacIncludePaths_SysRoot_Default_test():
   flags_object = flags.Flags()
 
@@ -211,10 +214,50 @@ def FlagsForFile_AddMacIncludePaths_SysRoot_Default_test():
 
 @MacOnly
 @patch( 'os.path.exists', lambda path:
-  path == '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform'
+  path in [
+    '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform'
           '/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks'
-          '/Foundation.framework/Headers' )
-def FlagsForFile_AddMacIncludePaths_SysRoot_Xcode_test():
+          '/Foundation.framework/Headers'
+  ] )
+def FlagsForFile_AddMacIncludePaths_SysRoot_Xcode_NoStdlib_test():
+  flags_object = flags.Flags()
+
+  def Settings( **kwargs ):
+    return {
+      'flags': [ '-Wall' ]
+    }
+
+  with MockExtraConfModule( Settings ):
+    flags_list, _ = flags_object.FlagsForFile( '/foo' )
+    assert_that( flags_list, contains_exactly(
+      '-Wall',
+      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-isystem',    '/Applications/Xcode.app/Contents/Developer/Platforms'
+                     '/MacOSX.platform/Developer/SDKs/MacOSX.sdk'
+                     '/usr/local/include',
+      '-isystem',    '/usr/local/include',
+      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    '/Applications/Xcode.app/Contents/Developer/Platforms'
+                     '/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include',
+      '-iframework', '/Applications/Xcode.app/Contents/Developer/Platforms'
+                     '/MacOSX.platform/Developer/SDKs/MacOSX.sdk'
+                     '/System/Library/Frameworks',
+      '-iframework', '/Applications/Xcode.app/Contents/Developer/Platforms'
+                     '/MacOSX.platform/Developer/SDKs/MacOSX.sdk'
+                     '/Library/Frameworks',
+      '-fspell-checking' ) )
+
+
+@MacOnly
+@patch( 'os.path.exists', lambda path:
+  path in [
+    '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform'
+          '/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1',
+    '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform'
+          '/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks'
+          '/Foundation.framework/Headers'
+  ] )
+def FlagsForFile_AddMacIncludePaths_SysRoot_Xcode_WithStdlin_test():
   flags_object = flags.Flags()
 
   def Settings( **kwargs ):
@@ -248,9 +291,13 @@ def FlagsForFile_AddMacIncludePaths_SysRoot_Xcode_test():
 
 @MacOnly
 @patch( 'os.path.exists', lambda path:
-  path == '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
-          '/System/Library/Frameworks/Foundation.framework/Headers' )
-def FlagsForFile_AddMacIncludePaths_SysRoot_CommandLine_test():
+  path in [
+    '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
+          '/usr/include/c++/v1',
+    '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
+          '/System/Library/Frameworks/Foundation.framework/Headers'
+  ] )
+def FlagsForFile_AddMacIncludePaths_SysRoot_CommandLine_WithStdlib_test():
   flags_object = flags.Flags()
 
   def Settings( **kwargs ):
@@ -279,8 +326,42 @@ def FlagsForFile_AddMacIncludePaths_SysRoot_CommandLine_test():
 
 
 @MacOnly
-@patch( 'os.path.exists', lambda path: False )
-def FlagsForFile_AddMacIncludePaths_Sysroot_Custom_test():
+@patch( 'os.path.exists', lambda path:
+  path in [
+    '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
+          '/System/Library/Frameworks/Foundation.framework/Headers'
+  ] )
+def FlagsForFile_AddMacIncludePaths_SysRoot_CommandLine_NoStdlib_test():
+  flags_object = flags.Flags()
+
+  def Settings( **kwargs ):
+    return {
+      'flags': [ '-Wall' ]
+    }
+
+  with MockExtraConfModule( Settings ):
+    flags_list, _ = flags_object.FlagsForFile( '/foo' )
+    assert_that( flags_list, contains_exactly(
+      '-Wall',
+      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-isystem',    '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
+                     '/usr/local/include',
+      '-isystem',    '/usr/local/include',
+      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
+                     '/usr/include',
+      '-iframework', '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
+                     '/System/Library/Frameworks',
+      '-iframework', '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
+                     '/Library/Frameworks',
+      '-fspell-checking' ) )
+
+@MacOnly
+@patch( 'os.path.exists', lambda path:
+        path in [
+          '/path/to/second/sys/root/usr/include/c++/v1'
+        ] )
+def FlagsForFile_AddMacIncludePaths_Sysroot_Custom_WithStdlib_test():
   flags_object = flags.Flags()
 
   def Settings( **kwargs ):
@@ -310,6 +391,37 @@ def FlagsForFile_AddMacIncludePaths_Sysroot_Custom_test():
       '-iframework', '/path/to/second/sys/root/Library/Frameworks',
       '-fspell-checking' ) )
 
+@MacOnly
+@patch( 'os.path.exists', lambda path: False )
+def FlagsForFile_AddMacIncludePaths_Sysroot_Custom_NoStdlib_test():
+  flags_object = flags.Flags()
+
+  def Settings( **kwargs ):
+    return {
+      'flags': [ '-Wall',
+                 '-isysroot/path/to/first/sys/root',
+                 '-isysroot', '/path/to/second/sys/root/',
+                 '--sysroot=/path/to/third/sys/root',
+                 '--sysroot', '/path/to/fourth/sys/root' ]
+    }
+
+  with MockExtraConfModule( Settings ):
+    flags_list, _ = flags_object.FlagsForFile( '/foo' )
+    assert_that( flags_list, contains_exactly(
+      '-Wall',
+      '-isysroot/path/to/first/sys/root',
+      '-isysroot', '/path/to/second/sys/root/',
+      '--sysroot=/path/to/third/sys/root',
+      '--sysroot', '/path/to/fourth/sys/root',
+      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-isystem',    '/path/to/second/sys/root/usr/local/include',
+      '-isystem',    '/usr/local/include',
+      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    '/path/to/second/sys/root/usr/include',
+      '-iframework', '/path/to/second/sys/root/System/Library/Frameworks',
+      '-iframework', '/path/to/second/sys/root/Library/Frameworks',
+      '-fspell-checking' ) )
+
 
 @MacOnly
 @patch( 'os.path.exists', lambda path:
@@ -330,6 +442,36 @@ def FlagsForFile_AddMacIncludePaths_Toolchain_Xcode_test():
       '-resource-dir=' + CLANG_RESOURCE_DIR,
       '-isystem',    '/Applications/Xcode.app/Contents/Developer/Toolchains'
                      '/XcodeDefault.xctoolchain/usr/include/c++/v1',
+      '-isystem',    '/usr/local/include',
+      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    '/Applications/Xcode.app/Contents/Developer/Toolchains'
+                     '/XcodeDefault.xctoolchain/usr/include',
+      '-isystem',    '/usr/include',
+      '-iframework', '/System/Library/Frameworks',
+      '-iframework', '/Library/Frameworks',
+      '-fspell-checking' ) )
+
+
+@MacOnly
+@patch( 'os.path.exists', lambda path:
+  path in [
+    '/usr/include/c++/v1',
+    '/Applications/Xcode.app/Contents/Developer/Toolchains/'
+          'XcodeDefault.xctoolchain'
+  ] )
+def FlagsForFile_AddMacIncludePaths_Toolchain_Xcode_WithSysrootStdlib_test():
+  flags_object = flags.Flags()
+
+  def Settings( **kwargs ):
+    return {
+      'flags': [ '-Wall' ]
+    }
+
+  with MockExtraConfModule( Settings ):
+    flags_list, _ = flags_object.FlagsForFile( '/foo' )
+    assert_that( flags_list, contains_exactly(
+      '-Wall',
+      '-resource-dir=' + CLANG_RESOURCE_DIR,
       '-isystem',    '/usr/include/c++/v1',
       '-isystem',    '/usr/local/include',
       '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
@@ -358,6 +500,31 @@ def FlagsForFile_AddMacIncludePaths_Toolchain_CommandLine_test():
       '-Wall',
       '-resource-dir=' + CLANG_RESOURCE_DIR,
       '-isystem',    '/Library/Developer/CommandLineTools/usr/include/c++/v1',
+      '-isystem',    '/usr/local/include',
+      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    '/Library/Developer/CommandLineTools/usr/include',
+      '-isystem',    '/usr/include',
+      '-iframework', '/System/Library/Frameworks',
+      '-iframework', '/Library/Frameworks',
+      '-fspell-checking' ) )
+
+
+@MacOnly
+@patch( 'os.path.exists', lambda path:
+  path in [ '/usr/include/c++/v1', '/Library/Developer/CommandLineTools' ] )
+def FlagsForFile_AddMacIncludePaths_Toolchain_CommandLine_SysrootStdlib_test():
+  flags_object = flags.Flags()
+
+  def Settings( **kwargs ):
+    return {
+      'flags': [ '-Wall' ]
+    }
+
+  with MockExtraConfModule( Settings ):
+    flags_list, _ = flags_object.FlagsForFile( '/foo' )
+    assert_that( flags_list, contains_exactly(
+      '-Wall',
+      '-resource-dir=' + CLANG_RESOURCE_DIR,
       '-isystem',    '/usr/include/c++/v1',
       '-isystem',    '/usr/local/include',
       '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
@@ -369,7 +536,7 @@ def FlagsForFile_AddMacIncludePaths_Toolchain_CommandLine_test():
 
 
 @MacOnly
-@patch( 'os.path.exists', lambda path: False )
+@patch( 'os.path.exists', lambda path: path == '/usr/include/c++/v1' )
 def FlagsForFile_AddMacIncludePaths_ObjCppLanguage_test():
   flags_object = flags.Flags()
 
@@ -396,6 +563,31 @@ def FlagsForFile_AddMacIncludePaths_ObjCppLanguage_test():
 
 @MacOnly
 @patch( 'os.path.exists', lambda path: False )
+def FlagsForFile_AddMacIncludePaths_ObjCppLanguage_NoSysrootStdbib_test():
+  flags_object = flags.Flags()
+
+  def Settings( **kwargs ):
+    return {
+      'flags': [ '-Wall', '-x', 'c', '-xobjective-c++' ]
+    }
+
+  with MockExtraConfModule( Settings ):
+    flags_list, _ = flags_object.FlagsForFile( '/foo' )
+    assert_that( flags_list, contains_exactly(
+      '-Wall',
+      '-x', 'c',
+      '-xobjective-c++',
+      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-isystem',    '/usr/local/include',
+      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    '/usr/include',
+      '-iframework', '/System/Library/Frameworks',
+      '-iframework', '/Library/Frameworks',
+      '-fspell-checking' ) )
+
+
+@MacOnly
+@patch( 'os.path.exists', lambda path: path == '/usr/include/c++/v1' )
 def FlagsForFile_AddMacIncludePaths_CppLanguage_test():
   flags_object = flags.Flags()
 
@@ -412,6 +604,31 @@ def FlagsForFile_AddMacIncludePaths_CppLanguage_test():
       '-xc++',
       '-resource-dir=' + CLANG_RESOURCE_DIR,
       '-isystem',    '/usr/include/c++/v1',
+      '-isystem',    '/usr/local/include',
+      '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
+      '-isystem',    '/usr/include',
+      '-iframework', '/System/Library/Frameworks',
+      '-iframework', '/Library/Frameworks',
+      '-fspell-checking' ) )
+
+
+@MacOnly
+@patch( 'os.path.exists', lambda path: False )
+def FlagsForFile_AddMacIncludePaths_CppLanguage_NoStdlib_test():
+  flags_object = flags.Flags()
+
+  def Settings( **kwargs ):
+    return {
+      'flags': [ '-Wall', '-x', 'c', '-xc++' ]
+    }
+
+  with MockExtraConfModule( Settings ):
+    flags_list, _ = flags_object.FlagsForFile( '/foo' )
+    assert_that( flags_list, contains_exactly(
+      '-Wall',
+      '-x', 'c',
+      '-xc++',
+      '-resource-dir=' + CLANG_RESOURCE_DIR,
       '-isystem',    '/usr/local/include',
       '-isystem',    os.path.join( CLANG_RESOURCE_DIR, 'include' ),
       '-isystem',    '/usr/include',
@@ -517,6 +734,29 @@ def FlagsForFile_AddMacIncludePaths_NoStandardSystemIncludes_test():
 @MacOnly
 @patch( 'os.path.exists', lambda path: False )
 def FlagsForFile_AddMacIncludePaths_NoBuiltinIncludes_test():
+  flags_object = flags.Flags()
+
+  def Settings( **kwargs ):
+    return {
+      'flags': [ '-Wall', '-nobuiltininc' ]
+    }
+
+  with MockExtraConfModule( Settings ):
+    flags_list, _ = flags_object.FlagsForFile( '/foo' )
+    assert_that( flags_list, contains_exactly(
+      '-Wall',
+      '-nobuiltininc',
+      '-resource-dir=' + CLANG_RESOURCE_DIR,
+      '-isystem',    '/usr/local/include',
+      '-isystem',    '/usr/include',
+      '-iframework', '/System/Library/Frameworks',
+      '-iframework', '/Library/Frameworks',
+      '-fspell-checking' ) )
+
+
+@MacOnly
+@patch( 'os.path.exists', lambda path: path == '/usr/include/c++/v1' )
+def FlagsForFile_AddMacIncludePaths_NoBuiltinIncludes_SysrootStdlib_test():
   flags_object = flags.Flags()
 
   def Settings( **kwargs ):


### PR DESCRIPTION
Previously the "platform" didn't include the standard library, so we
always ended up using the standard library from the "toolchain". As of
12.5 the platform includes a copy of the standard library which leads to
2 incompatible ones being included. This leads to lots of errors.

Solution is to only use one or t'other, preferring the platform one.

Tested this with/without clangd on Xcode 12.0.5 and Xcode 12.5 - passes.
Tested iOS project with Xcode 12.0.5 and 12.5 - works with libclang, fails with clangd (but confirmed this is the case irrespective of these changes, so much be a clangd problem)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1569)
<!-- Reviewable:end -->
