### PR TITLE
[READY] Make CI tests quiet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,13 +73,13 @@ jobs:
         echo -e "import coverage\ncoverage.process_startup()" > $(python -c "print(__import__('sysconfig').get_path('purelib'))")/sitecustomize.py
     - name: Run tests
       if: matrix.benchmark == false
-      run: python3 run_tests.py --no-parallel
+      run: python3 run_tests.py --no-parallel --quiet
     - name: Run benchmarks
       if: matrix.benchmark == true
-      run: python3 benchmark.py
+      run: python3 benchmark.py --quiet
     - name: Send coverage data
       if: matrix.benchmark == false
-      run: codecov --name "${{ matrix.runs-on }}-${{ matrix.name_suffix }}-tests"
+      run: codecov --name "${{ matrix.runs-on }}-${{ matrix.name_suffix }}-tests" 1>/dev/null
 
   linux_lint:
     name: "C++ Lint"
@@ -118,7 +118,7 @@ jobs:
     - name: Lint
       run: |
         YCM_TESTRUN=1 python3 build.py --clang-completer --clang-tidy --valgrind
-        python3 run_tests.py --valgrind --skip-build --no-flake8 --no-parallel
+        python3 run_tests.py --valgrind --skip-build --no-flake8 --no-parallel --quiet
 
   windows:
     strategy:
@@ -171,10 +171,10 @@ jobs:
       shell: bash
     - name: Run benchmarks
       if: matrix.benchmark == true
-      run: python3 benchmark.py --msvc ${{ matrix.msvc }}
+      run: python3 benchmark.py --msvc ${{ matrix.msvc }} --quiet
     - name: Run tests
       if: matrix.benchmark == false
-      run: python3 run_tests.py --msvc ${{ matrix.msvc }} --no-parallel
+      run: python3 run_tests.py --msvc ${{ matrix.msvc }} --no-parallel --quiet
     - name: Upload coverage data
       if: matrix.benchmark == false
-      run: codecov --name ${{ matrix.runs-on }}-${{ matrix.python-arch }}
+      run: codecov --name ${{ matrix.runs-on }}-${{ matrix.python-arch }} >null

--- a/build.py
+++ b/build.py
@@ -535,26 +535,23 @@ def RunYcmdTests( args, build_dir ):
   else:
     new_env[ 'LD_LIBRARY_PATH' ] = LIBCLANG_DIR
 
-  tests_cmd = [ p.join( tests_dir, 'ycm_core_tests' ) ]
+  tests_cmd = [ p.join( tests_dir, 'ycm_core_tests' ), '--gtest_brief' ]
   if args.core_tests != '*':
     tests_cmd.append( f'--gtest_filter={ args.core_tests }' )
-  if not args.valgrind:
-    CheckCall( tests_cmd,
-               env = new_env,
-               quiet = args.quiet,
-               status_message = 'Running ycmd tests' )
-  else:
+  if args.valgrind:
     new_env[ 'PYTHONMALLOC' ] = 'malloc'
-    cmd = [ 'valgrind',
+    tests_cmd = [ 'valgrind',
             '--gen-suppressions=all',
             '--error-exitcode=1',
             '--leak-check=full',
             '--show-leak-kinds=definite,indirect',
             '--errors-for-leak-kinds=definite,indirect',
             '--suppressions=' + p.join( DIR_OF_THIS_SCRIPT,
-                                        'valgrind.suppressions' ),
-            p.join( tests_dir, 'ycm_core_tests' ) ]
-    CheckCall( cmd, env = new_env )
+                                        'valgrind.suppressions' ) ] + tests_cmd
+  CheckCall( tests_cmd,
+      env = new_env,
+      quiet = args.quiet,
+      status_message = 'Running ycmd tests' )
 
 
 def RunYcmdBenchmarks( args, build_dir ):

--- a/cpp/ycm/tests/CMakeLists.txt
+++ b/cpp/ycm/tests/CMakeLists.txt
@@ -41,8 +41,8 @@ else()
   include( FetchContent )
   FetchContent_Declare(
     gmock
-    URL https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-    URL_HASH SHA256=9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb
+    GIT_REPOSITORY https://github.com/google/googletest
+    GIT_TAG f5e592d8ee5ffb1d9af5be7f715ce3576b8bf9c4
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gmock
   )
   FetchContent_GetProperties( gmock )

--- a/run_tests.py
+++ b/run_tests.py
@@ -230,6 +230,9 @@ def BuildYcmdLibs( args ):
 
 def PytestValgrind( parsed_args, extra_pytests_args ):
   pytests_args = BASE_PYTEST_ARGS
+  if parsed_args.quiet:
+    pytests_args[ 0 ] = '-q'
+
   if extra_pytests_args:
     pytests_args.extend( extra_pytests_args )
   else:
@@ -261,6 +264,8 @@ def PytestValgrind( parsed_args, extra_pytests_args ):
 
 def PytestTests( parsed_args, extra_pytests_args ):
   pytests_args = BASE_PYTEST_ARGS
+  if parsed_args.quiet:
+    pytests_args[ 0 ] = '-q'
 
   for key in COMPLETERS:
     if key not in parsed_args.completers:


### PR DESCRIPTION
This pull request sets `-q` by default for pytest and `--gtest_brief` for core tests.

Also, I made the `--valgrind` flag respect `--quiet`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1570)
<!-- Reviewable:end -->
