### PR TITLE
[READY?] Make codecov setup more robust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,16 +66,11 @@ jobs:
         sudo apt-get install clang-7
         sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-7 100
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-7 100
-    - name: Run pip and prepare codecov - macOS only
-      if: matrix.benchmark == false && runner.os == 'macOS'
+    - name: Run pip and prepare codecov
+      if: matrix.benchmark == false
       run: |
         python3 -m pip install -r test_requirements.txt
-        echo -e "import coverage\ncoverage.process_startup" > /Users/runner/hostedtoolcache/Python/3.6.13/x64/lib/python3.6/site-packages/sitecustomize.py
-    - name: Run pip and prepare codecov - Linux only
-      if: matrix.benchmark == false && runner.os == 'Linux'
-      run: |
-        python3 -m pip install -r test_requirements.txt
-        echo -e "import coverage\ncoverage.process_startup" > /opt/hostedtoolcache/Python/3.6.13/x64/lib/python3.6/site-packages/sitecustomize.py
+        echo -e "import coverage\ncoverage.process_startup()" > $(python -c "print(__import__('sysconfig').get_path('purelib'))")/sitecustomize.py
     - name: Run tests
       if: matrix.benchmark == false
       run: python3 run_tests.py --no-parallel
@@ -172,7 +167,8 @@ jobs:
       if: matrix.benchmark == false
       run: |
         python3 -m pip install -r test_requirements.txt
-        echo '__import__("coverage").process_startup()' > "C:\\hostedtoolcache\\windows\\python\\3.9.4\\x64\\lib\\site-packages\\sitecustomize.py"
+        echo -e "import coverage\ncoverage.process_startup()" > $(python -c "print(__import__('sysconfig').get_path('purelib'))")/sitecustomize.py
+      shell: bash
     - name: Run benchmarks
       if: matrix.benchmark == true
       run: python3 benchmark.py --msvc ${{ matrix.msvc }}


### PR DESCRIPTION
Previously the site-packages path was hardcoded, with python version
like 3.6.13 or 3.9.4.

To make this more robust, we ask the interpreter what's the path to
site-packages - `sysconfig.get_path('purelib')`.

Note: I have no idea if the path substitution works, considering yaml is describing bash/batch which is doing command substitution which is calling python, redi... Let's see what CI has to say.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1571)
<!-- Reviewable:end -->
