### PR TITLE
[RFC] Manually parallelize sorting and filtering

### DIFF
--- a/cpp/ycm/Result.h
+++ b/cpp/ycm/Result.h
@@ -100,7 +100,6 @@ private:
 
 template< class T >
 struct ResultAnd {
-  ResultAnd() = default; // Needed for parallel algos
   ResultAnd( const Result &result, T extra_object )
     : extra_object_( extra_object ),
       result_( result ) {

--- a/cpp/ycm/Result.h
+++ b/cpp/ycm/Result.h
@@ -100,6 +100,7 @@ private:
 
 template< class T >
 struct ResultAnd {
+  ResultAnd() = default; // Needed for parallel algos
   ResultAnd( const Result &result, T extra_object )
     : extra_object_( extra_object ),
       result_( result ) {

--- a/cpp/ycm/Utils.h
+++ b/cpp/ycm/Utils.h
@@ -22,8 +22,10 @@
 #include <atomic>
 #include <condition_variable>
 #include <filesystem>
+#include <future>
 #include <limits>
 #include <mutex>
+#include <queue>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -115,6 +117,85 @@ bool Erase( Container &container, const Key &key ) {
 }
 
 
+class ThreadPool {
+public:
+  explicit ThreadPool( size_t n = 2 * std::thread::hardware_concurrency() )
+    : threads_( n ),
+      stop_( false ) {
+    for( auto&& t : threads_ ) {
+      t = std::thread( &ThreadPool::thread_loop, this );
+    }
+  }
+
+  // TODO: Rule of five?
+  ~ThreadPool() {
+    stop_.store( true, std::memory_order_release );
+    cv_.notify_all();
+    for( auto& t : threads_ ) {
+      t.join();
+    }
+  }
+
+  template< typename F, typename...Args >
+  std::future< std::invoke_result_t< F, Args... > > push( F&& f, Args&&...args ) {
+    // We need the future associated with this packaged_task.
+    // That means we can't move the packaged_task itself into the queue.
+    // Hence, the unique_ptr< packaged_task< return_type > >.
+    auto task = std::make_unique< std::packaged_task< std::invoke_result_t< F, Args... >() > >(
+        std::bind(std::forward< F >( f ), std::forward< Args >( args )...) );
+    std::future< std::invoke_result_t< F, Args... > > future = task->get_future();
+    {
+      std::lock_guard lock{ queued_tasks_mutex_ };
+      // Using release() because std::function requires a copyable type
+      // but also because trivial copyability is needed to avoid allocations.
+      queued_tasks_.push( [ task = task.release() ] {
+          ( *task )();
+          delete task;
+      } );
+    }
+    cv_.notify_one();
+    return future;
+  }
+
+private:
+  void thread_loop() {
+    while( 1 ) {
+      std::function< void() > task;
+      {
+        std::unique_lock lock{ queued_tasks_mutex_ };
+        cv_.wait( lock, [ this ]{
+            return !queued_tasks_.empty() ||
+                   stop_.load( std::memory_order_acquire );
+        } );
+        if ( stop_.load( std::memory_order_relaxed ) ) {
+          // We need to drain the queue somehow.
+          // This is draining the queue in a single thread.
+          // Is there a better way?
+          // Is it okay to be slow at shutdown?
+          while( !queued_tasks_.empty() ) {
+            queued_tasks_.front()();
+            queued_tasks_.pop();
+          }
+          return;
+        }
+        task = std::move( queued_tasks_.front() );
+        queued_tasks_.pop();
+      }
+      task();
+    }
+  }
+
+  std::vector< std::thread > threads_;
+  std::queue< std::function< void() > > queued_tasks_;
+  std::mutex queued_tasks_mutex_;
+  std::condition_variable cv_;
+  std::atomic_bool stop_; // Really a job for stop_token/jthread.
+};
+// TODO: Should this be a singleton instead?
+// Or just a free function that returns an instance?
+
+
+inline ThreadPool tasks;
 // Shrink a vector to its sorted |num_sorted_elements| smallest elements. If
 // |num_sorted_elements| is 0 or larger than the vector size, sort the whole
 // vector.
@@ -140,51 +221,51 @@ void PartialSort( std::vector< Element > &elements,
     std::partial_sort( elements.begin(),
                        elements.begin() + static_cast< diff >( max_elements ),
                        elements.end() );
-#if __has_include( <execution> )
   } else if ( 256 <= std::min( nb_elements, max_elements ) ) {
+    // Should this be extracted into ParallelSort instead?
     const auto real_begin = elements.begin();
-    const auto real_end = elements.begin() + max_elements;
+    const auto real_end = elements.end();
     const auto n_threads = std::thread::hardware_concurrency();
     const auto chunk_size = max_elements / n_threads;
-    auto begin = real_begin;
-    auto end = real_begin + chunk_size;
-    std::vector< std::thread > threads( n_threads );
-    //std::vector< std::atomic< bool > > finished( n_threads );
+    std::vector< std::future< void > > futures( n_threads );
     std::mutex cv_mutex;
     std::condition_variable cv;
     std::vector< bool > finished( n_threads );
     for ( auto i = 0u; i < n_threads; ++i ) {
       auto begin = real_begin + i * chunk_size;
-      auto end = real_end - begin < chunk_size ? real_end : begin + chunk_size;
-      threads[ i ] = std::thread( [ & ] ( auto begin, auto end, unsigned id ) {
-	                            std::sort( begin, end );
-				    if ( id % 2 == 0 ) {
-				      unsigned next_wait = 1;
-				      do {
-				        if ( id + next_wait > n_threads - 1 ) {
-					  break;
-					}
-					//while(!finished[ id + next_wait ].load( std::memory_order::memory_order_relaxed )) {}
-					std::unique_lock lock{ cv_mutex };
-					cv.wait( lock, [&] { return finished[ id + next_wait ] == true; } );
-					auto middle = begin + chunk_size * next_wait;
-					end = begin + chunk_size * next_wait * 2;
-				        std::inplace_merge( begin, middle, end );
-				      } while( ~id & (next_wait <<= 1) );
-				    }
-				    //finished[ id ].store( true, std::memory_order::memory_order_relaxed );
-				    {
-				    	std::unique_lock lock{ cv_mutex };
-					finished[ id ] = true;
-				    }
-				    cv.notify_all();
-				  },
-				  begin,
-				  end,
-		     		  i );
+      auto end = real_end - begin < static_cast< diff >( chunk_size ) ? real_end : begin + chunk_size;
+      futures[i] = tasks.push(
+        [ &, i ] ( auto begin, auto end ) {
+          std::sort( begin, end );
+          if ( i % 2 == 0 ) {
+            unsigned next_wait = 1;
+            do {
+              if ( i + next_wait > n_threads - 1 ) {
+                break;
+              }
+              {
+                // This might be better served by a semaphore.
+                // That's C++20 and a naive semaphore built on atmoics is
+                // about as good as this thing.
+                std::unique_lock lock{ cv_mutex };
+                cv.wait( lock, [ &finished, i, next_wait ] {
+                  return finished[ i + next_wait ] == true;
+                } );
+              }
+              auto middle = begin + chunk_size * next_wait;
+              end = begin + chunk_size * next_wait * 2;
+              std::inplace_merge( begin, middle, end );
+            // TODO: Boris, mind explaining this magic?
+            } while( ~i & ( next_wait <<= 1 ) );
+          }
+          {
+              std::unique_lock lock{ cv_mutex };
+              finished[ i ] = true;
+          }
+          cv.notify_all();
+        }, begin, end );
     }
-    for ( auto&& t : threads ) { t.join(); }
-#endif
+    for ( auto&& f : futures ) { f.get(); }
   } else {
     std::nth_element( elements.begin(),
                       elements.begin() + static_cast< diff >( max_elements ),

--- a/cpp/ycm/Utils.h
+++ b/cpp/ycm/Utils.h
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <filesystem>
+#include <functional>
 #include <future>
 #include <limits>
 #include <mutex>


### PR DESCRIPTION
This may be just <strike>~100</strike> ~200 lines, but that's deceptive.

Two things are being parallelized independently - the `PartialSort` and the `FilterAndSortCandidates` functions' loops.

### The filtering algorithm

We only do parallelization if we have >=256 candidates to filter. If we do, we create nproc \* `std::vector partial_results`. Each thread gets its own `partial_results` vector and processes `candidates.size() / nproc` candidates.

Then we ~~`join()` all the threads~~ `get()` all the futures in the main thread and accumulate all the `partial_results` vectors into a "big" `results_and_objects` vector that then needs to be sorted.

Note: ~~TSAN complains about the way I'm using `partial_results` vectors. They are defined in the main thread, then populated in different threads (one thread populates one and only one `partial_results` object). Then the threads are `join()`-ed. Finally, once only the main thread is left, it accumulates all the `partial_results` vectors into the final `result_and_objects`. This all sounds fine at first - we populate the vectors independenty and join the threads, then accumulate once there's only one thread left. Naively, this should work without any synchronization. And... it really seems to work, apart from TSAN getting angry. Language lawyer: This is UB, because, without synchronization, there's no guarantee the main thread will ever see writes from the other threads, `thread::join()` be damned!~~

~~The correct way would be:~~

1. ~~Either move the definition of `partial_results` into the spawned threads, do the work, lock a mutex and append to the "big vector" under mutex.~~
2. ~~Or use `std::packaged_task`/`std::future`, so that we can "return" the partial results from each thread.~~

EDIT: TSAN did complain, but I initially read the report completely wrong. `thread::join()` does synchronize things nicely. It's also irrelevant now that we use a thread pool. The actual race was about wrong capture of a loop counter variable.

### The sorting algorithm

Now that we have a `results_and_objects`, we spawn new nproc threads to sort it.\* Initially, each thread does `std::sort` on its portion of the vector. Once the initial sorting is done, we're left with nproc sorted partitions of the vector. Naively, a single thread sort over the whole vector would work, but we can do better.

    {[(0 1) (2 3)] [(4 5) (6 7)]}

The numbers represent a partition index. The different kinds of brackets represent how one would want to call `std::inplace_merge` to sort the whole vector. "Outer" calls depend on "inner" calls and are represented with different kinds of brackets. Independent calls aren't nested and thus:

- From thread that sorted partition 0:
  - First, merge 0 and 1. Make sure 1 has finished before trying to merge 0 and 1.
  - Second, merge 0/1 with 2/3 once 2 has finished its job.
  - Finally, merge 0/1/2/3 with 4/5/6/7 once 4 notifies that it has done its job.
- From the thread that sorted partition 1 (or 3, or 5, or 7):
  - Nothing. At no point in time are these threads/partitions at the left side of a pair of partitions. Simply notify everyone that the job is done.
- From the thread that sorted partition 2 (or 6):
  - First merge 2 with 3, once 3 is done and notify everyone.
- From the thread that sorted partition 4:
  - First merge 4 and 5.
  - Then 4/5 and 6/7. Then notify.


An obvious question - how do we figure out which thread should wait for which other thread(s)? ***EASY!***

First, notice that you have to wait in order. That is T1 needs to wait for T2, then T3, then T5. Similarly for other threads. That means we can't just have a single atomic flag, but need a bool vector.

In other words:

1. `0` waits for `{1, 2, 4}`
2. `1` waits for `{}`
3. `2` waits for `{3}`
4. `3` waits for `{}`
5. `4` waits for `{5, 6}`
6. `5` waits for `{}`
7. `6` waits for `{7}`

In binary:

1. `0b0000` waits `{0b0001, 0b0010, 0b0100}` and would also wait for `8` (`0b1000`) had there been 9 threads.
2. `0b0001` waits `{}`
3. `0b0010` waits `{0b0011}`
4. `0b0011` waits for `{}`
5. `0b0100` waits for `{0b0101, 0b0110}`
6. `0b0101` waits for `{}`
7. `0b0110` waits for `{0b0111}`

So there should be two conditions  for "there's nothing to wait any more:

1. `current_thread_index + next_chunk_to_wait_for > n_threads - 1` - likely to happen with non-power-of-two threads.
2. Courtesy of @YannickJadoul `~current_index & (next_chunk_to_wait_for << 1)`. The idea is that we stop as soon as a set bit of current index matches any of the set bits of the `next_wait` index. I won't pretend that it is clear, but no matter what numbers I pick, it gets the right result. **Auditing very welcome.**
2.1. Tests are passing and TSAN\*\* is says this is all fine.

We have a `condition_variable` for notifying when some thread has finished its job. There's a bit vector. When a thread finishes its job, it sets the bit at the same index as the partition index above. We have a `cv_mutex` that is used for all of:

1. Synchronizing access to the condition_variable.
2. Synchronizing access to the bit vector.

\* Once again, we're only doing things in parallel if `max_candidates >= 256`.

\*\* The initial sorts that create partitions all operate on a single, big vector, there's no mutex, yet TSAN says it's fine. Because it is. Because I'm being careful to not overlap writes from different threads without synchronization. So, as long as each thread stays within its `begin`/`end` there's no problem. Language lawyer helmet: Technically, there's no parallel access to the array of `T`, because the language says that only scalar types can be accessed. I.e. `arr[0]` doesn't access an array, it only accesses the first element. Thus locking/synchronization is only needed once we start merging partitions.

### FQA

Q: Why no thread pool?
A: ~~Because that would mean dragging in a dependency or hand rolling one and I didn't feel like doing either, since we still gain a measurable performance improvement. `std::thread_pool_executor` should be in C++23, hopefully.~~
A: Says who?

Q: Why not parallelize `IdentifierDatabase::ResultsForQueryAndType()`?
A: Because that one is actually much harder to do. It uses `seen_candidates` set to avoid duplicate work which, as far as parallelizing `ResultsFor...`, is shared state. Skipping deduplication is a performance hit and synchronizing access to `seen_candidates` is an even bigger performance hit. Instead, we just leave `ResultsFor...` single threaded.

Q: WTF is that formatting?!
A: You didn't see it before "cleaning up". Hey! The PR is marked RFC, not READY!

Q: What happened to `<execution>`?
A: First, this is more efficient for `FilterAndSortCandidates()` and on par for the identifier completer. Second, LLVM doesn't yet enable their parallel STL. Third, libstdc++'s parallel algorithms depend on Intel's TBB.

Q: Should TSAN be a part of our CI?
A: I don't know. Should it? We can ditch Valgrind and use ASAN + UBSAN, MSAN and TSAN.

Q: Where benchmarks?
A: Right here!

### Benchmark summary

At a request, I'll upload the raw numbers.

1. Identifier completer benchmarks have shown a margin of error difference of ~0.5ms. Inconsistent, so no percentages.
2. Filter and sort with all candidates cached in the repository up front has seen ~10% improvement when sorting all and ~18% when sorting just top 50 candidates.
3. Filter and sort with no up-front caching in the repository has seen between 1% and 2% improvement.

With this, once candidates are cached in the repo, the C++ side of semantic completer is as fast as the C++ side of identifier completer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1572)
<!-- Reviewable:end -->
