### PR TITLE
[READY] Document /ready request

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -208,6 +208,18 @@
                     </tr>
                     <tr>
                             <td class="swagger--summary-path" rowspan="1">
+                                <a href="#path--ready">/ready</a>
+                            </td>
+                        <td>
+                            <a href="#operation--ready-get">GET</a>
+                        </td>
+                        <td>
+                            <p>Check if the server is ready.</p>
+        
+                        </td>
+                    </tr>
+                    <tr>
+                            <td class="swagger--summary-path" rowspan="1">
                                 <a href="#path--receive_messages">/receive_messages</a>
                             </td>
                         <td>
@@ -1534,6 +1546,83 @@
                                                 <div  class="panel panel-definition">
                                                     <div class="panel-body">
                                                                 <a class="json-schema-ref" href="#/definitions/ExceptionResponse">ExceptionResponse</a>
+                                                    </div>
+                                                </div></div>
+                                            
+                                            </div>                </dd>
+                            </dl>
+                        </section>
+                </div>
+            </div>
+        
+        <span id="path--ready"></span>
+            <div id="operation--ready-get" class="swagger--panel-operation-get panel">
+                <div class="panel-heading">
+                    <div class="operation-summary">Check if the server is ready.</div>
+                    <h3 class="panel-title"><span class="operation-name">GET</span> <strong>/ready</strong></h3>
+                </div>
+                <div class="panel-body">
+                    <section class="sw-operation-description">
+                        <p>Return <code>true</code> if the (sub)server is ready, <code>false</code> otherwise. The client
+            should use this endpoint to keep the server alive.</p>
+            
+                    </section>
+            
+                    
+                        <section class="sw-request-params">
+                            <table class="table">
+                                <thead>
+                                <tr>
+                                    <th class="sw-param-name"></th>
+                                    <th class="sw-param-description"></th>
+                                    <th class="sw-param-type"></th>
+                                    <th class="sw-param-data-type"></th>
+                                    <th class="sw-param-annotation"></th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                        <tr>
+                                            <td>
+                                                subserver
+                                            </td>
+                                            <td><p>Subserver filetype for which the request is made. If a subserver
+                                        supports multiple filetypes, the parameter may hold any one of them.</p>
+                                        </td>
+                                            <td>query</td>
+                                            <td>
+                                        <span class="json-property-type">string</span>
+                                        <span class="json-property-range" title="Value limits"></span>
+                                        
+                                            </td>
+                                            <td>
+                                            </td>
+                                        </tr>
+                                </tbody>
+                            </table>
+                        </section>
+                    
+                        <section class="sw-responses">
+                                <p><span class="label label-default">application/json</span> 
+                    </p>
+                    
+                            <dl>
+                                    <dt class="sw-response-200">
+                                        200 OK
+                                    
+                                    </dt>
+                                    <dd class="sw-response-200">
+                                            <div class="row">
+                                                <div class="col-md-12">
+                                                    <p>Server is ready.</p>
+                                            
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                
+                                                <div class="col-md-6 sw-response-model">
+                                                <div  class="panel panel-definition">
+                                                    <div class="panel-body">
+                                                                <a class="json-schema-ref" href="#/definitions/YesNo">YesNo</a>
                                                     </div>
                                                 </div></div>
                                             

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1266,6 +1266,27 @@ paths:
           schema:
             $ref: "#/definitions/ExceptionResponse"
 
+  /ready:
+    get:
+      summary: Check if the server is ready.
+      description: |-
+        Return `true` if the (sub)server is ready, `false` otherwise. The client
+        should use this endpoint to keep the server alive.
+      produces:
+        - application/json
+      parameters:
+        - name: subserver
+          in: query
+          description: |-
+            Subserver filetype for which the request is made. If a subserver
+            supports multiple filetypes, the parameter may hold any one of them.
+          required: false
+          type: string
+      responses:
+        200:
+          description: Server is ready.
+          schema:
+            $ref: "#/definitions/YesNo"
   /healthy:
     get:
       summary: Check if the server is healthy.


### PR DESCRIPTION
A few questions:

1. Do we want to document the subserver query, since we don't document it for `/healthy`? The comment says `/healthy` doesn't document `subserver` query because it's only intended for testing.
2. Can `/ready` ever return 500? I don't think so.

Thanks to @theli-ua for pointing out the bug in the docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1576)
<!-- Reviewable:end -->
