### PR TITLE
Fallback to boost_filesystem if no filesystem lib is present

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -277,12 +277,19 @@ if ( UNIX AND NOT ( APPLE OR SYSTEM_IS_OPENBSD OR HAIKU ) )
 endif()
 
 # Check if we need to add -lstdc++fs or -lc++fs or nothing
-file( WRITE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp "#include <filesystem>\nint main( int argc, char ** argv ) {\n  std::filesystem::path p( argv[ 0 ] );\n  return p.string().length();\n}" )
+file( WRITE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp "#if defined(USE_BOOST_FS)\n#include <boost/filesystem.hpp>\nnamespace fs = boost::filesystem;\n#else\n#include <filesystem>\nnamespace fs = std::filesystem;\n#endif\nint main( int argc, char ** argv ) {\n  fs::path p( argv[ 0 ] );\n  return p.parent_path().string().length();\n}" )
 try_compile( STD_FS_NO_LIB_NEEDED ${CMAKE_CURRENT_BINARY_DIR}
              SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
              CXX_STANDARD 17
              CXX_STANDARD_REQUIRED TRUE
              CXX_EXTENSIONS ${NEEDS_EXTENSIONS} )
+try_compile( STD_FS_NEEDS_BOOSTFS ${CMAKE_CURRENT_BINARY_DIR}
+             SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+             CXX_STANDARD 17
+             CXX_STANDARD_REQUIRED TRUE
+             CXX_EXTENSIONS ${NEEDS_EXTENSIONS}
+             COMPILE_DEFINITIONS -DUSE_BOOST_FS
+             LINK_LIBRARIES boost_system boost_filesystem)
 try_compile( STD_FS_NEEDS_STDCXXFS ${CMAKE_CURRENT_BINARY_DIR}
              SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
              CXX_STANDARD 17
@@ -299,12 +306,19 @@ file( REMOVE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp )
 
 if( ${STD_FS_NEEDS_STDCXXFS} )
   set( STD_FS_LIB stdc++fs )
+  set( STD_FS_DEFINES "" )
 elseif( ${STD_FS_NEEDS_CXXFS} )
   set( STD_FS_LIB c++fs )
+  set( STD_FS_DEFINES "" )
 elseif( ${STD_FS_NO_LIB_NEEDED} )
   set( STD_FS_LIB "" )
+  set( STD_FS_DEFINES "" )
+elseif( ${STD_FS_NEEDS_BOOSTFS} )
+  message( STATUS "Using boost_filesystem" )
+  set( STD_FS_LIB boost_system boost_filesystem )
+  set( STD_FS_DEFINES -DUSE_BOOST_FS )
 else()
-  message( FATAL_ERROR "Unknown compiler - C++17 filesystem library missing" )
+  message( FATAL_ERROR "Unknown compiler - C++17 filesystem library and boost_filesystem both missing" )
 endif()
 
 # Check if Abseil supports this environment
@@ -347,6 +361,9 @@ if ( USE_CLANG_COMPLETER AND NOT LIBCLANG_TARGET )
                           "your configuration" )
 endif()
 
+target_compile_definitions( ${PROJECT_NAME}
+                            PUBLIC ${STD_FS_DEFINES}
+                          )
 target_link_libraries( ${PROJECT_NAME}
                        PUBLIC ${Python3_LIBRARIES}
                        PUBLIC ${LIBCLANG_TARGET}

--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -23,7 +23,6 @@
 
 #include <algorithm>
 #include <cstdlib>
-#include <filesystem>
 #include <memory>
 
 using std::unique_lock;

--- a/cpp/ycm/IdentifierUtils.cpp
+++ b/cpp/ycm/IdentifierUtils.cpp
@@ -19,14 +19,11 @@
 #include "Utils.h"
 
 #include <array>
-#include <filesystem>
 #include <functional>
 #include <string_view>
 #include <utility>
 
 namespace YouCompleteMe {
-
-namespace fs = std::filesystem;
 
 namespace {
 

--- a/cpp/ycm/IdentifierUtils.h
+++ b/cpp/ycm/IdentifierUtils.h
@@ -20,12 +20,12 @@
 
 #include "IdentifierDatabase.h"
 
-#include <filesystem>
+#include "Utils.h"
 
 namespace YouCompleteMe {
 
 YCM_EXPORT FiletypeIdentifierMap ExtractIdentifiersFromTagsFile(
-  const std::filesystem::path &path_to_tag_file );
+  const fs::path &path_to_tag_file );
 
 } // namespace YouCompleteMe
 

--- a/cpp/ycm/Utils.cpp
+++ b/cpp/ycm/Utils.cpp
@@ -18,13 +18,10 @@
 #include "Utils.h"
 
 #include <cmath>
-#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <string>
 #include <vector>
-
-namespace fs = std::filesystem;
 
 namespace YouCompleteMe {
 

--- a/cpp/ycm/Utils.h
+++ b/cpp/ycm/Utils.h
@@ -20,14 +20,19 @@
 
 #include <algorithm>
 #include <cmath>
-#include <filesystem>
 #include <limits>
 #include <string>
 #include <string_view>
 #include <type_traits>
 #include <vector>
 
+#if defined(USE_BOOST_FS)
+#include <boost/filesystem.hpp>
+namespace fs = boost::filesystem;
+#else
+#include <filesystem>
 namespace fs = std::filesystem;
+#endif
 
 namespace YouCompleteMe {
 

--- a/cpp/ycm/tests/IdentifierUtils_test.cpp
+++ b/cpp/ycm/tests/IdentifierUtils_test.cpp
@@ -21,11 +21,9 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
-#include <filesystem>
 
 namespace YouCompleteMe {
 
-namespace fs = std::filesystem;
 using ::testing::ElementsAre;
 using ::testing::ContainerEq;
 using ::testing::IsEmpty;

--- a/cpp/ycm/tests/TestUtils.cpp
+++ b/cpp/ycm/tests/TestUtils.cpp
@@ -19,18 +19,6 @@
 
 #include <whereami.c>
 
-namespace std {
-
-namespace filesystem {
-
-void PrintTo( const fs::path &path, std::ostream *os ) {
-  *os << path;
-}
-
-} // namespace filesystem
-
-} // namespace std
-
 namespace YouCompleteMe {
 
 std::ostream& operator<<( std::ostream& os, const CodePointTuple &code_point ) {

--- a/cpp/ycm/tests/TestUtils.h
+++ b/cpp/ycm/tests/TestUtils.h
@@ -20,16 +20,14 @@
 
 #include "Character.h"
 #include "CodePoint.h"
+#include "Utils.h"
 #include "Word.h"
 
-#include <filesystem>
 #include <gmock/gmock.h>
 #include <string>
 #include <vector>
 
 using ::testing::PrintToString;
-
-namespace fs = std::filesystem;
 
 namespace YouCompleteMe {
 


### PR DESCRIPTION
On Termux, the standard clang auxiliary c++fs lib is not yet available, but boost is.

This patch provides for building on such systems.  Even if this change is not desired, it can still be useful for others to patch their builds going forward.

- fs:: namespace consolidated into Utils.h
- cmake filesystem test uses a non-inlined function (parent_path)
- detects and uses boost_filesystem if other options fail
- removed PrintTo test filesystem function which appears replaced

edit: force-pushed to resolve two test failures on other platforms caused by typos

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1585)
<!-- Reviewable:end -->
