### PR TITLE
Option to add general completers via ycm_general_completers global var

### DIFF
--- a/ycmd/completers/general/general_completer_store.py
+++ b/ycmd/completers/general/general_completer_store.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
+from importlib import import_module
+from ycmd import responses
 from ycmd.completers.completer import Completer
 from ycmd.completers.all.identifier_completer import IdentifierCompleter
 from ycmd.completers.general.filename_completer import FilenameCompleter
@@ -41,6 +43,21 @@ class GeneralCompleterStore( Completer ):
                              self._filename_completer,
                              self._ultisnips_completer ]
 
+    if 'general_completers' in user_options:
+      general_completers = self._GetGeneralCompleters( user_options ) 
+      self._non_filename_completers += general_completers 
+
+
+  def _GetGeneralCompleters( self, user_options ):
+    general_completers = []
+    for general_completer in user_options.get( 'general_completers' ):
+      try:
+        module = import_module( general_completer.get( 'module' ) )
+        completer = module.GetCompleter( user_options )
+        general_completers.append( completer )
+      except ImportError:
+        pass
+    return general_completers
 
   def SupportedFiletypes( self ):
     return set()


### PR DESCRIPTION
[Tabnine](https://www.tabnine.com/) is a GPT2 based AI completer tool.
Currently Tabnine provides vim support through a [fork](https://github.com/codota/tabnine-vim) for YouCompleteMe which is not optimal to say the least.

As currently `ycmd` doesn't provide an API to register custom completer providers - 
I'm propsing to introduce a new global variable `ycm_general_completers` which users can use to add their own custom completers.

e.g: 
```
let g:ycm_general_completers = 
  \ [
  \  {
  \    'name': 'tabnine',
  \    'module': 'ycmd_tabnine.hook' 
  \  }
  \ ]
```

in this example, `ycmd_tabnine.hook` exposes a GetCompleter factory method same as other completers. 
e.g https://github.com/tabnine/tabnine-ycmd 


https://user-images.githubusercontent.com/70566578/131334533-e0daf04a-3b16-46c7-9c19-1ecbc1f74c4b.mp4


Appreciate your feedback

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1588)
<!-- Reviewable:end -->
