### PR TITLE
Go get is deprecated in favor of install

### DIFF
--- a/build.py
+++ b/build.py
@@ -827,7 +827,7 @@ def EnableGoCompleter( args ):
   new_env[ 'GOPATH' ] = p.join( DIR_OF_THIS_SCRIPT, 'third_party', 'go' )
   new_env.pop( 'GOROOT', None )
   new_env[ 'GOBIN' ] = p.join( new_env[ 'GOPATH' ], 'bin' )
-  CheckCall( [ go, 'get', 'golang.org/x/tools/gopls@v0.7.1' ],
+  CheckCall( [ go, 'install', 'golang.org/x/tools/gopls@v0.7.1' ],
              env = new_env,
              quiet = args.quiet,
              status_message = 'Building gopls for go completion' )


### PR DESCRIPTION
The current version returns a warning:

```
go get: installing executables with 'go get' in module mode is deprecated.
	Use 'go install pkg@version' instead.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

To install the binaries one should use `go install` nowadays.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1590)
<!-- Reviewable:end -->
