### PR TITLE
[READY] Avoid deprecated threading function names

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -808,7 +808,7 @@ class TCPSingleStreamConnection( LanguageServerConnection ):
 
 
   def WriteData( self, data ):
-    assert self._connection_event.isSet()
+    assert self._connection_event.is_set()
     assert self._client_socket
 
     total_sent = 0
@@ -825,7 +825,7 @@ class TCPSingleStreamConnection( LanguageServerConnection ):
 
 
   def ReadData( self, size=-1 ):
-    assert self._connection_event.isSet()
+    assert self._connection_event.is_set()
     assert self._client_socket
 
     chunks = []

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -63,7 +63,7 @@ class DeferredResponse:
 
   def result( self ):
     self._event.wait( timeout = self._timeout )
-    if not self._event.isSet():
+    if not self._event.is_set():
       raise RuntimeError( 'Response Timeout' )
     message = self._message
     if not message[ 'success' ]:


### PR DESCRIPTION
Python's `threading` deprecated some identifiers in favour of snake_case
alternatives. One example is
`threading.Event.isSet()` -> `threading.event.is_set()`

Hopefully, this will make us ready for python 3.10.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1592)
<!-- Reviewable:end -->
