### PR TITLE
Use EUID for the root check instead of `sudo`'s environment variable

### DIFF
--- a/build.py
+++ b/build.py
@@ -1157,11 +1157,12 @@ def DoCmakeBuilds( args ):
 def Main(): # noqa: C901
   args = ParseArguments()
 
-  if 'SUDO_COMMAND' in os.environ:
+  if not OnWindows() and os.geteuid() == 0:
     if args.force_sudo:
-      print( 'Forcing build with sudo. If it breaks, keep the pieces.' )
+      print( 'Forcing build with root privileges. '
+             'If it breaks, keep the pieces.' )
     else:
-      sys.exit( 'This script should not be run with sudo.' )
+      sys.exit( 'This script should not be run with root privileges.' )
 
   if not args.skip_build:
     DoCmakeBuilds( args )


### PR DESCRIPTION
Fixes #1593

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1594)
<!-- Reviewable:end -->
