### PR TITLE
[READY] Call hierarchy support for LSP and typescript

### DIFF
--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -558,6 +558,23 @@ def Position( line_num, line_value, column_codepoint ):
   }
 
 
+def PrepareCallHierarchy( request_id, request_data ):
+  return BuildRequest( request_id, 'textDocument/prepareCallHierarchy', {
+    'textDocument': {
+      'uri': FilePathToUri( request_data[ 'filepath' ] ),
+    },
+    'position': Position( request_data[ 'line_num' ],
+                          request_data[ 'line_value' ],
+                          request_data[ 'column_codepoint' ] )
+  } )
+
+
+def CallHierarchy( request_id, direction, item ):
+  return BuildRequest( request_id, f'callHierarchy/{ direction }Calls', {
+    'item': item
+  } )
+
+
 def Formatting( request_id, request_data ):
   return BuildRequest( request_id, 'textDocument/formatting', {
     'textDocument': {

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -437,6 +437,12 @@ class TypeScriptCompleter( Completer ):
 
   def GetSubcommandsMap( self ):
     return {
+      'GoToCallers'       : ( lambda self, request_data, args:
+                              self._CallHierarchy( request_data,
+                                                   [ 'Incoming' ] ) ),
+      'GoToCallees'  : ( lambda self, request_data, args:
+                              self._CallHierarchy( request_data,
+                                                   [ 'Outgoing' ] ) ),
       'RestartServer'     : ( lambda self, request_data, args:
                               self._RestartServer( request_data ) ),
       'StopServer'        : ( lambda self, request_data, args:
@@ -672,6 +678,39 @@ class TypeScriptCompleter( Completer ):
       'file': filename,
       'includeLinePosition': True
     } )
+
+
+  def _CallHierarchy( self, request_data, args ):
+    self._Reload( request_data )
+
+    response = self._SendRequest( f'provideCallHierarchy{ args[ 0 ] }Calls', {
+      'file':   request_data[ 'filepath' ],
+      'line':   request_data[ 'line_num' ],
+      'offset': request_data[ 'column_codepoint' ]
+    } )
+
+    goto_response = []
+    for hierarchy_item in response:
+      description = hierarchy_item.get( 'from', hierarchy_item.get( 'to' ) )
+      filepath = description[ 'file' ]
+      start_position = hierarchy_item[ 'fromSpans' ][ 0 ][ 'start' ]
+      goto_line = start_position[ 'line' ]
+      try:
+        line_value = GetFileLines( request_data, filepath )[ goto_line - 1 ]
+      except IndexError:
+        continue
+      goto_column = utils.CodepointOffsetToByteOffset(
+        line_value,
+        start_position[ 'offset' ] )
+      goto_response.append( responses.BuildGoToResponse(
+        filepath,
+        goto_line,
+        goto_column,
+        description[ 'name' ] ) )
+
+    if goto_response:
+      return goto_response
+    raise RuntimeError( f'No { args[ 0 ].lower() } calls found.' )
 
 
   def _GoToDefinition( self, request_data ):

--- a/ycmd/tests/clangd/subcommands_test.py
+++ b/ycmd/tests/clangd/subcommands_test.py
@@ -580,6 +580,8 @@ class SubcommandsTest( TestCase ):
                                                'GetType',
                                                'GetTypeImprecise',
                                                'GoTo',
+                                               'GoToCallees',
+                                               'GoToCallers',
                                                'GoToDeclaration',
                                                'GoToDefinition',
                                                'GoToDocumentOutline',
@@ -606,6 +608,8 @@ class SubcommandsTest( TestCase ):
       'GetType',
       'GetTypeImprecise',
       'GoTo',
+      'GoToCallees',
+      'GoToCallers',
       'GoToDeclaration',
       'GoToDefinition',
       'GoToInclude',
@@ -866,6 +870,24 @@ class SubcommandsTest( TestCase ):
     ]:
       with self.subTest( test = test ):
         RunGoToTest_all( app, '', 'GoToImplementation', test )
+
+
+  @SharedYcmd
+  def test_Subcommands_GoToCallers( self, app ):
+    for test in [
+      { 'req': ( 'call_hierarchy.cc', 1, 6 ), # Simple case.
+        'res': [ ( 'call_hierarchy.cc', 4, 10 ) ] },
+      { 'req': ( 'call_hierarchy.cc', 6, 6 ),
+        'res': [
+          ( 'call_hierarchy.cc', 15, 3 ), # More than one location in response.
+          ( 'call_hierarchy.cc', 11, 3 ),
+          ( 'call_hierarchy.cc',  7, 3 ), # Recursive call.
+      ] },
+      { 'req': ( 'call_hierarchy.cc', 3, 6 ), # Top of call hierarchy.
+        'res': 'No incoming calls found.' }
+    ]:
+      with self.subTest( test = test ):
+        RunGoToTest_all( app, '', 'GoToCallers', test )
 
 
   @SharedYcmd

--- a/ycmd/tests/clangd/testdata/call_hierarchy.cc
+++ b/ycmd/tests/clangd/testdata/call_hierarchy.cc
@@ -1,0 +1,16 @@
+void simple_2() {
+}
+void simple_1() {
+  return simple_2();
+}
+void multiple_2() {
+  multiple_2();
+}
+
+void multiple_1() {
+  multiple_2();
+}
+
+void multiple_0() {
+  multiple_2();
+}

--- a/ycmd/tests/go/go_module/call_hierarchy.go
+++ b/ycmd/tests/go/go_module/call_hierarchy.go
@@ -1,0 +1,19 @@
+package main
+
+func simple_2() {}
+func simple_1() {
+	simple_2();
+}
+
+func multiple_2() {
+	multiple_2();
+}
+func multiple_1() {
+	multiple_2();
+	multiple_1();
+}
+func multiple_0() {
+	multiple_2();
+	multiple_1();
+	multiple_0();
+}

--- a/ycmd/tests/java/subcommands_test.py
+++ b/ycmd/tests/java/subcommands_test.py
@@ -169,6 +169,8 @@ class SubcommandsTest( TestCase ):
                    'GoToDefinition',
                    'GoToDocumentOutline',
                    'GoTo',
+                   'GoToCallers',
+                   'GoToCallees',
                    'GetDoc',
                    'GetType',
                    'GoToImplementation',
@@ -1946,6 +1948,77 @@ class SubcommandsTest( TestCase ):
                      test[ 'request' ][ 'col' ],
                      'GoToImplementation',
                      has_entries( test[ 'response' ] ) )
+
+
+  @WithRetry()
+  @SharedYcmd
+  def test_Subcommands_GoToCallers( self, app ):
+    for test in [
+      { 'request': { 'line': 6, 'col': 17, 'filepath': TEST_JAVA },
+        'response': [ has_entries( {
+          'line_num': 12,
+          'column_num': 10,
+          'filepath': TEST_JAVA } ) ],
+        'description': 'GoToCallers on a function call.' },
+      { 'request': { 'line': 20, 'col': 16, 'filepath': TEST_JAVA },
+        'response': [ has_entries( {
+          'line_num': 15,
+          'column_num': 41,
+          'filepath': TEST_JAVA } ) ],
+        'description': 'GoToCallers on a class name '
+                       'produces constructor calls' },
+    ]:
+      with self.subTest( test = test ):
+        RunGoToTest( app,
+                     test[ 'description' ],
+                     test[ 'request' ][ 'filepath' ],
+                     test[ 'request' ][ 'line' ],
+                     test[ 'request' ][ 'col' ],
+                     'GoToCallers',
+                     contains_inanyorder( *test[ 'response' ] ) )
+
+
+  @WithRetry()
+  @SharedYcmd
+  def test_Subcommands_GoToCallees( self, app ):
+    for test in [
+      { 'request': { 'line': 26, 'col': 22, 'filepath': TESTLAUNCHER_JAVA },
+        'response': [
+          has_entries( {
+            'filepath': TESTLAUNCHER_JAVA,
+            'line_num': 27,
+            'column_num': 22 } ),
+          has_entries( {
+            'filepath': TESTLAUNCHER_JAVA,
+            'line_num': 27,
+            'column_num': 22 } ),
+          has_entries( {
+            'filepath': TESTLAUNCHER_JAVA,
+            'line_num': 28,
+            'column_num':  5 } ),
+          has_entries( {
+            'filepath': TESTLAUNCHER_JAVA,
+            'line_num': 28,
+            'column_num':  5 } ),
+          has_entries( {
+            'filepath': TESTLAUNCHER_JAVA,
+            'line_num': 28,
+            'column_num': 12 } ),
+          has_entries( {
+            'filepath': TESTLAUNCHER_JAVA,
+            'line_num': 37,
+            'column_num':  5 } ),
+        ],
+        'description': 'Basic GoToCallees test.' }
+    ]:
+      with self.subTest( test = test ):
+        RunGoToTest( app,
+                     test[ 'description' ],
+                     test[ 'request' ][ 'filepath' ],
+                     test[ 'request' ][ 'line' ],
+                     test[ 'request' ][ 'col' ],
+                     'GoToCallees',
+                      contains_inanyorder( *test[ 'response' ] ) )
 
 
   @WithRetry()

--- a/ycmd/tests/javascript/subcommands_test.py
+++ b/ycmd/tests/javascript/subcommands_test.py
@@ -105,6 +105,8 @@ class SubcommandsTest( TestCase ):
       contains_inanyorder(
         'Format',
         'GoTo',
+        'GoToCallees',
+        'GoToCallers',
         'GoToDeclaration',
         'GoToDefinition',
         'GoToImplementation',
@@ -608,6 +610,27 @@ class SubcommandsTest( TestCase ):
       'expect': {
         'response': requests.codes.ok,
         'data': LocationMatcher( PathToTestFile( 'test.js' ), 1, 7 )
+      }
+    } )
+
+
+  @SharedYcmd
+  def test_Subcommands_GoToCallers( self, app ):
+    RunTest( app, {
+      'description': 'Basic GoToCallers works.',
+      'request': {
+        'command': 'GoToCallers',
+        'line_num': 27,
+        'column_num': 3,
+        'filepath': PathToTestFile( 'test.js' ),
+      },
+      'expect': {
+        'response': requests.codes.ok,
+        'data': contains_inanyorder(
+          LocationMatcher( PathToTestFile( 'file2.js' ), 1, 11 ),
+          LocationMatcher( PathToTestFile( 'file3.js' ), 2,  5 ),
+          LocationMatcher( PathToTestFile( 'test.js' ), 31,  5 ),
+        )
       }
     } )
 

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -1060,7 +1060,7 @@ class LanguageServerCompleterTest( TestCase ):
                          side_effect = [ fixit_response ] ):
         with patch( 'ycmd.completers.language_server.language_server_protocol.'
                     'CodeAction' ) as code_action:
-          assert_that( completer.GetCodeActions( request_data, [] ),
+          assert_that( completer.GetCodeActions( request_data ),
                        has_entry( 'fixits', empty() ) )
           assert_that(
             # Range passed to lsp.CodeAction.

--- a/ycmd/tests/rust/subcommands_test.py
+++ b/ycmd/tests/rust/subcommands_test.py
@@ -143,6 +143,8 @@ class SubcommandsTest( TestCase ):
                                       'GetDoc',
                                       'GetType',
                                       'GoTo',
+                                      'GoToCallees',
+                                      'GoToCallers',
                                       'GoToDeclaration',
                                       'GoToDefinition',
                                       'GoToDocumentOutline',

--- a/ycmd/tests/typescript/subcommands_test.py
+++ b/ycmd/tests/typescript/subcommands_test.py
@@ -141,6 +141,8 @@ class SubcommandsTest( TestCase ):
       contains_inanyorder(
         'Format',
         'GoTo',
+        'GoToCallees',
+        'GoToCallers',
         'GoToDeclaration',
         'GoToDefinition',
         'GoToImplementation',
@@ -820,6 +822,48 @@ class SubcommandsTest( TestCase ):
       'expect': {
         'response': requests.codes.internal_server_error,
         'data': ErrorMatcher( RuntimeError, 'Could not find type definition.' )
+      }
+    } )
+
+
+  @SharedYcmd
+  def test_Subcommands_GoToCallers( self, app ):
+    RunTest( app, {
+      'description': 'Basic GoToCallers works.',
+      'request': {
+        'command': 'GoToCallers',
+        'line_num': 30,
+        'column_num': 3,
+        'filepath': PathToTestFile( 'test.ts' ),
+      },
+      'expect': {
+        'response': requests.codes.ok,
+        'data': contains_inanyorder(
+          LocationMatcher( PathToTestFile( 'file2.ts' ), 1, 11 ),
+          LocationMatcher( PathToTestFile( 'file3.ts' ), 2,  5 ),
+          LocationMatcher( PathToTestFile( 'test.ts' ), 34,  5 ),
+        )
+      }
+    } )
+
+
+  @SharedYcmd
+  def test_Subcommands_GoToCallees( self, app ):
+    filepath = PathToTestFile( 'signatures.ts' )
+    RunTest( app, {
+      'description': 'Basic GoToCallees works.',
+      'request': {
+        'command': 'GoToCallees',
+        'line_num': 53,
+        'column_num': 3,
+        'filepath': filepath,
+      },
+      'expect': {
+        'response': requests.codes.ok,
+        'data': has_items(
+          LocationMatcher( filepath, 56, 15 ),
+          LocationMatcher( filepath, 58, 10 )
+        )
       }
     } )
 


### PR DESCRIPTION
It works by returning a GoToResponse and it retrieves, not the whole call stack, but just the list off immediate callers.

Comments a very much needed, even if they are "WTF, who would want to use that implementation?!"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1607)
<!-- Reviewable:end -->
