### PR TITLE
Support MSVC 17 (Visual Studio 2022)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,15 +124,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ windows-2019 ]
+        runs-on: [ windows-2022 ]
         benchmark: [ true, false ]
         python-arch: [ 'x64', 'x86' ]
-        msvc: [ 16 ]
+        msvc: [ 17 ]
         exclude:
-          - runs-on: windows-2019
+          - runs-on: windows-2022
             benchmark: true
             python-arch: 'x86'
         include:
+          - runs-on: windows-2019
+            benchmark: false
+            python-arch: 'x64'
+            msvc: 16
           - runs-on: windows-2016
             benchmark: false
             python-arch: 'x64'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Install Python
       uses: deadsnakes/action@v2.1.1
       with:
-        python-version: 3.9
+        python-version: '3.10'
         debug: true
     - name: Install GCC
       run: |
@@ -156,7 +156,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
         architecture: ${{ matrix.python-arch }}
     - name: Install Go
       if: matrix.benchmark == false

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,8 +12,9 @@ pull_request_rules:
       - status-success=C++ Lint
       - status-success=Windows MSVC 15 x64 - test run
       - status-success=Windows MSVC 16 x64 - test run
-      - status-success=Windows MSVC 16 x86 - test run
-      - status-success=Windows MSVC 16 x64 - C++ Benchmark
+      - status-success=Windows MSVC 17 x64 - test run
+      - status-success=Windows MSVC 17 x86 - test run
+      - status-success=Windows MSVC 17 x64 - C++ Benchmark
       - status-success=code-review/reviewable
     actions:
       merge:
@@ -33,8 +34,9 @@ pull_request_rules:
       - status-success=C++ Lint
       - status-success=Windows MSVC 15 x64 - test run
       - status-success=Windows MSVC 16 x64 - test run
-      - status-success=Windows MSVC 16 x86 - test run
-      - status-success=Windows MSVC 16 x64 - C++ Benchmark
+      - status-success=Windows MSVC 17 x64 - test run
+      - status-success=Windows MSVC 17 x86 - test run
+      - status-success=Windows MSVC 17 x64 - C++ Benchmark
 
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"

--- a/TESTS.md
+++ b/TESTS.md
@@ -45,7 +45,7 @@ To run the full suite, just run `run_tests.py`. Options are:
   everything is built;
 * `--no-completers`: do not build or test with listed semantic completion engine(s);
 * `--completers`: only build and test with listed semantic completion engine(s);
-* `--msvc`: the Microsoft Visual C++ version to build with (default: 15).
+* `--msvc`: the Microsoft Visual C++ version to build with (default: 16).
   Windows only;
 * `--coverage`: generate code coverage data.
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -16,7 +16,7 @@ DIR_OF_THIS_SCRIPT = p.dirname( p.abspath( __file__ ) )
 
 def ParseArguments():
   parser = argparse.ArgumentParser()
-  parser.add_argument( '--msvc', type = int, choices = [ 14, 15, 16 ],
+  parser.add_argument( '--msvc', type = int, choices = [ 15, 16, 17 ],
                        default = 16, help = 'Choose the Microsoft Visual '
                        'Studio version (default: %(default)s).' )
 

--- a/build.py
+++ b/build.py
@@ -377,6 +377,8 @@ def GetGenerator( args ):
     # Studio 16 generator.
     if args.msvc == 16:
       return 'Visual Studio 16'
+    if args.msvc == 17:
+      return 'Visual Studio 17 2022'
     return f"Visual Studio { args.msvc }{ ' Win64' if IS_64BIT else '' }"
   return 'Unix Makefiles'
 
@@ -403,7 +405,7 @@ def ParseArguments():
   parser.add_argument( '--system-libclang', action = 'store_true',
                        help = 'Use system libclang instead of downloading one '
                        'from llvm.org. NOT RECOMMENDED OR SUPPORTED!' )
-  parser.add_argument( '--msvc', type = int, choices = [ 15, 16 ],
+  parser.add_argument( '--msvc', type = int, choices = [ 15, 16, 17 ],
                        default = 16, help = 'Choose the Microsoft Visual '
                        'Studio version (default: %(default)s).' )
   parser.add_argument( '--ninja', action = 'store_true',
@@ -518,8 +520,8 @@ def FindCmake( args ):
 def GetCmakeCommonArgs( args ):
   cmake_args = [ '-G', GetGenerator( args ) ]
 
-  # Set the architecture for the Visual Studio 16 generator.
-  if OnWindows() and args.msvc == 16 and not args.ninja and not IS_MSYS:
+  # Set the architecture for the Visual Studio 16/17 generator.
+  if OnWindows() and args.msvc >= 16 and not args.ninja and not IS_MSYS:
     arch = 'x64' if IS_64BIT else 'Win32'
     cmake_args.extend( [ '-A', arch ] )
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -132,7 +132,7 @@ def ParseArguments():
                        choices = COMPLETERS.keys() )
   parser.add_argument( '--skip-build', action = 'store_true',
                        help = 'Do not build ycmd before testing.' )
-  parser.add_argument( '--msvc', type = int, choices = [ 14, 15, 16 ],
+  parser.add_argument( '--msvc', type = int, choices = [ 15, 16, 17 ],
                        default = 16, help = 'Choose the Microsoft Visual '
                        'Studio version (default: %(default)s).' )
   parser.add_argument( '--coverage', action = 'store_true',

--- a/ycmd/tests/cs/testdata/testy-multiple-solutions/solution-named-like-folder/not-testy/testy.csproj
+++ b/ycmd/tests/cs/testdata/testy-multiple-solutions/solution-named-like-folder/not-testy/testy.csproj
@@ -9,6 +9,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>testy</RootNamespace>
     <AssemblyName>testy</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ycmd/tests/cs/testdata/testy-multiple-solutions/solution-named-like-folder/testy/testy.csproj
+++ b/ycmd/tests/cs/testdata/testy-multiple-solutions/solution-named-like-folder/testy/testy.csproj
@@ -9,6 +9,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>testy</RootNamespace>
     <AssemblyName>testy</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ycmd/tests/cs/testdata/testy-multiple-solutions/solution-not-named-like-folder/extra-conf-abs/testy/testy.csproj
+++ b/ycmd/tests/cs/testdata/testy-multiple-solutions/solution-not-named-like-folder/extra-conf-abs/testy/testy.csproj
@@ -9,6 +9,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>testy</RootNamespace>
     <AssemblyName>testy</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ycmd/tests/cs/testdata/testy-multiple-solutions/solution-not-named-like-folder/extra-conf-bad/testy/testy.csproj
+++ b/ycmd/tests/cs/testdata/testy-multiple-solutions/solution-not-named-like-folder/extra-conf-bad/testy/testy.csproj
@@ -9,6 +9,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>testy</RootNamespace>
     <AssemblyName>testy</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ycmd/tests/cs/testdata/testy-multiple-solutions/solution-not-named-like-folder/extra-conf-rel/testy/testy.csproj
+++ b/ycmd/tests/cs/testdata/testy-multiple-solutions/solution-not-named-like-folder/extra-conf-rel/testy/testy.csproj
@@ -9,6 +9,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>testy</RootNamespace>
     <AssemblyName>testy</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ycmd/tests/cs/testdata/testy-multiple-solutions/solution-not-named-like-folder/testy/testy.csproj
+++ b/ycmd/tests/cs/testdata/testy-multiple-solutions/solution-not-named-like-folder/testy/testy.csproj
@@ -9,6 +9,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>testy</RootNamespace>
     <AssemblyName>testy</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ycmd/tests/cs/testdata/testy/testy.csproj
+++ b/ycmd/tests/cs/testdata/testy/testy.csproj
@@ -9,6 +9,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>testy</RootNamespace>
     <AssemblyName>testy</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ycmd/tests/cs/testdata/неприличное слово/a project.csproj
+++ b/ycmd/tests/cs/testdata/неприличное слово/a project.csproj
@@ -9,6 +9,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>testy</RootNamespace>
     <AssemblyName>testy</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Now that VS 2022 is released, ycmd should be buildable on Windows without requiring installing old versions of the build tools.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1608)
<!-- Reviewable:end -->
