### PR TITLE
ts-completer: Give node more memory to avoid crashes

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -207,6 +207,9 @@ class TypeScriptCompleter( Completer ):
     environ = os.environ.copy()
     environ[ 'TSS_LOG' ] = tsserver_log
 
+    # TSServer runs out of memory on larger projects. This is the value that VSCode uses.
+    environ[ 'NODE_OPTIONS'] = '--max_old_space_size=3072'
+
     LOGGER.info( 'TSServer log file: %s', self._logfile )
 
     # We need to redirect the error stream to the output one on Windows.


### PR DESCRIPTION
I copied this value from vscode, so I think it's reasonable to just set this on behalf of the user, but arguably this could be a new config option?

One interesting thing I discovered while tracking down this  bug is that the node process out of memory error didn't make it into the tsserver logs. I'm assuming that's not something we have a lot of control over though.