### PR TITLE
[READY] Upgrade to typescript 4.5

### DIFF
--- a/third_party/tsserver/package.json
+++ b/third_party/tsserver/package.json
@@ -1,6 +1,6 @@
 {
   "description": "ycmd tern runtime area with required typescript version and plugins",
   "dependencies": {
-    "typescript": "4.3.5"
+    "typescript": "4.5.2"
   }
 }

--- a/ycmd/tests/javascriptreact/get_completions_test.py
+++ b/ycmd/tests/javascriptreact/get_completions_test.py
@@ -72,7 +72,10 @@ class GetCompletionsTest( TestCase ):
           'completions': has_item( has_entries( {
             'insertion_text':  'alinkColor',
             'extra_menu_info': '(property) Document.alinkColor: string',
-            'detailed_info':   '(property) Document.alinkColor: string',
+             'detailed_info':  '(property) Document.alinkColor: string\n'
+                               '\n'
+                               'Sets or gets the color of all active links '
+                               'in the document.',
             'kind':            'property',
           } ) )
         } )

--- a/ycmd/tests/typescript/subcommands_test.py
+++ b/ycmd/tests/typescript/subcommands_test.py
@@ -1024,10 +1024,6 @@ class SubcommandsTest( TestCase ):
                 'this-is-a-longer-string',
                 LocationMatcher( PathToTestFile( 'file3.ts' ), 1, 15 ),
                 LocationMatcher( PathToTestFile( 'file3.ts' ), 1, 18 ) ),
-              ChunkMatcher(
-                'this-is-a-longer-string',
-                LocationMatcher( PathToTestFile( 'test.tsx' ), 10, 8 ),
-                LocationMatcher( PathToTestFile( 'test.tsx' ), 10, 11 ) ),
             ),
             'location': LocationMatcher( PathToTestFile( 'test.ts' ), 25, 9 )
           } ) )


### PR DESCRIPTION
Just a quick update. Noteworthy changes:

1. Completion items get detailed info in javascriptreact now.
2. The project-wide rename command in a `.ts` file didn't get applied to `.tsx` file. Possibly we need a better `tsconfig.json`, instead of just `{}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1612)
<!-- Reviewable:end -->
