### PR TITLE
Support Apple Silicon (and cache CI dependencies)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,41 @@ jobs:
       with:
         submodules: recursive
         fetch-depth: 0
+
+    - uses: actions/cache@v2
+      if: matrix.libclang == true
+      with:
+        key: v1-libclang-${{ runner.os }}-${{ hashFiles( 'cpp/ycm/CMakeLists.txt' ) }}
+        restore-keys: |
+          v1-libclang-${{ runner.os }}-
+        path: |
+          clang_archives
+      name: Cache libclang
+
+    - uses: actions/cache@v2
+      if: matrix.benchmark == false
+      with:
+        key: v1-deps-${{ runner.os }}-${{ hashFiles( 'build.py' ) }}
+        restore-keys: |
+          v1-deps-${{ runner.os }}-
+        path: |
+          third-party/clangd/cache
+          third_party/eclipse.jdt.ls/target/cache
+          third_party/go
+          third_party/omnisharp-roslyn/v[0-9]*
+      name: Cache dependencies
+
+    - uses: actions/cache@v2
+      if: matrix.benchmark == false
+      with:
+        key: v1-testdeps-${{ runner.os }}-${{ hashFiles( 'run_tests.py' ) }}
+        restore-keys: |
+          v1-testdeps-${{ runner.os }}-
+        path: |
+          third-party/lombok/cache
+          ~/.npm
+      name: Cache test deps
+
     - name: Install Java
       if: matrix.benchmark == false
       uses: actions/setup-java@v2
@@ -151,6 +186,41 @@ jobs:
       with:
         submodules: recursive
         fetch-depth: 0
+
+    - uses: actions/cache@v2
+      if: matrix.libclang == true
+      with:
+        key: v1-libclang-${{ runner.os }}-${{ hashFiles( 'cpp/ycm/CMakeLists.txt' ) }}
+        restore-keys: |
+          v1-libclang-${{ runner.os }}-
+        path: |
+          clang_archives
+      name: Cache libclang
+
+    - uses: actions/cache@v2
+      if: matrix.benchmark == false
+      with:
+        key: v1-deps-${{ runner.os }}-${{ hashFiles( 'build.py' ) }}
+        restore-keys: |
+          v1-deps-${{ runner.os }}-
+        path: |
+          third-party/clangd/cache
+          third_party/eclipse.jdt.ls/target/cache
+          third_party/go
+          third_party/omnisharp-roslyn/v[0-9]*
+      name: Cache dependencies
+
+    - uses: actions/cache@v2
+      if: matrix.benchmark == false
+      with:
+        key: v1-testdeps-${{ runner.os }}-${{ hashFiles( 'run_tests.py' ) }}
+        restore-keys: |
+          v1-testdeps-${{ runner.os }}-
+        path: |
+          third-party/lombok/cache
+          ~/.npm
+      name: Cache test deps
+
     - name: Install Java
       if: matrix.benchmark == false
       uses: actions/setup-java@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,9 @@ jobs:
     - uses: actions/cache@v2
       if: matrix.libclang == true
       with:
-        key: v1-libclang-${{ runner.os }}-${{ hashFiles( 'cpp/ycm/CMakeLists.txt' ) }}
+        key: v2-libclang-${{ runner.os }}-${{ hashFiles( 'cpp/ycm/CMakeLists.txt' ) }}
         restore-keys: |
+          v2-libclang-${{ runner.os }}-
           v1-libclang-${{ runner.os }}-
         path: |
           clang_archives
@@ -51,8 +52,9 @@ jobs:
     - uses: actions/cache@v2
       if: matrix.benchmark == false
       with:
-        key: v1-deps-${{ runner.os }}-${{ hashFiles( 'build.py' ) }}
+        key: v2-deps-${{ runner.os }}-${{ hashFiles( 'build.py' ) }}
         restore-keys: |
+          v2-deps-${{ runner.os }}-
           v1-deps-${{ runner.os }}-
         path: |
           third-party/clangd/cache
@@ -64,8 +66,9 @@ jobs:
     - uses: actions/cache@v2
       if: matrix.benchmark == false
       with:
-        key: v1-testdeps-${{ runner.os }}-${{ hashFiles( 'run_tests.py' ) }}
+        key: v2-testdeps-${{ runner.os }}-${{ hashFiles( 'run_tests.py' ) }}
         restore-keys: |
+          v2-testdeps-${{ runner.os }}-
           v1-testdeps-${{ runner.os }}-
         path: |
           third-party/lombok/cache
@@ -190,8 +193,9 @@ jobs:
     - uses: actions/cache@v2
       if: matrix.libclang == true
       with:
-        key: v1-libclang-${{ runner.os }}-${{ hashFiles( 'cpp/ycm/CMakeLists.txt' ) }}
+        key: v2-libclang-${{ runner.os }}-${{ hashFiles( 'cpp/ycm/CMakeLists.txt' ) }}
         restore-keys: |
+          v2-libclang-${{ runner.os }}-
           v1-libclang-${{ runner.os }}-
         path: |
           clang_archives
@@ -200,8 +204,9 @@ jobs:
     - uses: actions/cache@v2
       if: matrix.benchmark == false
       with:
-        key: v1-deps-${{ runner.os }}-${{ hashFiles( 'build.py' ) }}
+        key: v2-deps-${{ runner.os }}-${{ hashFiles( 'build.py' ) }}
         restore-keys: |
+          v2-deps-${{ runner.os }}-
           v1-deps-${{ runner.os }}-
         path: |
           third-party/clangd/cache
@@ -213,8 +218,9 @@ jobs:
     - uses: actions/cache@v2
       if: matrix.benchmark == false
       with:
-        key: v1-testdeps-${{ runner.os }}-${{ hashFiles( 'run_tests.py' ) }}
+        key: v2-testdeps-${{ runner.os }}-${{ hashFiles( 'run_tests.py' ) }}
         restore-keys: |
+          v2-testdeps-${{ runner.os }}-
           v1-testdeps-${{ runner.os }}-
         path: |
           third-party/lombok/cache

--- a/build.py
+++ b/build.py
@@ -1052,32 +1052,36 @@ def GetClangdTarget():
   if OnWindows():
     return [
       ( 'clangd-{version}-win64',
-        'a9f84b169c53fe27c70f01fc5981f448a67e8507543b759a6d3067f1c71e6525' ),
+        'ca4c9b7c0350a936e921b3e3dc6bdd51a6e905d65eac26b23ede7774158d2305' ),
       ( 'clangd-{version}-win32',
-        'b89a00ee761a56ff187d6960435d9fe4f087c0e2f3f59e68bbce629a51faf48a' ) ]
+        'a2eab3a4b23b700a16b9ef3e6b5b122438fcf016ade88dd8e10d1f81bde9386e' ) ]
   if OnMac():
+    if OnArm():
+      return [
+        ( 'clangd-{version}-arm64-apple-darwin',
+          '68be75dbe52893cba5d75486e598e51032f7f67b24c748655aace932152d4421' ) ]
     return [
       ( 'clangd-{version}-x86_64-apple-darwin',
-        '113f2e8940f9bcc49e150b233e8ed1119eaedf2e026c80551d719c6cf22b2ec8' ) ]
+        'eacbe2d7df6e57e6053f60be798e9f64d3e57556a0b2c58cf0c5599fdf9e793d' ) ]
   if OnFreeBSD():
     return [
       ( 'clangd-{version}-amd64-unknown-freebsd13',
-        '3e002c0d02eec5cd20cd632352b137d40d0f0ec3c705ddc43c9abfb5510ed665' ),
+        'bc6a11bd22251f4996290384baa59854b88537ce9105da2c64d0c70992cc548b' ),
       ( 'clangd-{version}-i386-unknown-freebsd13',
-        '2f9564a67ce4bd981505db0035512d0bddf4d9c1abc02613edcfb2422e4807ad' ) ]
+        '5ea931ca15b02c667fc3ad4d08266447b8212a83b43c80e644e3989645d63e2b' ) ]
   if OnAArch64():
     return [
       ( 'clangd-{version}-aarch64-linux-gnu',
-        'd6c6b7c94df88b15b465b66593e40c114053871e386d99cae0166e405df269ab' ) ]
+        'f0e9cea316217a40298d48ef81198ac1b41e6686fc7f7631a6ce54dd75a6989e' ) ]
   if OnArm():
     return [
       None, # First list index is for 64bit archives. ARMv7 is 32bit only.
       ( 'clangd-{version}-armv7a-linux-gnueabihf',
-        '9201d5f5466ac45192ad382cf9624f9a9a578b97ed0e8daa9c77dc6e04665e7a' ) ]
+        'bb52085decd18621f5c15b884dde6a327e3193b69bfc4b3a49c5f4459242e522' ) ]
   if OnX86_64():
     return [
       ( 'clangd-{version}-x86_64-unknown-linux-gnu',
-        'dc0e073a7e57562f6811a70349ff7f05afbb5c151e1e306215c2fc31c468944c' ) ]
+        '10a64c468d1dd2a384e0e5fd4eb2582fd9f1dfa706b6d2d2bb88fb0fbfc2718d' ) ]
   raise InstallationFailed(
     CLANGD_BINARIES_ERROR_MESSAGE.format( version = CLANGD_VERSION,
                                           platform = 'this system' ) )

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -33,44 +33,50 @@ if ( USE_CLANG_COMPLETER AND
   set( CLANG_VERSION 13.0.0 )
 
   if ( APPLE )
-    set( LIBCLANG_DIRNAME "libclang-${CLANG_VERSION}-x86_64-apple-darwin" )
-    set( LIBCLANG_SHA256
-         "818276776ea79373b58de91236c99dcfe675f34ed16cda0c8cae1b44a8fbce23" )
+    if ( "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm64" )
+      set( LIBCLANG_DIRNAME "libclang-${CLANG_VERSION}-arm64-apple-darwin" )
+      set( LIBCLANG_SHA256
+           "46486411f44c5c21f248590f3749492d455ae28ac4ad71e531ebb59417a339c0" )
+    else()
+      set( LIBCLANG_DIRNAME "libclang-${CLANG_VERSION}-x86_64-apple-darwin" )
+      set( LIBCLANG_SHA256
+           "09a7562be4f2c608e82de01c996899ffffc79d130af5414278a8bd0ae84d352e" )
+    endif()
   elseif ( WIN32 )
     if( 64_BIT_PLATFORM )
       set( LIBCLANG_DIRNAME "libclang-${CLANG_VERSION}-win64" )
       set( LIBCLANG_SHA256
-           "3a28ae296de2aa70543954422ade370389674d46b882a7a56e8111c4334e8b54" )
+           "82a467174053ed10f87e77fc79c20776ebc7521356b4b8f1e3290714a4b48cf5" )
     else()
       set( LIBCLANG_DIRNAME "libclang-${CLANG_VERSION}-win32" )
       set( LIBCLANG_SHA256
-           "30c9d42271d8b47e3e1a451c44540a52131e910f6c5798bb65081381828fff9f" )
+           "988c8152dbf8fd9fa9eda2a2c8c97acef7f688cefe37c5f1624f9db69a1ea142" )
     endif()
   elseif ( SYSTEM_IS_FREEBSD )
     if ( 64_BIT_PLATFORM )
       set( LIBCLANG_DIRNAME
            "libclang-${CLANG_VERSION}-amd64-unknown-freebsd13" )
       set( LIBCLANG_SHA256
-           "9a0aaa880a6966660f5f08d91bac52f7cc658fd795d5d7f32466fd5faaa3b4d6" )
+           "ca3cf651f570f53f507cde65b7501626a002f15e13038ee1c9ddfd8bfaf6ed3b" )
     else()
       set( LIBCLANG_DIRNAME
            "libclang-${CLANG_VERSION}-i386-unknown-freebsd13" )
       set( LIBCLANG_SHA256
-           "8e410599d629f7aa3f249fe71ab06d17f94312a23a25e3fdcf7c0c3219394f2b" )
+           "95b2b75ca59e4d401d1195fdfa62bf6a019d3bbfdedf37d649bb8d1b57623012" )
     endif()
   elseif ( CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*)" )
     set( LIBCLANG_DIRNAME "libclang-${CLANG_VERSION}-aarch64-linux-gnu" )
     set( LIBCLANG_SHA256
-         "89d675dfe5e24b4fd48845ed4bbb603c176facbe51be3705ba7aae592dc9e0eb" )
+         "2ca6a11236f1572c90a450406131711ce3a260c952d89a7004f3351550fc3e10" )
   elseif ( CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm.*|ARM.*)" )
     set( LIBCLANG_DIRNAME "libclang-${CLANG_VERSION}-armv7a-linux-gnueabihf" )
     set( LIBCLANG_SHA256
-         "230d2342f43bbd1ece7ceb434a75bac0c46284263e0b0dd84a00a043b8b83914" )
+         "d7490f7c3470f41052319bcf4b40a36a6534a6a8b9357ccf3facff8109a59517" )
   elseif ( CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64)" )
     set( LIBCLANG_DIRNAME
          "libclang-${CLANG_VERSION}-x86_64-unknown-linux-gnu" )
     set( LIBCLANG_SHA256
-         "2c340cf525d2ae27f51bdd212ebb11949c5e30809c9ddbe24b73e2a1d3d6f65f" )
+         "9a5bee818a4995bc52e91588059bef42728d046808206bfb93977f4e3109e50c" )
   else()
     message( FATAL_ERROR
       "No prebuilt Clang ${CLANG_VERSION} binaries for this system. "


### PR DESCRIPTION
Sorry for the 2-in-one:

1. Cache the dependency downlaods in CI to avoid Lombok and other crap failing to download all the time
2. Support for Apple arm64 natively

I tested this on my arm Mac and both libclang and clangd work out of the box.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1613)
<!-- Reviewable:end -->
