### PR TITLE
Use Scheme identifier regex for Racket

### DIFF
--- a/ycmd/identifier_utils.py
+++ b/ycmd/identifier_utils.py
@@ -158,6 +158,8 @@ FILETYPE_TO_IDENTIFIER_REGEX[ 'elisp' ] = (
   FILETYPE_TO_IDENTIFIER_REGEX[ 'clojure' ] )
 FILETYPE_TO_IDENTIFIER_REGEX[ 'lisp' ] = (
   FILETYPE_TO_IDENTIFIER_REGEX[ 'clojure' ] )
+FILETYPE_TO_IDENTIFIER_REGEX[ 'racket' ] = (
+  FILETYPE_TO_IDENTIFIER_REGEX[ 'scheme' ] )
 
 
 def CommentAndStringRegexForFiletype( filetype ):


### PR DESCRIPTION
Racket is a descendant of Scheme, and AFAIK hasn't changed the identifier rules any.
Without this change, either YCMD will use the default regex, or Vim will apply Scheme highlighting and `lispwords` values and the like rather than those set by the `vim-racket` plugin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1616)
<!-- Reviewable:end -->
