### PR TITLE
[READY] Don't set a maximum Python version required

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -232,7 +232,7 @@ if ( NOT CPP17_AVAILABLE )
   message( FATAL_ERROR "Your C++ compiler does NOT fully support C++17." )
 endif()
 
-find_package( Python3 3.6...3.10 REQUIRED COMPONENTS Interpreter Development )
+find_package( Python3 3.6 REQUIRED COMPONENTS Interpreter Development )
 
 #############################################################################
 


### PR DESCRIPTION
We require Python 3.6+, but we're checking for 3.6 up to 3.10, which is
apparently interpreted as up to and including 3.10, but not 3.10.1.

Anyway, we have no "maximum" supported Python version, so we should just
check for a minimum of 3.6.

Fixes #1617

Incidentally, the 'version range' check we were doing is not actually
supported in our minimum cmake version (3.14). It was added in 3.19
according to the cmake docs, so this change also fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1618)
<!-- Reviewable:end -->
