### PR TITLE
Use git submodule for absl instead of FetchContent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,4 +109,3 @@ third_party/regex-build
 # CMake FetchContent output directories
 cpp/ycm/benchmarks/benchmark/
 cpp/ycm/tests/gmock/
-cpp/absl

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "third_party/mrab-regex"]
 	path = third_party/mrab-regex
 	url = https://bitbucket.org/mrabarnett/mrab-regex.git
+[submodule "cpp/absl"]
+	path = cpp/absl
+	url = https://github.com/abseil/abseil-cpp

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -240,17 +240,20 @@ set( CMAKE_POSITION_INDEPENDENT_CODE ON )
 if ( USE_SYSTEM_ABSEIL )
   find_package( absl REQUIRED )
 else()
-  include( FetchContent )
-  FetchContent_Declare(
-    absl
-    GIT_REPOSITORY https://github.com/abseil/abseil-cpp
-    GIT_TAG 3b4a16abad2c2ddc494371cc39a2946e36d35d11
-    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/absl
-  )
-  FetchContent_GetProperties( absl )
-  if ( NOT absl_POPULATED )
-    FetchContent_Populate( absl )
-  endif()
+  find_package( Git REQUIRED QUIET )
+  if ( GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git" )
+    # Update submodules as needed
+    option ( GIT_SUBMODULE "Check submodules during build" ON )
+    if ( GIT_SUBMODULE )
+      message( STATUS "Submodule update" )
+      execute_process( COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                       RESULT_VARIABLE GIT_SUBMOD_RESULT )
+      if ( NOT GIT_SUBMOD_RESULT EQUAL "0" )
+        message ( FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+      endif ()
+    endif ()
+  endif ()
   add_subdirectory( absl )
 endif()
 


### PR DESCRIPTION
For every run of cmake, FetchContent will remove the existing absl
directory and re-download. It is inconvenient and time-consuming. git
submodule doesn't have such issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1621)
<!-- Reviewable:end -->
