### PR TITLE
Fix rpath to libclang archive on mac

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -361,6 +361,13 @@ target_link_libraries( ${PROJECT_NAME}
 
 if( LIBCLANG_TARGET )
   set( LIBCLANG_DIR "${CMAKE_SOURCE_DIR}/../third_party/clang/lib" )
+  # add rpath to libclang and remove rpath to temporary directory
+  if ( NOT MSVC )
+    set_target_properties( ${PROJECT_NAME} PROPERTIES
+      BUILD_WITH_INSTALL_RPATH ON
+      SKIP_BUILD_RPATH FALSE
+      INSTALL_RPATH ${LIBCLANG_DIR} )
+  endif ()
   # Remove all previous libclang libraries.
   file( GLOB LIBCLANG_FILEPATHS "${LIBCLANG_DIR}/libclang*" )
   foreach( FILEPATH ${LIBCLANG_FILEPATHS} )

--- a/ycmd/tests/__init__.py
+++ b/ycmd/tests/__init__.py
@@ -15,10 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-from ycmd.utils import ImportAndCheckCore, CORE_COMPATIBLE_STATUS
-if ImportAndCheckCore() != CORE_COMPATIBLE_STATUS:
-  raise RuntimeError( "Could NOT import core!" )
-
 import functools
 import os
 from ycmd.tests.test_utils import ClearCompletionsCache, IsolatedApp, SetUpApp

--- a/ycmd/tests/clang/comment_strip_test.py
+++ b/ycmd/tests/clang/comment_strip_test.py
@@ -20,10 +20,6 @@ method/variable,etc. headers in order to remove non-data-ink from the raw
 comment"""
 
 
-from ycmd.utils import ImportAndCheckCore, CORE_COMPATIBLE_STATUS
-if ImportAndCheckCore() != CORE_COMPATIBLE_STATUS:
-  raise RuntimeError( "Could NOT import core!" )
-
 # flake8: noqa
 from hamcrest import assert_that, equal_to
 from unittest import TestCase


### PR DESCRIPTION
tested with `otool -l ycm_core.cpython-39-darwin.so|grep -A3 LC_RPATH`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1622)
<!-- Reviewable:end -->
