### PR TITLE
Fix libclang's objc and objcpp support

### DIFF
--- a/ycmd/completers/cpp/flags.py
+++ b/ycmd/completers/cpp/flags.py
@@ -369,6 +369,11 @@ def _AddLanguageFlagWhenAppropriate( flags, enable_windows_style_flags ):
           for fl in reversed( flags ) ):
     return flags
 
+  # Libclang will add "-x objective-c" and "-x objective-c++" automatically
+  if any( fl.endswith( '.m' ) or fl.endswith( '.mm' )
+          for fl in reversed( flags ) ):
+    return flags
+
   # NOTE: This is intentionally NOT checking for enable_windows_style_flags.
   #
   # The first flag is now either an absolute path, a Windows style flag or a

--- a/ycmd/tests/clang/diagnostics_test.py
+++ b/ycmd/tests/clang/diagnostics_test.py
@@ -29,7 +29,8 @@ from pprint import pprint
 from unittest import TestCase
 from ycmd.tests.clang import setUpModule # noqa
 from ycmd.tests.clang import SharedYcmd, IsolatedYcmd, PathToTestFile
-from ycmd.tests.test_utils import BuildRequest, LocationMatcher, RangeMatcher
+from ycmd.tests.test_utils import ( BuildRequest, LocationMatcher,
+                                    RangeMatcher )
 from ycmd.utils import ReadFile
 
 
@@ -390,6 +391,240 @@ int main() {
         'location_extent': RangeMatcher( filepath, ( 70, 8 ), ( 70, 18 ) ),
         'ranges': empty(),
         'text': equal_to( "use of undeclared identifier 'undeclared'" ),
+        'fixit_available': False
+      } ),
+    ) )
+
+
+  @SharedYcmd
+  def test_Diagnostics_ObjectiveC( self, app ):
+    filepath = PathToTestFile( 'objc', 'objc-diags.m' )
+
+    event_data = BuildRequest( filepath = filepath,
+                               contents = ReadFile( filepath ),
+                               event_name = 'FileReadyToParse',
+                               filetype = 'objc',
+                               compilation_flags = [ '-x', 'objective-c' ] )
+
+    response = app.post_json( '/event_notification', event_data ).json
+
+    pprint( response )
+
+    assert_that( response, contains_inanyorder(
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 5, 10 ),
+        'location_extent': RangeMatcher( filepath, ( 5, 10 ), ( 5, 12 ) ),
+        'ranges': empty(),
+        'text': equal_to( "string literal must be prefixed by '@'" ),
+        'fixit_available': True
+      } )
+    ) )
+
+
+  @SharedYcmd
+  def test_Diagnostics_ObjectiveCpp( self, app ):
+    filepath = PathToTestFile( 'objc', 'objc-cxx-keyword-identifiers.mm' )
+
+    event_data = BuildRequest( filepath = filepath,
+                               contents = ReadFile( filepath ),
+                               event_name = 'FileReadyToParse',
+                               filetype = 'objcpp',
+                               compilation_flags = [ '-x', 'objective-c++' ] )
+
+    response = app.post_json( '/event_notification', event_data ).json
+
+    pprint( response )
+
+    assert_that( response, contains_inanyorder(
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 7, 7 ),
+        'location_extent': RangeMatcher( filepath, ( 7, 7 ), ( 7, 12 ) ),
+        'ranges': contains_exactly(
+                    RangeMatcher( filepath, ( 7, 3 ), ( 7, 6 ) ) ),
+        'text': equal_to( "expected member name or ';' after declaration "
+                          "specifiers; 'throw' is a keyword in Objective-C++" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 10, 12 ),
+        'location_extent': RangeMatcher( filepath, ( 10, 12 ), ( 10, 17 ) ),
+        'ranges': empty(),
+        'text': equal_to( "expected identifier; 'class' is a keyword in "
+                          "Objective-C++" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 13, 17 ),
+        'location_extent': RangeMatcher( filepath, ( 13, 17 ), ( 13, 22 ) ),
+        'ranges': empty(),
+        'text': equal_to( "expected identifier; 'class' is a keyword in "
+                          "Objective-C++" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 19, 11 ),
+        'location_extent': RangeMatcher( filepath, ( 19, 11 ), ( 19, 14 ) ),
+        'ranges': empty(),
+        'text': equal_to( "expected identifier; 'new' is a keyword in "
+                          "Objective-C++" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 23, 11 ),
+        'location_extent': RangeMatcher( filepath, ( 23, 11 ), ( 23, 17 ) ),
+        'ranges': empty(),
+        'text': equal_to( "expected identifier; 'delete' is a keyword in "
+                          "Objective-C++" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 26, 13 ),
+        'location_extent': RangeMatcher( filepath, ( 26, 13 ), ( 26, 16 ) ),
+        'ranges': empty(),
+        'text': equal_to( "expected identifier; 'try' is a keyword in "
+                          "Objective-C++" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 30, 44 ),
+        'location_extent': RangeMatcher( filepath, ( 30, 44 ), ( 30, 49 ) ),
+        'ranges': contains_exactly(
+                    RangeMatcher( filepath, ( 30, 34 ), ( 30, 37 ) ) ),
+        'text': equal_to( "expected member name or ';' after declaration "
+                          "specifiers; 'throw' is a keyword in Objective-C++" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 32, 11 ),
+        'location_extent': RangeMatcher( filepath, ( 32, 11 ), ( 32, 16 ) ),
+        'ranges': empty(),
+        'text': equal_to( "expected identifier; 'class' is a keyword in "
+                          "Objective-C++" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 33, 11 ),
+        'location_extent': RangeMatcher( filepath, ( 33, 11 ), ( 33, 20 ) ),
+        'ranges': empty(),
+        'text': equal_to( "expected identifier; 'constexpr' is a keyword in "
+                          "Objective-C++" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 37, 23 ),
+        'location_extent': RangeMatcher( filepath, ( 37, 23 ), ( 37, 26 ) ),
+        'ranges': empty(),
+        'text': equal_to( "expected identifier; 'new' is a keyword in "
+                          "Objective-C++" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 43, 17 ),
+        'location_extent': RangeMatcher( filepath, ( 43, 17 ), ( 43, 24 ) ),
+        'ranges': empty(),
+        'text': equal_to( "expected identifier; 'virtual' is a keyword in "
+                          "Objective-C++" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 45, 10 ),
+        'location_extent': RangeMatcher( filepath, ( 45, 10 ), ( 45, 15 ) ),
+        'ranges': empty(),
+        'text': equal_to( "expected identifier; 'throw' is a keyword in "
+                          "Objective-C++" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 47, 11 ),
+        'location_extent': RangeMatcher( filepath, ( 47, 11 ), ( 47, 16 ) ),
+        'ranges': empty(),
+        'text': equal_to( "expected identifier; 'class' is a keyword in "
+                          "Objective-C++" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'WARNING' ),
+        'location': LocationMatcher( filepath, 40, 17 ),
+        'location_extent': RangeMatcher( filepath, ( 40, 17 ), ( 40, 20 ) ),
+        'ranges': empty(),
+        'text': equal_to( "method definition for 'foo:' not found" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'WARNING' ),
+        'location': LocationMatcher( filepath, 28, 12 ),
+        'location_extent': RangeMatcher( filepath, ( 28, 12 ), ( 28, 15 ) ),
+        'ranges': empty(),
+        'text': equal_to( "class 'Foo' defined without specifying "
+                          "a base class" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 52, 17 ),
+        'location_extent': RangeMatcher( filepath, ( 52, 17 ), ( 52, 22 ) ),
+        'ranges': empty(),
+        'text': equal_to( "expected identifier; 'class' is a keyword in "
+                          "Objective-C++" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'WARNING' ),
+        'location': LocationMatcher( filepath, 10, 12 ),
+        'location_extent': RangeMatcher( filepath, ( 10, 12 ), ( 10, 17 ) ),
+        'ranges': empty(),
+        'text': equal_to( "class 'class' defined without specifying "
+                          "a base class" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 55, 22 ),
+        'location_extent': RangeMatcher( filepath, ( 55, 22 ), ( 55, 27 ) ),
+        'ranges': empty(),
+        'text': equal_to( "expected identifier; 'class' is a keyword in "
+                          "Objective-C++" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 59, 22 ),
+        'location_extent': RangeMatcher( filepath, ( 59, 22 ), ( 59, 32 ) ),
+        'ranges': empty(),
+        'text': equal_to( "expected identifier; 'const_cast' is a keyword in "
+                          "Objective-C++" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 60, 25 ),
+        'location_extent': RangeMatcher( filepath, ( 60, 25 ), ( 60, 30 ) ),
+        'ranges': empty(),
+        'text': equal_to( "expected identifier; 'class' is a keyword in "
+                          "Objective-C++" ),
+        'fixit_available': False
+      } ),
+      has_entries( {
+        'kind': equal_to( 'ERROR' ),
+        'location': LocationMatcher( filepath, 64, 19 ),
+        'location_extent': RangeMatcher( filepath, ( 64, 19 ), ( 64, 25 ) ),
+        'ranges': empty(),
+        'text': equal_to( "expected identifier; 'delete' is a keyword in "
+                          "Objective-C++" ),
         'fixit_available': False
       } ),
     ) )

--- a/ycmd/tests/clang/flags_test.py
+++ b/ycmd/tests/clang/flags_test.py
@@ -53,7 +53,8 @@ def _MakeRelativePathsInFlagsAbsoluteTest( test ):
     contains_exactly( *test[ 'expect' ] ) )
 
 
-def _AddLanguageFlagWhenAppropriateTester( compiler, language_flag = [] ):
+def _AddLanguageFlagWhenAppropriateTester( compiler, filename,
+                                           language_flag = [] ):
   to_removes = [
     [],
     [ '/usr/bin/ccache' ],
@@ -62,12 +63,13 @@ def _AddLanguageFlagWhenAppropriateTester( compiler, language_flag = [] ):
   expected = [ '-foo', '-bar' ]
 
   for to_remove in to_removes:
-    assert_that( [ compiler ] + language_flag + expected,
+    assert_that( [ compiler ] + language_flag + expected + [ filename ],
                  equal_to( flags._AddLanguageFlagWhenAppropriate(
-                             to_remove + [ compiler ] + expected,
-                             ShouldAllowWinStyleFlags( to_remove +
-                                                       [ compiler ] +
-                                                       expected ) ) ) )
+                           to_remove + [ compiler ] + expected + [ filename ],
+                           ShouldAllowWinStyleFlags( to_remove +
+                                                     [ compiler ] +
+                                                     expected +
+                                                     [ filename ] ) ) ) )
 
 
 class FlagsTest( TestCase ):
@@ -1335,7 +1337,14 @@ class FlagsTest( TestCase ):
     for compiler in [ 'cc', 'gcc', 'clang',
                       '/usr/bin/cc', '/some/other/path', 'some_command' ]:
       with self.subTest( compiler = compiler ):
-        _AddLanguageFlagWhenAppropriateTester( compiler )
+        _AddLanguageFlagWhenAppropriateTester( compiler,  'dummy.c' )
+
+
+  def test_AddLanguageFlagWhenAppropriate_ObjectiveCCompiler( self ):
+    for compiler in [ 'cc', 'gcc', 'clang',
+                      '/usr/bin/cc', '/some/other/path', 'some_command' ]:
+      with self.subTest( compiler = compiler ):
+        _AddLanguageFlagWhenAppropriateTester( compiler, 'dummy.m', [] )
 
 
   def test_AddLanguageFlagWhenAppropriate_CppCompiler( self ):
@@ -1346,7 +1355,19 @@ class FlagsTest( TestCase ):
        '/some/other/path++-4.9.3', 'some_command++-5.1',
        '/some/other/path++-4.9.31', 'some_command++-5.10' ]:
       with self.subTest( compiler = compiler ):
-        _AddLanguageFlagWhenAppropriateTester( compiler, [ '-x', 'c++' ] )
+        _AddLanguageFlagWhenAppropriateTester( compiler, 'dummy.cc',
+                                               [ '-x', 'c++' ] )
+
+
+  def test_AddLanguageFlagWhenAppropriate_ObjectiveCppCompiler( self ):
+    for compiler in [ 'c++', 'g++', 'clang++', '/usr/bin/c++',
+       '/some/other/path++', 'some_command++',
+       'c++-5', 'g++-5.1', 'clang++-3.7.3', '/usr/bin/c++-5',
+       'c++-5.11', 'g++-50.1.49', 'clang++-3.12.3', '/usr/bin/c++-10',
+       '/some/other/path++-4.9.3', 'some_command++-5.1',
+       '/some/other/path++-4.9.31', 'some_command++-5.10' ]:
+      with self.subTest( compiler = compiler ):
+        _AddLanguageFlagWhenAppropriateTester( compiler, 'dummy.mm', [] )
 
 
   def test_CompilationDatabase_NoDatabase( self ):
@@ -1555,6 +1576,69 @@ class FlagsTest( TestCase ):
                             '-x',
                             'cuda',
                             '--' ) )
+
+
+  def test_CompilationDatabase_ObjectiveCLanguageFlags( self ):
+    with TemporaryTestDir() as tmp_dir:
+      compile_commands = [
+        {
+          'directory': tmp_dir,
+          'command': 'clang -Wall {}'.format( './test.m' ),
+          'file': os.path.join( tmp_dir, 'test.m' ),
+        },
+      ]
+
+      with TemporaryClangProject( tmp_dir, compile_commands ):
+        # If we ask for a header file, it returns the equivalent objc file
+        assert_that(
+          flags.Flags().FlagsForFile(
+            os.path.join( tmp_dir, 'test.h' ),
+            add_extra_clang_flags = False )[ 0 ],
+          contains_exactly( 'clang',
+                            '-Wall',
+                            '-x',
+                            'objective-c-header' ) )
+
+      with TemporaryClangProject( tmp_dir, compile_commands ):
+        # If we ask for a header file, it returns the equivalent objc file
+        assert_that(
+          flags.Flags().FlagsForFile(
+            os.path.join( tmp_dir, 'test.m' ),
+            add_extra_clang_flags = False )[ 0 ],
+          contains_exactly( 'clang', '-Wall' ) )
+
+
+  def test_CompilationDatabase_ObjectiveCppLanguageFlags( self ):
+    with TemporaryTestDir() as tmp_dir:
+      compile_commands = [
+        {
+          'directory': tmp_dir,
+          'command': 'clang++ -Wall {}'.format( './test.mm' ),
+          'file': os.path.join( tmp_dir, 'test.mm' ),
+        },
+      ]
+
+      with TemporaryClangProject( tmp_dir, compile_commands ):
+        # If we ask for a header file, it returns the equivalent objcpp file
+        assert_that(
+          flags.Flags().FlagsForFile(
+            os.path.join( tmp_dir, 'test.h' ),
+            add_extra_clang_flags = False )[ 0 ],
+          contains_exactly( 'clang++',
+                            '-x',
+                            'c++',
+                            '--driver-mode=g++',
+                            '-Wall',
+                            '-x',
+                            'objective-c++-header' ) )
+
+      with TemporaryClangProject( tmp_dir, compile_commands ):
+        # If we ask for a header file, it returns the equivalent objcpp file
+        assert_that(
+          flags.Flags().FlagsForFile(
+            os.path.join( tmp_dir, 'test.mm' ),
+            add_extra_clang_flags = False )[ 0 ],
+          contains_exactly( 'clang++', '--driver-mode=g++', '-Wall' ) )
 
 
   def test_MakeRelativePathsInFlagsAbsolute( self ):

--- a/ycmd/tests/clang/get_completions_test.py
+++ b/ycmd/tests/clang/get_completions_test.py
@@ -1507,6 +1507,39 @@ int main()
     } )
 
 
+  # This test is isolated to make sure we trigger c hook for clangd, instead of
+  # fetching completer from cache.
+  @IsolatedYcmd()
+  def test_GetCompletions_objcpp( self, app ):
+    RunTest( app, {
+      'description': 'Completion of Objective-C++ files',
+      'request': {
+        'filetype'  : 'objcpp',
+        'filepath'  : PathToTestFile( 'objc', 'complete-lambdas.mm' ),
+        'compilation_flags': [ '-x', 'objective-c++', '-std=c++11' ],
+        'line_num'  : 14,
+        'column_num': 5,
+        'force_semantic': True,
+      },
+      'expect': {
+        'response': requests.codes.ok,
+        'data': has_entries( {
+          'completion_start_column': 3,
+          'completions': has_item( has_entries( {
+            'insertion_text':
+            '(id)instanceMethod:(int)value withOther:(int)other',
+            'menu_text':
+            '( id )instanceMethod:(int )value withOther:(int )other',
+            'detailed_info':
+            ' ( id )instanceMethod:(int )value withOther:(int )other\n',
+            'kind':            'FUNCTION',
+          } ) ),
+          'errors': empty(),
+        } )
+      }
+    } )
+
+
   @SharedYcmd
   def test_GetCompletions_StillParsingError( self, app ):
     completer = handlers._server_state.GetFiletypeCompleter( [ 'cpp' ] )

--- a/ycmd/tests/clang/testdata/objc/complete-lambdas.mm
+++ b/ycmd/tests/clang/testdata/objc/complete-lambdas.mm
@@ -1,0 +1,24 @@
+/* Modified by ycmd contributors */
+// This test is line- and column-sensitive. See below for run lines.
+
+
+@interface A
+- instanceMethod:(int)value withOther:(int)other;
++ classMethod;
+@end
+
+@interface B : A
+@end
+
+@implementation B
+- someMethod:(A*)a {
+  [a classMethod];
+  [A classMethod];
+  [a instanceMethod:0 withOther:1];
+  [self someMethod:a];
+  [super instanceMethod];
+  [&,a ]{};
+  [a,self instanceMethod:0 withOther:1]{};
+}
+
+@end

--- a/ycmd/tests/clang/testdata/objc/objc-cxx-keyword-identifiers.mm
+++ b/ycmd/tests/clang/testdata/objc/objc-cxx-keyword-identifiers.mm
@@ -1,0 +1,65 @@
+/* Modified by ycmd contributors */
+// RUN: %clang_cc1 -fsyntax-only -std=c++11 -Wno-objc-root-class -Wno-incomplete-implementation -triple x86_64-apple-macosx10.10.0 -verify %s
+
+// rdar://20626062
+
+struct S {
+  int throw; // expected-error {{expected member name or ';' after declaration specifiers; 'throw' is a keyword in Objective-C++}}
+};
+
+@interface class // expected-error {{expected identifier; 'class' is a keyword in Objective-C++}}
+@end
+
+@interface Bar: class // expected-error {{expected identifier; 'class' is a keyword in Objective-C++}}
+@end
+
+@protocol P // ok
+@end
+
+@protocol new // expected-error {{expected identifier; 'new' is a keyword in Objective-C++}}
+@end
+
+@protocol P2;
+@protocol delete // expected-error {{expected identifier; 'delete' is a keyword in Objective-C++}}
+@end
+
+@class Foo, try; // expected-error {{expected identifier; 'try' is a keyword in Objective-C++}}
+
+@interface Foo
+
+@property (readwrite, nonatomic) int a, b, throw; // expected-error {{expected member name or ';' after declaration specifiers; 'throw' is a keyword in Objective-C++}}
+
+-foo:(int)class; // expected-error {{expected identifier; 'class' is a keyword in Objective-C++}}
++foo:(int)constexpr; // expected-error {{expected identifier; 'constexpr' is a keyword in Objective-C++}}
+
+@end
+
+@interface Foo () <P, new> // expected-error {{expected identifier; 'new' is a keyword in Objective-C++}}
+@end
+
+@implementation Foo
+
+@synthesize a = _a; // ok
+@synthesize b = virtual; // expected-error {{expected identifier; 'virtual' is a keyword in Objective-C++}}
+
+@dynamic throw; // expected-error {{expected identifier; 'throw' is a keyword in Objective-C++}}
+
+-foo:(int)class { // expected-error {{expected identifier; 'class' is a keyword in Objective-C++}}
+}
+
+@end
+
+@implementation class // expected-error {{expected identifier; 'class' is a keyword in Objective-C++}}
+@end
+
+@implementation Bar: class // expected-error {{expected identifier; 'class' is a keyword in Objective-C++}}
+@end
+
+@compatibility_alias C Foo; // ok
+@compatibility_alias const_cast Bar; // expected-error {{expected identifier; 'const_cast' is a keyword in Objective-C++}}
+@compatibility_alias C2 class; // expected-error {{expected identifier; 'class' is a keyword in Objective-C++}}
+
+void func() {
+  (void)@protocol(P); // ok
+  (void)@protocol(delete); // expected-error {{expected identifier; 'delete' is a keyword in Objective-C++}}
+}

--- a/ycmd/tests/clang/testdata/objc/objc-diags.m
+++ b/ycmd/tests/clang/testdata/objc/objc-diags.m
@@ -1,0 +1,7 @@
+/* Modified by ycmd contributors */
+// Note: the run lines follow all tests, since line/column matter here
+
+id testIncompatibleType() {
+  return "";
+}
+

--- a/ycmd/tests/clang/testdata/objc/objc-expr.m
+++ b/ycmd/tests/clang/testdata/objc/objc-expr.m
@@ -1,0 +1,7 @@
+/* Modified by ycmd contributors */
+// Note: the run lines follow all tests, since line/column matter here
+
+id testCompleteAfterAtSign() {
+  return @"";
+}
+


### PR DESCRIPTION
For c++ source, it is correct to use "-x c++" language options but it
doesn't true for objective-c++ and objective-c source code. This patch
will fix it.

Add three unittests, subcommands unittests will be added next time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1624)
<!-- Reviewable:end -->
