### PR TITLE
Try to infer the latest MSVC version on windows like CMake Does

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 import argparse
+import platform
 import os
 import os.path as p
 import subprocess
@@ -31,7 +32,7 @@ def BuildYcmdLibsAndRunBenchmark( args, extra_args ):
 
   os.environ[ 'YCM_BENCHMARK' ] = '1'
 
-  if args.msvc:
+  if args.msvc and platform.system() == 'Windows':
     build_cmd.extend( [ '--msvc', str( args.msvc ) ] )
 
   subprocess.check_call( build_cmd )

--- a/build.py
+++ b/build.py
@@ -162,14 +162,14 @@ def FindLatestMSVC(quiet):
     if not quiet:
       print('Trying to find '
             rf'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\{i}.0')
-      try:
-        winreg.OpenKey(handle, rf'SOFTWARE\Microsoft\VisualStudio\{i}.0')
-        if not quiet:
-          print(f"Found MSVC version {i}")
-          msvc = i
-          break
-      except FileNotFoundError:
-        pass
+    try:
+      winreg.OpenKey(handle, rf'SOFTWARE\Microsoft\VisualStudio\{i}.0')
+      if not quiet:
+        print(f"Found MSVC version {i}")
+      msvc = i
+      break
+    except FileNotFoundError:
+      pass
   return msvc
 
 

--- a/build.py
+++ b/build.py
@@ -115,57 +115,57 @@ CLANGD_BINARIES_ERROR_MESSAGE = (
   'See the YCM docs for details on how to use a custom Clangd.' )
 
 
-def FindLatestMSVC(quiet):
-  ACCEPTABLE_VERSIONS = [17, 16, 15]
+def FindLatestMSVC( quiet ):
+  ACCEPTABLE_VERSIONS = [ 17, 16, 15 ]
 
-  VSWHERE_EXE = os.path.join(os.environ['ProgramFiles(x86)'],
+  VSWHERE_EXE = os.path.join( os.environ[ 'ProgramFiles(x86)' ],
                              'Microsoft Visual Studio',
-                             'Installer', 'vswhere.exe')
+                             'Installer', 'vswhere.exe' )
 
-  if os.path.exists(VSWHERE_EXE):
+  if os.path.exists( VSWHERE_EXE ):
     if not quiet:
-      print("Calling vswhere -latest -installationVersion")
+      print( "Calling vswhere -latest -installationVersion" )
     latest_full_v = subprocess.check_output(
-      [VSWHERE_EXE, '-latest', '-property', 'installationVersion']
+      [ VSWHERE_EXE, '-latest', '-property', 'installationVersion' ]
     ).strip().decode()
     if '.' in latest_full_v:
       try:
-        latest_v = int(latest_full_v.split('.')[0])
+        latest_v = int( latest_full_v.split( '.' )[ 0 ] )
       except ValueError:
-        raise ValueError("{latest_full_v=} is not a version number.")
+        raise ValueError( "{latest_full_v=} is not a version number." )
 
       if not quiet:
-        print(f'vswhere -latest returned version {latest_full_v=}')
+        print( f'vswhere -latest returned version {latest_full_v=}' )
 
       if latest_v not in ACCEPTABLE_VERSIONS:
         if latest_v > 17:
           if not quiet:
-            print(f'MSVC Version {latest_full_v=} is newer than expected.')
+            print( f'MSVC Version {latest_full_v=} is newer than expected.' )
         else:
           raise ValueError(
             f'vswhere returned {latest_full_v=} which is unexpected.'
-            'Pass --msvc <version> argument.')
+            'Pass --msvc <version> argument.' )
       return latest_v
     else:
       if not quiet:
-        print(f'vswhere returned nothing usable, {latest_full_v=}')
+        print( f'vswhere returned nothing usable, {latest_full_v=}' )
 
   # Fall back to registry parsing, which works at least until MSVC 2019 (16)
   # but is likely failing on MSVC 2022 (17)
   if not quiet:
-    print("vswhere method failed, falling back to searching the registry")
+    print( "vswhere method failed, falling back to searching the registry" )
 
   import winreg
-  handle = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
+  handle = winreg.ConnectRegistry( None, winreg.HKEY_LOCAL_MACHINE )
   msvc = None
   for i in ACCEPTABLE_VERSIONS:
     if not quiet:
-      print('Trying to find '
-            rf'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\{i}.0')
+      print( 'Trying to find '
+             rf'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\{i}.0' )
     try:
-      winreg.OpenKey(handle, rf'SOFTWARE\Microsoft\VisualStudio\{i}.0')
+      winreg.OpenKey( handle, rf'SOFTWARE\Microsoft\VisualStudio\{i}.0' )
       if not quiet:
-        print(f"Found MSVC version {i}")
+        print( f"Found MSVC version {i}" )
       msvc = i
       break
     except FileNotFoundError:
@@ -468,7 +468,7 @@ def ParseArguments():
                        help = 'Use system libclang instead of downloading one '
                        'from llvm.org. NOT RECOMMENDED OR SUPPORTED!' )
   if OnWindows():
-      parser.add_argument( '--msvc', type = int, choices = [ 15, 16, 17 ],
+    parser.add_argument( '--msvc', type = int, choices = [ 15, 16, 17 ],
                           default=None,
                           help= 'Choose the Microsoft Visual Studio version '
                                 '(default: %(default)s).' )
@@ -551,9 +551,9 @@ def ParseArguments():
     args.enable_debug = True
 
   if OnWindows() and args.msvc is None:
-    args.msvc = FindLatestMSVC(args.quiet)
+    args.msvc = FindLatestMSVC( args.quiet )
     if args.msvc is None:
-      raise FileNotFoundError("Could not find a valid MSVC version.")
+      raise FileNotFoundError( "Could not find a valid MSVC version." )
 
   if args.core_tests:
     os.environ[ 'YCM_TESTRUN' ] = '1'

--- a/build.py
+++ b/build.py
@@ -115,18 +115,62 @@ CLANGD_BINARIES_ERROR_MESSAGE = (
   'See the YCM docs for details on how to use a custom Clangd.' )
 
 
-def FindLatestMSVC():
-    import winreg
-    handle = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
-    msvc = None
-    for i in [17, 16, 15]:
-        try:
-            winreg.OpenKey(handle, rf'SOFTWARE\Microsoft\VisualStudio\{i}.0')
-            msvc = i
-            break
-        except FileNotFoundError:
-            pass
-    return msvc
+def FindLatestMSVC(quiet):
+  ACCEPTABLE_VERSIONS = [17, 16, 15]
+
+  VSWHERE_EXE = os.path.join(os.environ['ProgramFiles(x86)'],
+                             'Microsoft Visual Studio',
+                             'Installer', 'vswhere.exe')
+
+  if os.path.exists(VSWHERE_EXE):
+    if not quiet:
+      print("Calling vswhere -latest -installationVersion")
+    latest_full_v = subprocess.check_output(
+      [VSWHERE_EXE, '-latest', '-property', 'installationVersion']
+    ).strip().decode()
+    if '.' in latest_full_v:
+      try:
+        latest_v = int(latest_full_v.split('.')[0])
+      except ValueError:
+        raise ValueError("{latest_full_v=} is not a version number.")
+
+      if not quiet:
+        print(f'vswhere -latest returned version {latest_full_v=}')
+
+      if latest_v not in ACCEPTABLE_VERSIONS:
+        if latest_v > 17:
+          if not quiet:
+            print(f'MSVC Version {latest_full_v=} is newer than expected.')
+        else:
+          raise ValueError(
+            f'vswhere returned {latest_full_v=} which is unexpected.'
+            'Pass --msvc <version> argument.')
+      return latest_v
+    else:
+      if not quiet:
+        print(f'vswhere returned nothing usable, {latest_full_v=}')
+
+  # Fall back to registry parsing, which works at least until MSVC 2019 (16)
+  # but is likely failing on MSVC 2022 (17)
+  if not quiet:
+    print("vswhere method failed, falling back to searching the registry")
+
+  import winreg
+  handle = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
+  msvc = None
+  for i in ACCEPTABLE_VERSIONS:
+    if not quiet:
+      print('Trying to find '
+            rf'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\{i}.0')
+      try:
+        winreg.OpenKey(handle, rf'SOFTWARE\Microsoft\VisualStudio\{i}.0')
+        if not quiet:
+          print(f"Found MSVC version {i}")
+          msvc = i
+          break
+      except FileNotFoundError:
+        pass
+  return msvc
 
 
 def RemoveDirectory( directory ):
@@ -507,9 +551,9 @@ def ParseArguments():
     args.enable_debug = True
 
   if OnWindows() and args.msvc is None:
-    args.msvc = FindLatestMSVC()
+    args.msvc = FindLatestMSVC(args.quiet)
     if args.msvc is None:
-      raise FileNotFoundError("Could not find a valid MSVC version")
+      raise FileNotFoundError("Could not find a valid MSVC version.")
 
   if args.core_tests:
     os.environ[ 'YCM_TESTRUN' ] = '1'

--- a/build.py
+++ b/build.py
@@ -132,23 +132,23 @@ def FindLatestMSVC( quiet ):
       try:
         latest_v = int( latest_full_v.split( '.' )[ 0 ] )
       except ValueError:
-        raise ValueError( "{latest_full_v=} is not a version number." )
+        raise ValueError( f"{latest_full_v} is not a version number." )
 
       if not quiet:
-        print( f'vswhere -latest returned version {latest_full_v=}' )
+        print( f'vswhere -latest returned version {latest_full_v}' )
 
       if latest_v not in ACCEPTABLE_VERSIONS:
         if latest_v > 17:
           if not quiet:
-            print( f'MSVC Version {latest_full_v=} is newer than expected.' )
+            print( f'MSVC Version {latest_full_v} is newer than expected.' )
         else:
           raise ValueError(
-            f'vswhere returned {latest_full_v=} which is unexpected.'
+            f'vswhere returned {latest_full_v} which is unexpected.'
             'Pass --msvc <version> argument.' )
       return latest_v
     else:
       if not quiet:
-        print( f'vswhere returned nothing usable, {latest_full_v=}' )
+        print( f'vswhere returned nothing usable, {latest_full_v}' )
 
   # Fall back to registry parsing, which works at least until MSVC 2019 (16)
   # but is likely failing on MSVC 2022 (17)

--- a/run_tests.py
+++ b/run_tests.py
@@ -199,7 +199,7 @@ def BuildYcmdLibs( args ):
       if key in args.completers:
         build_cmd.extend( COMPLETERS[ key ][ 'build' ] )
 
-    if args.msvc:
+    if args.msvc and platform.system() == 'Windows':
       build_cmd.extend( [ '--msvc', str( args.msvc ) ] )
 
     if args.coverage:


### PR DESCRIPTION
- Remove --msvc arg on other platforms than windows
- Default the value of msvc to the latest found

eg, trying it on on one of my windows VMs that has MSVC 2022 (=17)

```
  --msvc {15,16,17}     Choose the Microsoft Visual Studio version (default: 17).
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1626)
<!-- Reviewable:end -->
