### PR TITLE
Update `go get` to  `go install` for gopls

### DIFF
--- a/build.py
+++ b/build.py
@@ -863,7 +863,7 @@ def EnableGoCompleter( args ):
   new_env[ 'GOPATH' ] = p.join( DIR_OF_THIS_SCRIPT, 'third_party', 'go' )
   new_env.pop( 'GOROOT', None )
   new_env[ 'GOBIN' ] = p.join( new_env[ 'GOPATH' ], 'bin' )
-  CheckCall( [ go, 'get', 'golang.org/x/tools/gopls@v0.7.1' ],
+  CheckCall( [ go, 'install', 'golang.org/x/tools/gopls@v0.7.1' ],
              env = new_env,
              quiet = args.quiet,
              status_message = 'Building gopls for go completion' )


### PR DESCRIPTION
The use of `go get` to install binaries is deprecated, and causes an error in the newly released Go 1.18.
See https://go.dev/doc/go-get-install-deprecation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1628)
<!-- Reviewable:end -->
