### PR TITLE
Fix annoying popups when editing incomplete macros

### DIFF
--- a/cpp/ycm/ClangCompleter/TranslationUnit.cpp
+++ b/cpp/ycm/ClangCompleter/TranslationUnit.cpp
@@ -482,9 +482,21 @@ void TranslationUnit::UpdateLatestDiagnostics() {
                         clang_disposeDiagnostic ),
         clang_translation_unit_ );
 
-    if ( diagnostic.kind_ != DiagnosticKind::INFORMATION ) {
-      latest_diagnostics_.push_back( diagnostic );
+    if ( diagnostic.kind_ == DiagnosticKind::INFORMATION ) {
+        continue;
     }
+
+    // Sometimes libclang returns invalid ranges causing ycm in trouble
+    // Specially editing incomplete macros
+    diagnostic.ranges_.erase( std::remove_if( diagnostic.ranges_.begin(),
+                                              diagnostic.ranges_.end(),
+                                              []( const auto &range ) -> bool {
+        return range.start_.line_number_ == 0 ||
+               range.start_.column_number_ == 0 ||
+               range.end_.line_number_ == 0 ||
+               range.end_.column_number_ == 0;
+        } ), diagnostic.ranges_.end() );
+    latest_diagnostics_.push_back( diagnostic );
   }
 }
 

--- a/ycmd/tests/clang/diagnostics_test.py
+++ b/ycmd/tests/clang/diagnostics_test.py
@@ -265,8 +265,6 @@ int main() {
         'location': LocationMatcher( filepath, 8, 7 ),
         'location_extent': RangeMatcher( filepath, ( 8, 7 ), ( 8, 11 ) ),
         'ranges': contains_exactly(
-          # FIXME: empty ranges from libclang should be ignored.
-          RangeMatcher( '', ( 0, 0 ), ( 0, 0 ) ),
           RangeMatcher( filepath, ( 8, 7 ), ( 8, 11 ) )
         ),
         'text': equal_to( 'constructor cannot have a return type' ),


### PR DESCRIPTION
Sometimes libclang returns invalid ranges causing ycm in trouble.

No log is recorded (both of ycmd and ycm) for this inconvenice.
<img width="953" alt="Screen Shot 2022-04-06 at 11 05 10" src="https://user-images.githubusercontent.com/54673341/161889062-18323828-62f2-48b5-bf4b-5c226ddb78fb.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1633)
<!-- Reviewable:end -->
