### PR TITLE
Allow generic/LSP completers to override built-in completers

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -176,7 +176,25 @@ def Settings( **kwargs ):
 
   if language == 'python':
     return {
-      'interpreter_path': PathToPythonUsedDuringBuild()
+      'interpreter_path': PathToPythonUsedDuringBuild(),
+      'ls': {
+        'python': {
+          'analysis': {
+            'extraPaths': [
+              p.join( DIR_OF_THIS_SCRIPT ),
+              p.join( DIR_OF_THIRD_PARTY, 'bottle' ),
+              p.join( DIR_OF_THIRD_PARTY, 'regex-build' ),
+              p.join( DIR_OF_THIRD_PARTY, 'frozendict' ),
+              p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'jedi' ),
+              p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'parso' ),
+              p.join( DIR_OF_WATCHDOG_DEPS, 'watchdog', 'build', 'lib3' ),
+              p.join( DIR_OF_WATCHDOG_DEPS, 'pathtools' ),
+              p.join( DIR_OF_THIRD_PARTY, 'waitress' )
+            ],
+            'useLibraryCodeForTypes': True
+          }
+        }
+      }
     }
 
   return {}
@@ -185,15 +203,16 @@ def Settings( **kwargs ):
 def PythonSysPath( **kwargs ):
   sys_path = kwargs[ 'sys_path' ]
 
-  interpreter_path = kwargs[ 'interpreter_path' ]
-
   sys_path[ 0:0 ] = [ p.join( DIR_OF_THIS_SCRIPT ),
                       p.join( DIR_OF_THIRD_PARTY, 'bottle' ),
                       p.join( DIR_OF_THIRD_PARTY, 'regex-build' ),
                       p.join( DIR_OF_THIRD_PARTY, 'frozendict' ),
                       p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'jedi' ),
                       p.join( DIR_OF_THIRD_PARTY, 'jedi_deps', 'parso' ),
-                      p.join( DIR_OF_WATCHDOG_DEPS, 'watchdog', 'build', 'lib3' ),
+                      p.join( DIR_OF_WATCHDOG_DEPS,
+                              'watchdog',
+                              'build',
+                              'lib3' ),
                       p.join( DIR_OF_WATCHDOG_DEPS, 'pathtools' ),
                       p.join( DIR_OF_THIRD_PARTY, 'waitress' ) ]
 

--- a/README.md
+++ b/README.md
@@ -328,7 +328,8 @@ Or, to use an unused  local port, set `port` to `*` and use `${port}` in the
 When plugging in a completer in this way, the `kwargs[ 'language' ]` will be set
 to the value of the `name` key, i.e. `gopls` in the above example.
 
-LSP completers currently supported without `language_server`:
+A number of LSP completers are currently supported without `language_server`,
+usch as:
 
 - Java
 - Rust
@@ -341,6 +342,9 @@ One can also override the root directory, with `project_directory`.
 def Settings( **kwargs ):
   return { 'project_directory': 'src/' } # The path may be absolute as well.
 ```
+
+Note: If an LSP based completer is configured for a language that's supported
+"built-in", it overrides the built-in support.
 
 ##### C-family settings
 


### PR DESCRIPTION
This allows, for example users to use python language server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1641)
<!-- Reviewable:end -->
