### PR TITLE
fix build.py for Solaris OS - add lib/64 to search paths (fix #1645)

### DIFF
--- a/build.py
+++ b/build.py
@@ -292,6 +292,7 @@ def GetPossiblePythonLibraryDirectories():
   return [
     sysconfig.get_config_var( 'LIBPL' ),
     p.join( prefix, 'lib64' ),
+    p.join( prefix, 'lib/64' ),
     p.join( prefix, 'lib' )
   ]
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1646)
<!-- Reviewable:end -->
