### PR TITLE
reduce the requirements for cmake version

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required( VERSION 3.14 )
+cmake_minimum_required( VERSION 3.12 )
 
 project( YouCompleteMe )
 

--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required( VERSION 3.14 )
+cmake_minimum_required( VERSION 3.12 )
 
 project( ycm_core )
 

--- a/cpp/ycm/benchmarks/CMakeLists.txt
+++ b/cpp/ycm/benchmarks/CMakeLists.txt
@@ -16,7 +16,7 @@
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
 project( ycm_core_benchmarks )
-cmake_minimum_required( VERSION 3.14 )
+cmake_minimum_required( VERSION 3.12 )
 
 # We don't want to test the benchmark library.
 set( BENCHMARK_ENABLE_TESTING

--- a/cpp/ycm/tests/CMakeLists.txt
+++ b/cpp/ycm/tests/CMakeLists.txt
@@ -16,7 +16,7 @@
 # along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
 
 project( ycm_core_tests )
-cmake_minimum_required( VERSION 3.14 )
+cmake_minimum_required( VERSION 3.12 )
 
 # The gtest library triggers warnings, so we turn them off; it's not up to us to
 # fix gtest warnings, it's up to upstream.


### PR DESCRIPTION
I have tested with cmake3.12, and everything seems to be ok.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1649)
<!-- Reviewable:end -->
