### PR TITLE
Remove raise from _ReadHeaders

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -566,7 +566,6 @@ class LanguageServerConnection( threading.Thread ):
             except Exception:
               LOGGER.exception( 'Received invalid protocol data from server: '
                                  + str( line ) )
-              raise
 
         read_bytes += 1
 


### PR DESCRIPTION
The only caller to this method does not handle exceptions from this method, so instead of crashing, just log the message and continue processing

This is related to #1673

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1674)
<!-- Reviewable:end -->
