### PR TITLE
TS: add @param and @returns to docs

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -913,7 +913,7 @@ class TypeScriptCompleter( Completer ):
 
     interface = _GetInterfaceDocumentation(info.get("tags", []))
     interface = '' if interface is None else (interface + '\n\n')
-    message = f'{ info[ "displayString" ] }\n\n{interface}{info[ "documentation" ]}'
+    message = f'{info["displayString"]}\n\n{interface}{info["documentation"]}'
     return responses.BuildDetailedInfoResponse( message )
 
 
@@ -1148,7 +1148,7 @@ def _GetInterfaceDocumentation(tags):
   for tag in tags:
     if tag["name"] == "param":
       text = tag["text"]
-      match = re.search("\s", text)
+      match = re.search(r"\s", text)
       index = len(text) if match is None else match.start(0)
       interface.append((text[:index], text[index + 1 :].strip()))
 


### PR DESCRIPTION
see https://github.com/ycm-core/ycmd/issues/1675

This adds a table between the signature and the description, listing all `@param` tags and any `@return`/`@returns` tag.
If a return tag exists, it is the last row and is named `return`.

GetDoc:
![Screenshot from 2023-01-12 16-51-09](https://user-images.githubusercontent.com/4567628/212118043-acc01ad2-0896-45d5-9706-278dd58eac1a.png)
Autocomplete:
![Screenshot from 2023-01-12 16-52-29](https://user-images.githubusercontent.com/4567628/212118057-0210b7cc-ed26-4950-bdde-de8769931e89.png)

Missing:
- tests

I would appreciate if anyone could write tests for this because I have 0 knowledge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1676)
<!-- Reviewable:end -->
