### PR TITLE
Specify CMAKE_BUILD_TYPE manually for ninja generator

### DIFF
--- a/build.py
+++ b/build.py
@@ -613,6 +613,8 @@ def GetCmakeArgs( parsed_args ):
   if parsed_args.enable_debug:
     cmake_args.append( '-DCMAKE_BUILD_TYPE=Debug' )
     cmake_args.append( '-DUSE_DEV_FLAGS=ON' )
+  else:
+    cmake_args.append( '-DCMAKE_BUILD_TYPE=Release' )
 
   # coverage is not supported for c++ on MSVC
   if not OnWindows() and parsed_args.enable_coverage:


### PR DESCRIPTION
CMAKE_BUILD_TYPE should be Release but it seems a problem under windows that with ninja generator, where cmake has pre-defined CMAKE_BUILD_TYPE and it passes by the setting line in cpp\CMakeLists.txt. Specify it manually, so it compiles and links correctly with release runtime.

Verified "/O2" instead of "/Od" in cl.exe commandline. Tested on a Windows 10 22H2 machine and VS2019 installation.

TODO I didn't have time to test it with "MSYS Makefiles" or "MINGW Makefiles" generator on windows. We can add this fix if we need it as well.

Fixes #1678.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1679)
<!-- Reviewable:end -->
