### PR TITLE
ignore compile_commands.json which is unreasonably small in size

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -427,6 +427,9 @@ class ClangdCompleter( language_server_completer.LanguageServerCompleter ):
 def CompilationDatabaseExists( file_dir ):
   for folder in PathsToAllParentFolders( file_dir ):
     if os.path.exists( os.path.join( folder, 'compile_commands.json' ) ):
-      return True
+      if os.path.getsize( os.path.join( folder, 'compile_commands.json' ) ) < 32:
+        return False
+      else:
+        return True
 
   return False


### PR DESCRIPTION
When working with sparse software repo, and opening file not in local, ycm can pick up invalid compile_commands.json in remote folder and ignore fallback .ycm_extra_config.py. It is possible (for me) to ask admin to properly generate valid compile_commands.json, but I think a simple filesize check to bypass would be helpful anyway.

OR: some mechanism to block (cerntain) compile_commands.json to be loaded at all could be useful.