### PR TITLE
Use macos 12 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     name: "${{ matrix.runs-on }} - ${{ matrix.name_suffix }}${{ matrix.benchmark && 'C++ Benchmark' || 'test run' }}"
     runs-on: ${{ matrix.runs-on }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
         fetch-depth: 0
@@ -127,7 +127,7 @@ jobs:
     name: "C++ Lint"
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
         fetch-depth: 0
@@ -185,7 +185,7 @@ jobs:
       COVERAGE: ${{ !matrix.benchmark }}
     name: "Windows MSVC ${{ matrix.msvc }} ${{ matrix.python-arch }} - ${{ matrix.benchmark && 'C++ Benchmark' || 'test run' }}"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
         fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ ubuntu-20.04, macos-10.15 ]
+        runs-on: [ ubuntu-20.04, macos-12 ]
         compiler: [ 'gcc' ] # Only used on linux
         libclang: [ true ] # Only used on linux
         benchmark: [ true, false ]

--- a/cpp/ycm/benchmarks/CMakeLists.txt
+++ b/cpp/ycm/benchmarks/CMakeLists.txt
@@ -29,8 +29,8 @@ else()
   include( FetchContent )
   FetchContent_Declare(
     benchmark
-    URL https://github.com/google/benchmark/archive/v1.7.1.tar.gz
-    URL_HASH SHA256=6430e4092653380d9dc4ccb45a1e2dc9259d581f4866dc0759713126056bc1d7
+    GIT_REPOSITORY https://github.com/google/benchmark
+    GIT_TAG 3b19d7222db7babfdc9b3949408b2294c3bbb540
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/benchmark
   )
   FetchContent_GetProperties( benchmark )

--- a/cpp/ycm/benchmarks/CMakeLists.txt
+++ b/cpp/ycm/benchmarks/CMakeLists.txt
@@ -29,8 +29,8 @@ else()
   include( FetchContent )
   FetchContent_Declare(
     benchmark
-    URL https://github.com/google/benchmark/archive/v1.5.2.tar.gz
-    URL_HASH SHA256=dccbdab796baa1043f04982147e67bb6e118fe610da2c65f88912d73987e700c
+    URL https://github.com/google/benchmark/archive/v1.7.1.tar.gz
+    URL_HASH SHA256=6430e4092653380d9dc4ccb45a1e2dc9259d581f4866dc0759713126056bc1d7
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/benchmark
   )
   FetchContent_GetProperties( benchmark )


### PR DESCRIPTION
Our records indicate that some of your organization’s workflow files are still referencing the macos-10.15 runner image. This image has been fully unsupported since 2022-12-01 and will be completely removed by 2023-03-31.

What you need to do

Workflows using the macos-10.15 YAML workflow label should be updated to macos-latest, macos-12, or macos-11. You can always get up-to-date information on our tools by reading about the [software](https://app.github.media/e/er?s=88570519&lid=3455&elqTrackId=20a1f0dfddfb4f279a143758449644bb&elq=80ef062d847e4addbbafffe8e5e487cb&elqaid=3113&elqat=1) in GitHub Actions runner images. Please contact [GitHub Support](https://app.github.media/e/er?s=88570519&lid=3338&elqTrackId=109f1ab4edb9447baf91e5e0d5dcb9c1&elq=80ef062d847e4addbbafffe8e5e487cb&elqaid=3113&elqat=1) if you run into any problems or need help.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1681)
<!-- Reviewable:end -->
