### PR TITLE
Fix URL of eclipse.jdt.ls

### DIFF
--- a/build.py
+++ b/build.py
@@ -1077,7 +1077,8 @@ def EnableJavaCompleter( switches ):
   REPOSITORY = p.join( TARGET, 'repository' )
   CACHE = p.join( TARGET, 'cache' )
 
-  JDTLS_SERVER_URL_FORMAT = ( 'http://download.eclipse.org/jdtls/snapshots/'
+  JDTLS_SERVER_URL_FORMAT = ( 'https://download.eclipse.org/jdtls/milestones/'
+                              '{jdtls_milestone}/'
                               '{jdtls_package_name}' )
   JDTLS_PACKAGE_NAME_FORMAT = ( 'jdt-language-server-{jdtls_milestone}-'
                                 '{jdtls_build_stamp}.tar.gz' )


### PR DESCRIPTION
The jdt-language-server package seems to got moved from snapshots to milestones.
Using the URL is no longer available, which causes the build.py script to throw "HTTP Error 404: Not Found".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1682)
<!-- Reviewable:end -->
