### PR TITLE
Suppress -Wbidi-chars on newer GCC's

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -418,6 +418,12 @@ endif()
 
 #############################################################################
 
+if ( CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12 )
+  target_compile_options( ${PROJECT_NAME} PRIVATE "-Wno-bidi-chars" )
+endif()
+
+#############################################################################
+
 if( SYSTEM_IS_SUNOS )
   # SunOS needs this setting for thread support
   target_compile_options( ${PROJECT_NAME} PUBLIC "-pthreads" )


### PR DESCRIPTION
Should I add a comment in CMakeLists.txt for the suppression?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1705)
<!-- Reviewable:end -->
