### PR TITLE
More CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
 
     - name: Install Java
       if: matrix.benchmark == false
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: 17
         distribution: 'adopt'
@@ -94,7 +94,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: stable
-        cache: true
+        cache: false
     - name: Install GCC
       if: runner.os == 'Linux' && matrix.compiler != 'clang'
       run: |
@@ -253,7 +253,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: stable
-        cache: true
+        cache: false
     - name: Run pip and prepare coverage
       if: matrix.benchmark == false
       run: |


### PR DESCRIPTION
Disables setup-go caching.
Upgrades setup-java for Unix-like runs, which was simply missed previously.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1709)
<!-- Reviewable:end -->
