### PR TITLE
Python 3.12 compatibility fixes

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -28,7 +28,7 @@
 #
 # For more information, please refer to <http://unlicense.org/>
 
-from distutils.sysconfig import get_python_inc
+from sysconfig import get_path
 import platform
 import os.path as p
 import subprocess
@@ -71,7 +71,7 @@ flags = [
 '-isystem',
 'cpp/BoostParts',
 '-isystem',
-get_python_inc(),
+get_path( 'include' ),
 '-isystem',
 'cpp/llvm/include',
 '-isystem',

--- a/build.py
+++ b/build.py
@@ -132,23 +132,23 @@ def FindLatestMSVC( quiet ):
       try:
         latest_v = int( latest_full_v.split( '.' )[ 0 ] )
       except ValueError:
-        raise ValueError( f"{latest_full_v} is not a version number." )
+        raise ValueError( f"{ latest_full_v } is not a version number." )
 
       if not quiet:
-        print( f'vswhere -latest returned version {latest_full_v}' )
+        print( f'vswhere -latest returned version { latest_full_v }' )
 
       if latest_v not in ACCEPTABLE_VERSIONS:
         if latest_v > 17:
           if not quiet:
-            print( f'MSVC Version {latest_full_v} is newer than expected.' )
+            print( f'MSVC Version { latest_full_v } is newer than expected.' )
         else:
           raise ValueError(
-            f'vswhere returned {latest_full_v} which is unexpected.'
+            f'vswhere returned { latest_full_v } which is unexpected.'
             'Pass --msvc <version> argument.' )
       return latest_v
     else:
       if not quiet:
-        print( f'vswhere returned nothing usable, {latest_full_v}' )
+        print( f'vswhere returned nothing usable, { latest_full_v }' )
 
   # Fall back to registry parsing, which works at least until MSVC 2019 (16)
   # but is likely failing on MSVC 2022 (17)
@@ -161,11 +161,11 @@ def FindLatestMSVC( quiet ):
   for i in ACCEPTABLE_VERSIONS:
     if not quiet:
       print( 'Trying to find '
-             rf'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\{i}.0' )
+             rf'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\{ i }.0' )
     try:
-      winreg.OpenKey( handle, rf'SOFTWARE\Microsoft\VisualStudio\{i}.0' )
+      winreg.OpenKey( handle, rf'SOFTWARE\Microsoft\VisualStudio\{ i }.0' )
       if not quiet:
-        print( f"Found MSVC version {i}" )
+        print( f"Found MSVC version { i }" )
       msvc = i
       break
     except FileNotFoundError:
@@ -978,7 +978,7 @@ def EnableRustCompleter( switches ):
   req_toolchain_version = switches.rust_toolchain_version
 
   if switches.quiet:
-    sys.stdout.write( f'Installing rust-analyzer "{req_toolchain_version}" '
+    sys.stdout.write( f'Installing rust-analyzer "{ req_toolchain_version }" '
                         'for Rust support...' )
     sys.stdout.flush()
 

--- a/ycmd/completers/cs/solutiondetection.py
+++ b/ycmd/completers/cs/solutiondetection.py
@@ -93,7 +93,7 @@ def _SolutionTestCheckHeuristics( candidates, tokens, i ):
   # 1. is there a solution named just like the subdirectory with the source?
   if ( not selection and i < len( tokens ) - 1 and
        f'{ tokens[ i + 1 ] }.sln' in candidates ):
-    selection = os.path.join( path, f'{ tokens[ i + 1] }.sln' )
+    selection = os.path.join( path, f'{ tokens[ i + 1 ] }.sln' )
     LOGGER.info( 'Selected solution file %s as it matches source subfolder',
                  selection )
 

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -214,7 +214,7 @@ class TypeScriptCompleter( Completer ):
       return
 
     self._logfile = utils.CreateLogfile( LOGFILE_FORMAT )
-    tsserver_log = f'-file { self._logfile } -level {_LogLevel()}'
+    tsserver_log = f'-file { self._logfile } -level { _LogLevel() }'
     # TSServer gets the configuration for the log file through the
     # environment variable 'TSS_LOG'. This seems to be undocumented but
     # looking at the source code it seems like this is the way:
@@ -911,7 +911,7 @@ class TypeScriptCompleter( Completer ):
       'offset': request_data[ 'column_codepoint' ]
     } )
 
-    message = f'{ info[ "displayString" ] }\n\n{info[ "documentation" ]}'
+    message = f'{ info[ "displayString" ] }\n\n{ info[ "documentation" ] }'
     return responses.BuildDetailedInfoResponse( message )
 
 


### PR DESCRIPTION
- Update of jedi
- f-string flake8 fixes
- Our extra conf no longer uses distutils.

CI is still not ready for python 3.12. Stay tuned.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1712)
<!-- Reviewable:end -->
