### PR TITLE
Make GoToCallers/GoToCallees respect ycmd protocol

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -313,6 +313,9 @@ class ClangdCompleter( language_server_completer.LanguageServerCompleter ):
 
 
   def GoToAlternateFile( self, request_data ):
+    if not self.ServerIsReady():
+      raise RuntimeError( 'Server is initializing. Please wait.' )
+
     request_id = self.GetConnection().NextRequestId()
     uri = lsp.FilePathToUri( request_data[ 'filepath' ] )
     request  = lsp.BuildRequest( request_id,

--- a/ycmd/tests/clangd/subcommands_test.py
+++ b/ycmd/tests/clangd/subcommands_test.py
@@ -606,6 +606,7 @@ class SubcommandsTest( TestCase ):
   @SharedYcmd
   def test_Subcommands_ServerNotInitialized( self, app ):
     for cmd in [
+      'ExecuteCommand',
       'FixIt',
       'Format',
       'GetDoc',
@@ -617,10 +618,14 @@ class SubcommandsTest( TestCase ):
       'GoToCallers',
       'GoToDeclaration',
       'GoToDefinition',
-      'GoToInclude',
+      'GoToDocumentOutline',
+      'GoToImprecise',
       'GoToImplementation',
+      'GoToInclude',
       'GoToReferences',
+      'GoToType',
       'RefactorRename',
+      'GoToAlternateFile',
     ]:
       with self.subTest( cmd = cmd ):
         completer = handlers._server_state.GetFiletypeCompleter( [ 'cpp' ] )
@@ -890,7 +895,7 @@ class SubcommandsTest( TestCase ):
   def test_Subcommands_GoToCallers( self, app ):
     for test in [
       { 'req': ( 'call_hierarchy.cc', 1, 6 ), # Simple case.
-        'res': [ ( 'call_hierarchy.cc', 4, 10 ) ] },
+        'res': ( 'call_hierarchy.cc', 4, 10 ) },
       { 'req': ( 'call_hierarchy.cc', 6, 6 ),
         'res': [
           ( 'call_hierarchy.cc', 15, 3 ), # More than one location in response.

--- a/ycmd/tests/go/subcommands_test.py
+++ b/ycmd/tests/go/subcommands_test.py
@@ -471,9 +471,9 @@ class SubcommandsTest( TestCase ):
     filepath = PathToTestFile( 'call_hierarchy.go' )
     for test in [
       { 'req': ( filepath, 4, 6 ),
-        'res': [ ( filepath, 5, 2 ) ] },
+        'res': ( filepath, 5, 2 ) },
       { 'req': ( filepath, 8, 6 ),
-        'res': [ ( filepath, 9, 2 ), ] },
+        'res': ( filepath, 9, 2 ), },
       { 'req': ( filepath, 11, 6 ),
         'res': [
           ( filepath, 12, 2 ),
@@ -493,7 +493,7 @@ class SubcommandsTest( TestCase ):
     filepath = PathToTestFile( 'call_hierarchy.go' )
     for test in [
       { 'req': ( filepath, 3, 6 ),
-        'res': [ ( filepath, 5, 2 ) ] },
+        'res': ( filepath, 5, 2 ) },
       { 'req': ( filepath, 8, 6 ),
         'res': [
           ( filepath, 9, 2 ),
@@ -504,7 +504,7 @@ class SubcommandsTest( TestCase ):
           ( filepath, 13, 2 ),
           ( filepath, 17, 2 ) ] },
       { 'req': ( filepath, 15, 6 ),
-        'res': [ ( filepath, 18, 2 ) ] }
+        'res': ( filepath, 18, 2 ) }
     ]:
       with self.subTest( test = test ):
         RunGoToTest( app, 'GoToCallers', test )

--- a/ycmd/tests/java/subcommands_test.py
+++ b/ycmd/tests/java/subcommands_test.py
@@ -2077,16 +2077,16 @@ class SubcommandsTest( TestCase ):
   def test_Subcommands_GoToCallers( self, app ):
     for test in [
       { 'request': { 'line': 6, 'col': 17, 'filepath': TEST_JAVA },
-        'response': [ has_entries( {
+        'response':  has_entries( {
           'line_num': 12,
           'column_num': 10,
-          'filepath': TEST_JAVA } ) ],
+          'filepath': TEST_JAVA } ) ,
         'description': 'GoToCallers on a function call.' },
       { 'request': { 'line': 20, 'col': 16, 'filepath': TEST_JAVA },
-        'response': [ has_entries( {
+        'response': has_entries( {
           'line_num': 15,
           'column_num': 41,
-          'filepath': TEST_JAVA } ) ],
+          'filepath': TEST_JAVA } ),
         'description': 'GoToCallers on a class name '
                        'produces constructor calls' },
     ]:
@@ -2097,7 +2097,7 @@ class SubcommandsTest( TestCase ):
                      test[ 'request' ][ 'line' ],
                      test[ 'request' ][ 'col' ],
                      'GoToCallers',
-                     contains_inanyorder( *test[ 'response' ] ) )
+                     test[ 'response' ] )
 
 
   @WithRetry()


### PR DESCRIPTION
ycmd protocol states that goto responses that contain only a single location will not be a list of locations, but just that location i.e. a json object, not a list of objects.

YCM as the main client uses this type level distinction to decide if it should open a location list or jump right away.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1713)
<!-- Reviewable:end -->
