### PR TITLE
Minor clangd completer fixes

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -313,6 +313,9 @@ class ClangdCompleter( language_server_completer.LanguageServerCompleter ):
 
 
   def GoToAlternateFile( self, request_data ):
+    if not self.ServerIsReady():
+      raise RuntimeError( 'Server is initializing. Please wait.' )
+
     request_id = self.GetConnection().NextRequestId()
     uri = lsp.FilePathToUri( request_data[ 'filepath' ] )
     request  = lsp.BuildRequest( request_id,

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -2843,6 +2843,9 @@ class LanguageServerCompleter( Completer ):
 
 
   def ExecuteCommand( self, request_data, args ):
+    if not self.ServerIsReady():
+      raise RuntimeError( 'Server is initializing. Please wait.' )
+
     if not args:
       raise ValueError( 'Must specify a command to execute' )
 

--- a/ycmd/tests/clangd/subcommands_test.py
+++ b/ycmd/tests/clangd/subcommands_test.py
@@ -606,6 +606,7 @@ class SubcommandsTest( TestCase ):
   @SharedYcmd
   def test_Subcommands_ServerNotInitialized( self, app ):
     for cmd in [
+      'ExecuteCommand',
       'FixIt',
       'Format',
       'GetDoc',
@@ -617,10 +618,14 @@ class SubcommandsTest( TestCase ):
       'GoToCallers',
       'GoToDeclaration',
       'GoToDefinition',
-      'GoToInclude',
+      'GoToDocumentOutline',
+      'GoToImprecise',
       'GoToImplementation',
+      'GoToInclude',
       'GoToReferences',
+      'GoToType',
       'RefactorRename',
+      'GoToAlternateFile',
     ]:
       with self.subTest( cmd = cmd ):
         completer = handlers._server_state.GetFiletypeCompleter( [ 'cpp' ] )


### PR DESCRIPTION
After dropping the functional stuff from #1713 , the only things left are two `ServerIsReady()` checks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1714)
<!-- Reviewable:end -->
