### PR TITLE
Display tsserver tags from docstrings in GetDoc and extra_menu_info

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -911,7 +911,12 @@ class TypeScriptCompleter( Completer ):
       'offset': request_data[ 'column_codepoint' ]
     } )
 
+    extra_info = _AggregateTagsFromDocstring( info )
+
     message = f'{ info[ "displayString" ] }\n\n{ info[ "documentation" ] }'
+    if extra_info:
+      message += f'\n\n{ extra_info }'
+
     return responses.BuildDetailedInfoResponse( message )
 
 
@@ -1117,6 +1122,16 @@ def _LogLevel():
   return 'verbose' if LOGGER.isEnabledFor( logging.DEBUG ) else 'normal'
 
 
+def _AggregateTagsFromDocstring( info ):
+  extra_info = []
+  for tag in info.get( 'tags', [] ):
+    tag_name = tag[ 'name' ]
+    tag_text = tag.get( 'text' )
+    formated_tag = tag_name + ( f': { tag_text }' if tag_text else '' )
+    extra_info.append( formated_tag )
+  return '\n'.join( extra_info )
+
+
 def _BuildCompletionExtraMenuAndDetailedInfo( request_data, entry ):
   signature = _DisplayPartsToString( entry[ 'displayParts' ] )
   if entry[ 'name' ] == signature:
@@ -1130,6 +1145,11 @@ def _BuildCompletionExtraMenuAndDetailedInfo( request_data, entry ):
 
   docs = entry.get( 'documentation', [] )
   detailed_info += [ doc[ 'text' ].strip() for doc in docs if doc ]
+
+  extra_info = _AggregateTagsFromDocstring( entry )
+  if extra_info:
+    detailed_info.append( extra_info )
+
   detailed_info = '\n\n'.join( detailed_info )
 
   return extra_menu_info, detailed_info

--- a/ycmd/tests/javascriptreact/get_completions_test.py
+++ b/ycmd/tests/javascriptreact/get_completions_test.py
@@ -75,7 +75,11 @@ class GetCompletionsTest( TestCase ):
              'detailed_info':  '(property) Document.alinkColor: string\n'
                                '\n'
                                'Sets or gets the color of all active links '
-                               'in the document.',
+                               'in the document.\n'
+                               '\n'
+                               'deprecated: [MDN Reference]'
+                               '(https://developer.mozilla.org/docs/Web/'
+                               'API/Document/alinkColor)',
             'kind':            'property',
           } ) )
         } )

--- a/ycmd/tests/typescript/get_completions_test.py
+++ b/ycmd/tests/typescript/get_completions_test.py
@@ -357,3 +357,34 @@ class GetCompletionsTest( TestCase ):
         } )
       }
     } )
+
+
+  @SharedYcmd
+  def test_GetCompletions_WithTags( self, app ):
+    filepath = PathToTestFile( 'signatures.ts' )
+    RunTest( app, {
+      'description': 'No need to force after a semantic trigger',
+      'request': {
+        'line_num': 101,
+        'column_num': 24,
+        'filepath': filepath,
+        'filetype': 'typescript'
+      },
+      'expect': {
+        'response': requests.codes.ok,
+        'data': has_entries( {
+          'completions': has_item( has_entries( {
+            'insertion_text': 'single_argument_with_doc',
+            'extra_data': {},
+            'extra_menu_info':
+                'function single_argument_with_doc(a: string): string',
+            'detailed_info':
+                'function single_argument_with_doc(a: string): string\n\n'
+                'A function with a single argument\n\n'
+                'param: a - The argument\n'
+                'returns: - The hashed input',
+            'kind': 'function'
+          } ) )
+        } )
+      }
+    } )

--- a/ycmd/tests/typescript/subcommands_test.py
+++ b/ycmd/tests/typescript/subcommands_test.py
@@ -611,6 +611,29 @@ class SubcommandsTest( TestCase ):
 
 
   @SharedYcmd
+  def test_Subcommands_GetDoc_FreeFunction_WithTags( self, app ):
+    RunTest( app, {
+      'description': 'GetDoc shows documentation of param and returns tags',
+      'request': {
+        'command': 'GetDoc',
+        'line_num': 101,
+        'column_num': 12,
+        'filepath': PathToTestFile( 'signatures.ts' ),
+      },
+      'expect': {
+        'response': requests.codes.ok,
+        'data': has_entries( {
+          'detailed_info':
+              'function single_argument_with_doc(a: string): string\n\n'
+              'A function with a single argument\n\n'
+              'param: a - The argument\n'
+              'returns: - The hashed input'
+        } )
+      }
+    } )
+
+
+  @SharedYcmd
   def test_Subcommands_GoToReferences( self, app ):
     RunTest( app, {
       'description': 'GoToReferences works',


### PR DESCRIPTION
Fixes #1675

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1716)
<!-- Reviewable:end -->
