### PR TITLE
[READY] Add diag kind to /detailed_diagnostic response

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1670,6 +1670,12 @@ class LanguageServerCompleter( Completer ):
       distance = _DistanceOfPointToRange( point, diagnostic[ 'range' ] )
       if minimum_distance is None or distance < minimum_distance:
         message = diagnostic[ 'message' ]
+        try:
+          code = diagnostic[ 'code' ]
+          message += f' [{ code }]'
+        except KeyError:
+          pass
+
         if distance == 0:
           break
         minimum_distance = distance

--- a/ycmd/tests/go/diagnostics_test.py
+++ b/ycmd/tests/go/diagnostics_test.py
@@ -74,7 +74,8 @@ class DiagnosticsTest( TestCase ):
                  any_of( has_entry( 'message',
                                     'undeclared name: diagnostics_test' ),
                          has_entry( 'message',
-                                    'undefined: diagnostics_test' ) ) )
+                                    'undefined: diagnostics_test'
+                                    ' [UndeclaredName]' ) ) )
 
 
   @WithRetry()

--- a/ycmd/tests/java/diagnostics_test.py
+++ b/ycmd/tests/java/diagnostics_test.py
@@ -301,7 +301,8 @@ class DiagnosticsTest( TestCase ):
     results = app.post_json( '/detailed_diagnostic', request_data ).json
     assert_that( results, has_entry(
         'message',
-        'The value of the field TestFactory.Bar.testString is not used' ) )
+        'The value of the field TestFactory.Bar.testString '
+        'is not used [570425421]' ) )
 
 
   @WithRetry()

--- a/ycmd/tests/rust/diagnostics_test.py
+++ b/ycmd/tests/rust/diagnostics_test.py
@@ -79,7 +79,7 @@ class DiagnosticsTest( TestCase ):
     results = app.post_json( '/detailed_diagnostic', request_data ).json
     assert_that( results, has_entry(
         'message',
-        'no field `build_` on type `test::Builder`\nunknown field' ) )
+        'no field `build_` on type `test::Builder`\nunknown field [E0609]' ) )
 
 
   @WithRetry()


### PR DESCRIPTION
Like I mentioned in gitter, we are missing `kind` in the `/detailed_diagnostic` response.

I am being lazy, so letting CI tell me if any tests are broken.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1720)
<!-- Reviewable:end -->
