### PR TITLE
Fix g:ycm_roslyn_binary_path being ignored

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -349,7 +349,7 @@ class CsharpCompleter( Completer ):
       omnisharp_server = responses.DebugInfoServer(
         name = 'OmniSharp',
         handle = completer._omnisharp_phandle,
-        executable = PATH_TO_ROSLYN_OMNISHARP,
+        executable = ' '.join( completer._ConstructOmnisharpCommand() ),
         address = 'localhost',
         port = completer._omnisharp_port,
         logfiles = [ completer._filename_stdout, completer._filename_stderr ],
@@ -398,6 +398,7 @@ class CsharpSolutionCompleter( object ):
     self._keep_logfiles = keep_logfiles
     self._filename_stderr = None
     self._filename_stdout = None
+    self._omnisharp_command = None
     self._omnisharp_port = None
     self._omnisharp_phandle = None
     self._desired_omnisharp_port = desired_omnisharp_port
@@ -420,6 +421,24 @@ class CsharpSolutionCompleter( object ):
       return self._StartServerNoLock()
 
 
+  def _ConstructOmnisharpCommand( self ):
+    if self._omnisharp_command:
+      return self._omnisharp_command
+
+    self._ChooseOmnisharpPort()
+    self._omnisharp_command = [ self._roslyn_path,
+                                '-p',
+                                str( self._omnisharp_port ),
+                                '-s',
+                                str( self._solution_path ) ]
+
+    if ( not utils.OnWindows()
+         and self._roslyn_path.endswith( '.exe' ) ):
+      self._omnisharp_command.insert( 0, self._mono_path )
+
+    return self._omnisharp_command
+
+
   def _StartServerNoLock( self ):
     """ Start the OmniSharp server if not already running. Use a lock to avoid
     starting the server multiple times for the same solution. """
@@ -429,18 +448,7 @@ class CsharpSolutionCompleter( object ):
     LOGGER.info( 'Starting OmniSharp server' )
     LOGGER.info( 'Loading solution file %s', self._solution_path )
 
-    self._ChooseOmnisharpPort()
-
-    command = [ PATH_TO_OMNISHARP_ROSLYN_BINARY,
-                '-p',
-                str( self._omnisharp_port ),
-                '-s',
-                str( self._solution_path ) ]
-
-    if ( not utils.OnWindows()
-         and self._roslyn_path.endswith( '.exe' ) ):
-      command.insert( 0, self._mono_path )
-
+    command = self._ConstructOmnisharpCommand()
     LOGGER.info( 'Starting OmniSharp server with: %s', command )
 
     solutionfile = os.path.basename( self._solution_path )
@@ -513,6 +521,7 @@ class CsharpSolutionCompleter( object ):
 
 
   def _CleanUp( self ):
+    self._omnisharp_command = None
     self._omnisharp_port = None
     self._omnisharp_phandle = None
     if not self._keep_logfiles:


### PR DESCRIPTION
Fixes the `g:ycm_roslyn_binary_path` only being used in prechecks, and the actual server always being started from the `ycmd/third_party` directory.

Also fixes the `:YcmDebugInfo` printing the directory containing default OmniSharp executable (and not the executable file itself); now prints full command with arguments used to start the server.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1721)
<!-- Reviewable:end -->
