### PR TITLE
CsCompleter: Implement GoToDocumentOutline.

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -241,6 +241,9 @@ class CsharpCompleter( Completer ):
          self._SolutionSubcommand( request_data,
                                    method = '_RefactorRename',
                                    args = args ) ),
+      'GoToDocumentOutline'              : ( lambda self, request_data, args:
+         self._SolutionSubcommand( request_data,
+                                   method = '_GoToDocumentOutline' ) ),
     }
 
 
@@ -657,6 +660,28 @@ class CsharpSolutionCompleter( object ):
               line ) )
 
         return goto_locations
+    else:
+      raise RuntimeError( 'No symbols found' )
+
+
+  def _GoToDocumentOutline( self, request_data ):
+    request = self._DefaultParameters( request_data )
+    response = self._GetResponse( '/currentfilemembersasflat', request )
+    if response is not None and len( response ) > 0:
+      goto_locations = []
+      for ref in response:
+        ref_file = ref[ 'FileName' ]
+        ref_line = ref[ 'Line' ]
+        lines = GetFileLines( request_data, ref_file )
+        line = lines[ min( len( lines ), ref_line - 1 ) ]
+        goto_locations.append(
+          responses.BuildGoToResponseFromLocation(
+            _BuildLocation( request_data,
+                            ref_file,
+                            ref_line,
+                            ref[ 'Column' ] ),
+            line ) )
+      return goto_locations
     else:
       raise RuntimeError( 'No symbols found' )
 

--- a/ycmd/tests/cs/subcommands_test.py
+++ b/ycmd/tests/cs/subcommands_test.py
@@ -909,3 +909,88 @@ class SubcommandsTest( TestCase ):
               LocationMatcher( filepath, 3, 1 ),
             )
           ) } ) ) } ) )
+
+
+  @SharedYcmd
+  def test_Subcommands_GoToDocumentOutline( self, app ):
+
+    # we reuse the ImportTest.cs file as it contains a good selection of
+    # symbols/ symbol types.
+    filepath = PathToTestFile( 'testy', 'GotoTestCase.cs' )
+    with WrapOmniSharpServer( app, filepath ):
+
+      # the command name and file are the only relevant arguments for this
+      # subcommand, our current cursor position in the file doesn't matter.
+      request = BuildRequest( command_arguments = [ 'GoToDocumentOutline' ],
+                              line_num = 11,
+                              column_num = 2,
+                              contents = ReadFile( filepath ),
+                              filetype = 'cs',
+                              filepath = filepath )
+
+      response = app.post_json( '/run_completer_command', request ).json
+
+      print( 'completer response = ', response )
+
+      assert_that( response,
+        has_items(
+          LocationMatcher(
+            PathToTestFile( 'testy', 'GotoTestCase.cs' ), 6, 8 ),
+          LocationMatcher(
+            PathToTestFile( 'testy', 'GotoTestCase.cs' ), 26, 12 ),
+          LocationMatcher(
+            PathToTestFile( 'testy', 'GotoTestCase.cs' ), 30, 8 ),
+          LocationMatcher(
+            PathToTestFile( 'testy', 'GotoTestCase.cs' ), 35, 12 ),
+          LocationMatcher(
+            PathToTestFile( 'testy', 'GotoTestCase.cs' ), 39, 12 ),
+          LocationMatcher(
+            PathToTestFile( 'testy', 'GotoTestCase.cs' ), 43, 8 ),
+          LocationMatcher(
+            PathToTestFile( 'testy', 'GotoTestCase.cs' ), 48, 8 ),
+          LocationMatcher(
+            PathToTestFile( 'testy', 'GotoTestCase.cs' ), 8, 15 ),
+          LocationMatcher(
+            PathToTestFile( 'testy', 'GotoTestCase.cs' ), 13, 15 ),
+          LocationMatcher(
+            PathToTestFile( 'testy', 'GotoTestCase.cs' ), 17, 15 ),
+          LocationMatcher(
+            PathToTestFile( 'testy', 'GotoTestCase.cs' ), 21, 15 ),
+          LocationMatcher(
+            PathToTestFile( 'testy', 'GotoTestCase.cs' ), 27, 8 ),
+          LocationMatcher(
+            PathToTestFile( 'testy', 'GotoTestCase.cs' ), 31, 15 ),
+          LocationMatcher(
+            PathToTestFile( 'testy', 'GotoTestCase.cs' ), 36, 8 ),
+          LocationMatcher(
+            PathToTestFile( 'testy', 'GotoTestCase.cs' ), 40, 8 ),
+          LocationMatcher(
+            PathToTestFile( 'testy', 'GotoTestCase.cs' ), 44, 15 ),
+          LocationMatcher(
+            PathToTestFile( 'testy', 'GotoTestCase.cs' ), 49, 15 ),
+        )
+      )
+
+  @SharedYcmd
+  def test_Subcommands_GoToDocumentOutline_Empty( self, app ):
+
+    filepath = PathToTestFile( 'testy', 'Empty.cs' )
+    with WrapOmniSharpServer( app, filepath ):
+
+      # the command name and file are the only relevant arguments for this
+      # subcommand.  our current cursor position in the file doesn't matter.
+      request = BuildRequest( command_arguments = [ 'GoToDocumentOutline' ],
+                              line_num = 0,
+                              column_num = 0,
+                              contents = ReadFile( filepath ),
+                              filetype = 'cs',
+                              filepath = filepath )
+
+      response = app.post_json( '/run_completer_command',
+                                request,
+                                expect_errors = True ).json
+
+      print( 'completer response = ', response )
+
+      assert_that( response, ErrorMatcher( RuntimeError,
+                                           'No symbols found' ) )

--- a/ycmd/tests/cs/testdata/testy/Empty.cs
+++ b/ycmd/tests/cs/testdata/testy/Empty.cs
@@ -1,0 +1,6 @@
+using System;
+using System.Data;
+
+namespace testy
+{
+}

--- a/ycmd/tests/cs/testdata/testy/testy.csproj
+++ b/ycmd/tests/cs/testdata/testy/testy.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ZeroColumnDiagnostic.cs" />
+    <Compile Include="Empty.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Implements `GoToDocumentOutline` in the `CsCompleter` to support `YCMFindSymbolInDocument` functionality for `cs` projects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1723)
<!-- Reviewable:end -->
