### PR TITLE
[READY] Make C# completer consistent with other completers regarding GoToDocumentOutline

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -681,7 +681,9 @@ class CsharpSolutionCompleter( object ):
                             ref_line,
                             ref[ 'Column' ] ),
             line ) )
-      return goto_locations
+      if len( goto_locations ) > 1:
+        return goto_locations
+      return goto_locations[ 0 ]
     else:
       raise RuntimeError( 'No symbols found' )
 

--- a/ycmd/tests/cs/testdata/testy/SingleEntity.cs
+++ b/ycmd/tests/cs/testdata/testy/SingleEntity.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Data;
+
+namespace testy
+{
+	class GotoTestCase
+	{
+	}
+}

--- a/ycmd/tests/cs/testdata/testy/testy.csproj
+++ b/ycmd/tests/cs/testdata/testy/testy.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ZeroColumnDiagnostic.cs" />
     <Compile Include="Empty.cs" />
+    <Compile Include="SingleEntity.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
All other semantic completers return a list only when more than one item is in the list. Otherwise return that one item.

WIP because I can't be bothered to set up C# on my machine. I will be using CI for that instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1724)
<!-- Reviewable:end -->
