### PR TITLE
[RFC] Do not use a full line as description for symbol search

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -633,31 +633,23 @@ class CsharpSolutionCompleter( object ):
     if quickfixes:
       if len( quickfixes ) == 1:
         ref = quickfixes[ 0 ]
-        ref_file = ref[ 'FileName' ]
-        ref_line = ref[ 'Line' ]
-        lines = GetFileLines( request_data, ref_file )
-        line = lines[ min( len( lines ), ref_line - 1 ) ]
         return responses.BuildGoToResponseFromLocation(
           _BuildLocation(
             request_data,
-            ref_file,
-            ref_line,
+            ref[ 'FileName' ],
+            ref[ 'Line' ],
             ref[ 'Column' ] ),
-          line )
+          ref[ 'Text' ] )
       else:
         goto_locations = []
         for ref in quickfixes:
-          ref_file = ref[ 'FileName' ]
-          ref_line = ref[ 'Line' ]
-          lines = GetFileLines( request_data, ref_file )
-          line = lines[ min( len( lines ), ref_line - 1 ) ]
           goto_locations.append(
             responses.BuildGoToResponseFromLocation(
               _BuildLocation( request_data,
-                              ref_file,
-                              ref_line,
+                              ref[ 'FileName' ],
+                              ref[ 'Line' ],
                               ref[ 'Column' ] ),
-              line ) )
+              ref[ 'Text' ] ) )
 
         return goto_locations
     else:
@@ -670,17 +662,13 @@ class CsharpSolutionCompleter( object ):
     if response is not None and len( response ) > 0:
       goto_locations = []
       for ref in response:
-        ref_file = ref[ 'FileName' ]
-        ref_line = ref[ 'Line' ]
-        lines = GetFileLines( request_data, ref_file )
-        line = lines[ min( len( lines ), ref_line - 1 ) ]
         goto_locations.append(
           responses.BuildGoToResponseFromLocation(
             _BuildLocation( request_data,
-                            ref_file,
-                            ref_line,
+                            ref[ 'FileName' ],
+                            ref[ 'Line' ],
                             ref[ 'Column' ] ),
-            line ) )
+            ref[ 'Text' ] ) )
       if len( goto_locations ) > 1:
         return goto_locations
       return goto_locations[ 0 ]


### PR DESCRIPTION
This does lose a bit of context, but not much. Methods still have their signatures visible and variables are... well... variables.

The idea is, if a client wants to later do filtering and sorting of symbols, we should not be doing that on the whole line, which might be left padded with tabs and have other punctuation. We already had a report that this does not work well. It almost works if a client `strip()`s the description before using it at all.

LSP completer instead uses `extra_data` to supply identifier name and kind, but omnisharp-roslyn does not provide us with a symbol kind and thus we can only put `ref[ 'Text' ]` in the description.

@teasp00n was the user who pointed out the problems with using the whole line for filtering.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1726)
<!-- Reviewable:end -->
