### PR TITLE
Sort diagnostics according to severity for detailed diag responses

### DIFF
--- a/ycmd/completers/cs/cs_completer.py
+++ b/ycmd/completers/cs/cs_completer.py
@@ -316,6 +316,9 @@ class CsharpCompleter( Completer ):
     if not diagnostics:
       raise ValueError( NO_DIAGNOSTIC_MESSAGE )
 
+    # Prefer errors to warnings and warnings to infos.
+    diagnostics.sort( key = _CsDiagnosticToLspSeverity )
+
     closest_diagnostic = None
     distance_to_closest_diagnostic = 999
 
@@ -968,3 +971,11 @@ def _ModifiedFilesToFixIt( changes, request_data ):
         request_data[ 'line_num' ],
         request_data[ 'column_codepoint' ] ),
       chunks )
+
+
+def _CsDiagnosticToLspSeverity( diagnostic ):
+  if diagnostic.kind_ == 'ERROR':
+    return 1
+  if diagnostic.kind_ == 'WARNING':
+    return 2
+  return 3

--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -656,6 +656,9 @@ class TypeScriptCompleter( Completer ):
     if not ts_diagnostics_on_line:
       raise ValueError( NO_DIAGNOSTIC_MESSAGE )
 
+    # Prefer errors to warnings and warnings to infos.
+    ts_diagnostics_on_line.sort( key = _TsDiagToLspSeverity )
+
     closest_ts_diagnostic = None
     distance_to_closest_ts_diagnostic = None
 
@@ -1264,3 +1267,12 @@ def _BuildTsFormatRange( request_data ):
 
 def _DisplayPartsToString( parts ):
   return ''.join( [ p[ 'text' ] for p in parts ] )
+
+
+def _TsDiagToLspSeverity( diag ):
+  category = diag[ 'category' ]
+  if category == 'error':
+    return 1
+  if category == 'warning':
+    return 2
+  return 3

--- a/ycmd/tests/clangd/diagnostics_test.py
+++ b/ycmd/tests/clangd/diagnostics_test.py
@@ -151,6 +151,23 @@ void foo() {
                  has_entry( 'message', contains_string( "Expected ';'" ) ) )
 
 
+  @IsolatedYcmd( { 'clangd_args': [ '--clang-tidy=0' ] } )
+  def test_Diagnostics_WarningAndErrorOnSameColumn( self, app ):
+    for col in [ 2, 22 ]:
+      with self.subTest( col = col ):
+        filepath = PathToTestFile( 'diag_ranges', 'detailed_diagnostic.cc' )
+        request = { 'filepath': filepath, 'filetype': 'cpp', 'column_num': col }
+        test = { 'request': request, 'route': '/receive_messages' }
+        RunAfterInitialized( app, test )
+        diag_data = BuildRequest( line_num = 3,
+                                  filepath = filepath,
+                                  filetype = 'cpp' )
+        result = app.post_json( '/detailed_diagnostic', diag_data ).json
+        assert_that( result,
+                     has_entry( 'message',
+                                 contains_string( 'uninitialized' ) ) )
+
+
   @IsolatedYcmd()
   def test_Diagnostics_Multiline( self, app ):
     contents = """

--- a/ycmd/tests/clangd/testdata/diag_ranges/compile_flags.txt
+++ b/ycmd/tests/clangd/testdata/diag_ranges/compile_flags.txt
@@ -1,0 +1,4 @@
+-Wno-error
+-Wfor-loop-analysis
+-Wno-error=for-loop-analysis
+-Werror=uninitialized

--- a/ycmd/tests/clangd/testdata/diag_ranges/detailed_diagnostic.cc
+++ b/ycmd/tests/clangd/testdata/diag_ranges/detailed_diagnostic.cc
@@ -1,0 +1,4 @@
+int main() {
+	int i;
+        for (int j; j;i){}
+}

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -1497,7 +1497,8 @@ class LanguageServerCompleterTest( TestCase ):
     # Point inside range.
     _Check_Distance( ( 0, 4 ), ( 0, 2 ), ( 0, 5 ) , 0 )
     # Point to the right of range.
-    _Check_Distance( ( 0, 8 ), ( 0, 2 ), ( 0, 5 ) , 3 )
+    # +1 because diags are half-open ranges.
+    _Check_Distance( ( 0, 8 ), ( 0, 2 ), ( 0, 5 ) , 4 )
 
 
   def test_LanguageServerCompleter_DistanceOfPointToRange_MultiLineRange(
@@ -1507,4 +1508,5 @@ class LanguageServerCompleterTest( TestCase ):
     # Point inside range.
     _Check_Distance( ( 1, 4 ), ( 0, 2 ), ( 3, 5 ) , 0 )
     # Point to the right of range.
-    _Check_Distance( ( 3, 8 ), ( 0, 2 ), ( 3, 5 ) , 3 )
+    # +1 because diags are half-open ranges.
+    _Check_Distance( ( 3, 8 ), ( 0, 2 ), ( 3, 5 ) , 4 )


### PR DESCRIPTION
Users are more likely to be interested in errors than warnings in /detailed_diagnostic responses. That means we need to sort the diagnostics before finding the one nearest to the cursor.

For LSP completers, that's easy as the severity is numerical. For Omnisharp-roslyn and TSServer, the severity is a word and we can't just say `sort( key = severity )`.

Since LSP severity was convenient for comparison, I have opted for sorting C# and TS diags by the equivalent LSP severity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1728)
<!-- Reviewable:end -->
