### PR TITLE
Fix rpath to libclang archive on mac with external llvm

### DIFF
--- a/cpp/ycm/CMakeLists.txt
+++ b/cpp/ycm/CMakeLists.txt
@@ -354,6 +354,7 @@ if( LIBCLANG_TARGET )
     set_target_properties( ${PROJECT_NAME} PROPERTIES
       BUILD_WITH_INSTALL_RPATH ON
       SKIP_BUILD_RPATH FALSE
+      INSTALL_RPATH_USE_LINK_PATH ON
       INSTALL_RPATH ${LIBCLANG_DIR} )
   endif ()
   # Remove all previous libclang libraries.


### PR DESCRIPTION
The impact on current build.py usage is minimal because build.py doesn't support external LLVM root. You can modify build.py to support it by add something like this `cmake_args.append( '-DPATH_TO_LLVM_ROOT=/Users/hky/clang+llvm-17.0.6-arm64-apple-darwin22.0' )`

1) tested with downloaded libclang
```
➜  ycmd git:(master) otool -l ycm_core.cpython-310-darwin.so|grep -A3 LC_RPATH
          cmd LC_RPATH
      cmdsize 96
         path /Users/hky/.vim/plugged/YouCompleteMe/third_party/ycmd/cpp/../third_party/clang/lib (offset 12)
Load command 18
```
Okay, because the dylib lies inside `LIBCLANG_DIR`
2) tested with system libclang
```
➜  ycmd git:(master) otool -l ycm_core.cpython-310-darwin.so|grep -A3 LC_RPATH
          cmd LC_RPATH
      cmdsize 96
         path /Users/hky/.vim/plugged/YouCompleteMe/third_party/ycmd/cpp/../third_party/clang/lib (offset 12)
Load command 18
          cmd LC_RPATH
      cmdsize 104
         path /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib (offset 12)
Load command 19
```
Okay, because the dylib lies outside `LIBCLANG_DIR` and next RPATH is correct.
3) tested with external libclang
```
➜  ycmd git:(master) ✗ otool -l ycm_core.cpython-310-darwin.so|grep -A3 LC_RPATH
          cmd LC_RPATH
      cmdsize 96
         path /Users/hky/.vim/plugged/YouCompleteMe/third_party/ycmd/cpp/../third_party/clang/lib (offset 12)
Load command 18
          cmd LC_RPATH
      cmdsize 72
         path /Users/hky/clang+llvm-17.0.6-arm64-apple-darwin22.0/lib (offset 12)
Load command 19
```
Okay, because the dylib lies outside `LIBCLANG_DIR` and next RPATH is correct.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1729)
<!-- Reviewable:end -->
