### PR TITLE
Update the server with current file state after a restart

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1236,6 +1236,9 @@ class LanguageServerCompleter( Completer ):
   def _RestartServer( self, request_data, *args, **kwargs ):
     self.Shutdown()
     self._StartAndInitializeServer( request_data, *args, **kwargs )
+    self._OnInitializeComplete(
+      lambda self: self._UpdateServerWithFileContents( request_data )
+    )
 
 
   def _ServerIsInitialized( self ):


### PR DESCRIPTION
Previously, ycmd would not update the LSP server with the current file state after RestartServer subcommand had been issued. This causes some stale diagnostics to linger.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1730)
<!-- Reviewable:end -->
