### PR TITLE
[READY] Add support for didChangeWorkspaceFolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ wouldn't usually know about. The value is a list of dictionaries containing:
 - `capabilities'`: Overrides the default LSP capabilities of ycmd.
   - If you enable `workspace/configuration` support, check the extra conf
     details, relevant to LSP servers.
+- `additional_workspace_dirs`: Specifies statically known workspaces that should
+  be open on LSP server startup.
 - `triggerCharacters`: Override the LSP server's trigger characters for
   completion. This can be useful when the server obnoxiously requests completion
   on every character or for example on whitespace characters.

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -404,6 +404,10 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
     return self._java_project_dir
 
 
+  def GetWorkspaceForFilepath( self, filepath ):
+    return _FindProjectDir( os.path.dirname( filepath ) )
+
+
   def _WipeWorkspace( self, request_data, args ):
     with_config = False
     if len( args ) > 0 and '--with-config' in args:

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -358,9 +358,6 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
       'OrganizeImports': (
         lambda self, request_data, args: self.OrganizeImports( request_data )
       ),
-      'OpenProject': (
-        lambda self, request_data, args: self._OpenProject( request_data, args )
-      ),
       'WipeWorkspace': (
         lambda self, request_data, args: self._WipeWorkspace( request_data,
                                                               args )
@@ -416,25 +413,6 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
     self._RestartServer( request_data,
                          wipe_workspace = True,
                          wipe_config = with_config )
-
-
-  def _OpenProject( self, request_data, args ):
-    if len( args ) != 1:
-      raise ValueError( "Usage: OpenProject <project directory>" )
-
-    project_directory = args[ 0 ]
-
-    # If the dir is not absolute, calculate it relative to the working dir of
-    # the client (if supplied).
-    if not os.path.isabs( project_directory ):
-      if 'working_dir' not in request_data:
-        raise ValueError( "Project directory must be absolute" )
-
-      project_directory = os.path.normpath( os.path.join(
-        request_data[ 'working_dir' ],
-        project_directory ) )
-
-    self._RestartServer( request_data, project_directory = project_directory )
 
 
   def _Reset( self ):

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -2361,10 +2361,15 @@ class LanguageServerCompleter( Completer ):
       # the settings on the Initialize request are somehow subtly different from
       # the settings supplied in didChangeConfiguration, though it's not exactly
       # clear how/where that is specified.
+      additional_workspace_dirs = self._settings.get(
+                                    'additional_workspace_dirs',
+                                    [] )
+      self._server_workspace_dirs.update( additional_workspace_dirs )
       msg = lsp.Initialize( request_id,
                             self._project_directory,
                             self.ExtraCapabilities(),
-                            self._settings.get( 'ls', {} ) )
+                            self._settings.get( 'ls', {} ),
+                            additional_workspace_dirs )
 
       def response_handler( response, message ):
         if message is None:

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -2961,6 +2961,8 @@ class LanguageServerCompleter( Completer ):
                                       ServerStateDescription() ),
              responses.DebugInfoItem( 'Project Directory',
                                       self._project_directory ),
+             responses.DebugInfoItem( 'Open Workspaces',
+                                      self._server_workspace_dirs ),
              responses.DebugInfoItem(
                'Settings',
                json.dumps( self._settings.get( 'ls', {} ),

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -294,7 +294,11 @@ def BuildResponse( request, parameters ):
   return _BuildMessageData( message )
 
 
-def Initialize( request_id, project_directory, extra_capabilities, settings ):
+def Initialize( request_id,
+                project_directory,
+                extra_capabilities,
+                settings,
+                workspaces ):
   """Build the Language Server initialize request"""
 
   capabilities = {
@@ -393,7 +397,7 @@ def Initialize( request_id, project_directory, extra_capabilities, settings ):
     'rootUri': FilePathToUri( project_directory ),
     'initializationOptions': settings,
     'capabilities': UpdateDict( capabilities, extra_capabilities ),
-    'workspaceFolders': WorkspaceFolders( project_directory ),
+    'workspaceFolders': WorkspaceFolders( *workspaces ),
   } )
 
 

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -447,6 +447,15 @@ def ApplyEditResponse( request, applied ):
   return Accept( request, msg )
 
 
+def DidChangeWorkspaceFolders( new_folder ):
+  return BuildNotification( 'workspace/didChangeWorkspaceFolders', {
+    'event': {
+      'removed': [],
+      'added': WorkspaceFolders( new_folder )
+    }
+  } )
+
+
 def DidChangeWatchedFiles( path, kind ):
   return BuildNotification( 'workspace/didChangeWatchedFiles', {
     'changes': [ {

--- a/ycmd/tests/clangd/debug_info_test.py
+++ b/ycmd/tests/clangd/debug_info_test.py
@@ -59,6 +59,10 @@ class DebugInfoTest( TestCase ):
               'value': None,
             } ),
             has_entries( {
+              'key': 'Open Workspaces',
+              'value': has_items()
+            } ),
+            has_entries( {
               'key': 'Settings',
               'value': '{}',
             } ),
@@ -94,6 +98,10 @@ class DebugInfoTest( TestCase ):
             has_entries( {
               'key': 'Project Directory',
               'value': PathToTestFile(),
+            } ),
+            has_entries( {
+              'key': 'Open Workspaces',
+              'value': has_items()
             } ),
             has_entries( {
               'key': 'Settings',
@@ -135,6 +143,10 @@ class DebugInfoTest( TestCase ):
               'value': PathToTestFile( 'extra_conf' ),
             } ),
             has_entries( {
+              'key': 'Open Workspaces',
+              'value': has_items()
+            } ),
+            has_entries( {
               'key': 'Settings',
               'value': '{}',
             } ),
@@ -173,6 +185,10 @@ class DebugInfoTest( TestCase ):
             has_entries( {
               'key': 'Project Directory',
               'value': PathToTestFile( 'extra_conf' ),
+            } ),
+            has_entries( {
+              'key': 'Open Workspaces',
+              'value': has_items()
             } ),
             has_entries( {
               'key': 'Settings',
@@ -217,6 +233,10 @@ class DebugInfoTest( TestCase ):
               'value': PathToTestFile(),
             } ),
             has_entries( {
+              'key': 'Open Workspaces',
+              'value': has_items()
+            } ),
+            has_entries( {
               'key': 'Settings',
               'value': '{}',
             } ),
@@ -258,6 +278,10 @@ class DebugInfoTest( TestCase ):
             has_entries( {
               'key': 'Project Directory',
               'value': PathToTestFile( 'extra_conf' ),
+            } ),
+            has_entries( {
+              'key': 'Open Workspaces',
+              'value': has_items()
             } ),
             has_entries( {
               'key': 'Settings',
@@ -307,6 +331,10 @@ class DebugInfoTest( TestCase ):
                 has_entries( {
                   'key': 'Project Directory',
                   'value': tmp_dir,
+                } ),
+                has_entries( {
+                  'key': 'Open Workspaces',
+                  'value': has_items()
                 } ),
                 has_entries( {
                   'key': 'Settings',
@@ -366,6 +394,10 @@ def Settings( **kwargs ):
                     'value': tmp_dir,
                   } ),
                   has_entries( {
+                    'key': 'Open Workspaces',
+                    'value': has_items()
+                  } ),
+                  has_entries( {
                     'key': 'Settings',
                     'value': '{}',
                   } ),
@@ -420,6 +452,10 @@ def Settings( **kwargs ):
                   'value': tmp_dir,
                 } ),
                 has_entries( {
+                  'key': 'Open Workspaces',
+                  'value': has_items()
+                } ),
+                has_entries( {
                   'key': 'Settings',
                   'value': '{}',
                 } ),
@@ -458,6 +494,10 @@ def Settings( **kwargs ):
             has_entries( {
               'key': 'Project Directory',
               'value': PathToTestFile( 'extra_conf' ),
+            } ),
+            has_entries( {
+              'key': 'Open Workspaces',
+              'value': has_items()
             } ),
             has_entries( {
               'key': 'Settings',

--- a/ycmd/tests/go/__init__.py
+++ b/ycmd/tests/go/__init__.py
@@ -73,7 +73,7 @@ def IsolatedYcmd( custom_options = {} ):
   return Decorator
 
 
-def PathToTestFile( *args ):
+def PathToTestFile( *args, module_dir = 'go_module' ):
   dir_of_current_script = os.path.dirname( os.path.abspath( __file__ ) )
   # GOPLS doesn't work if any parent directory is named "testdata"
-  return os.path.join( dir_of_current_script, 'go_module', *args )
+  return os.path.join( dir_of_current_script, module_dir, *args )

--- a/ycmd/tests/go/debug_info_test.py
+++ b/ycmd/tests/go/debug_info_test.py
@@ -19,6 +19,7 @@ from hamcrest import ( assert_that,
                        contains_exactly,
                        has_entries,
                        has_entry,
+                       has_items,
                        instance_of,
                        is_not,
                        empty )
@@ -61,6 +62,10 @@ class DebugInfoTest( TestCase ):
               'value': PathToTestFile(),
             } ),
             has_entries( {
+              'key': 'Open Workspaces',
+              'value': has_items()
+            } ),
+            has_entries( {
               'key': 'Settings',
               'value': is_json_string_matching( has_entries( {
                 'hints': is_not( empty() ),
@@ -101,6 +106,10 @@ class DebugInfoTest( TestCase ):
             has_entries( {
               'key': 'Project Directory',
               'value': PathToTestFile(),
+            } ),
+            has_entries( {
+              'key': 'Open Workspaces',
+              'value': has_items()
             } ),
             has_entries( {
               'key': 'Settings',

--- a/ycmd/tests/go/go_module/thing.go
+++ b/ycmd/tests/go/go_module/thing.go
@@ -1,9 +1,13 @@
 package main
 
+import "example.com/owner/module/td"
+
 type thinger interface {
-	DoThing()
+  DoThing()
 }
 
 type thing string
 
-func (thing) DoThing() {}
+func (thing) DoThing() {
+  td.Hello()
+}

--- a/ycmd/tests/go/go_module_2/go.mod
+++ b/ycmd/tests/go/go_module_2/go.mod
@@ -1,0 +1,3 @@
+module example.com/owner/other_module
+
+go 1.22.0

--- a/ycmd/tests/go/go_module_2/main.go
+++ b/ycmd/tests/go/go_module_2/main.go
@@ -1,0 +1,7 @@
+package main
+
+func f() {}
+
+func main() {
+  f()
+}

--- a/ycmd/tests/java/debug_info_test.py
+++ b/ycmd/tests/java/debug_info_test.py
@@ -104,6 +104,10 @@ class DebugInfoTest( TestCase ):
               'value': PathToTestFile( 'simple_eclipse_project' )
             } ),
             has_entries( {
+              'key': 'Open Workspaces',
+              'value': has_items()
+            } ),
+            has_entries( {
               'key': 'Settings',
               'value': json.dumps(
                 { 'bundles': [] },
@@ -158,6 +162,10 @@ class DebugInfoTest( TestCase ):
               'key': 'Project Directory',
               'value': PathToTestFile( 'extra_confs',
                                        'simple_extra_conf_project' )
+            } ),
+            has_entries( {
+              'key': 'Open Workspaces',
+              'value': has_items()
             } ),
             has_entries( {
               'key': 'Settings',

--- a/ycmd/tests/java/server_management_test.py
+++ b/ycmd/tests/java/server_management_test.py
@@ -18,7 +18,6 @@
 import functools
 import os
 import psutil
-import requests
 import time
 
 from unittest.mock import patch
@@ -36,12 +35,10 @@ from ycmd.tests.java import setUpModule, tearDownModule # noqa
 from ycmd.tests.java import ( PathToTestFile,
                               isolated_app,
                               IsolatedYcmd,
-                              SharedYcmd,
                               StartJavaCompleterServerInDirectory,
                               StartJavaCompleterServerWithFile )
 from ycmd.tests.test_utils import ( BuildRequest,
                                     CompleterProjectDirectoryMatcher,
-                                    ErrorMatcher,
                                     MockProcessTerminationTimingOut,
                                     TemporaryTestDir,
                                     WaitUntilCompleterServerReady )
@@ -297,45 +294,6 @@ class ServerManagementTest( TestCase ):
     request_data = BuildRequest( filetype = 'java' )
     assert_that( app.post_json( '/debug_info', request_data ).json,
                  CompleterProjectDirectoryMatcher( project ) )
-
-
-  @SharedYcmd
-  def test_ServerManagement_OpenProject_RelativePathNoWD( self, app ):
-    response = app.post_json(
-      '/run_completer_command',
-      BuildRequest(
-        filetype = 'java',
-        command_arguments = [
-          'OpenProject',
-          os.path.join( '..', 'simple_maven_project' ),
-        ],
-      ),
-      expect_errors = True,
-    )
-    assert_that( response.status_code,
-                 equal_to( requests.codes.internal_server_error ) )
-    assert_that( response.json,
-                 ErrorMatcher( ValueError,
-                               'Project directory must be absolute' ) )
-
-
-  @SharedYcmd
-  def test_ServerManagement_OpenProject_RelativePathNoPath( self, app ):
-    response = app.post_json(
-      '/run_completer_command',
-      BuildRequest(
-        filetype = 'java',
-        command_arguments = [
-          'OpenProject',
-        ],
-      ),
-      expect_errors = True,
-    )
-    assert_that( response.status_code,
-                 equal_to( requests.codes.internal_server_error ) )
-    assert_that( response.json,
-                 ErrorMatcher( ValueError,
-                               'Usage: OpenProject <project directory>' ) )
 
 
   def test_ServerManagement_ProjectDetection_NoParent( self ):

--- a/ycmd/tests/java/subcommands_test.py
+++ b/ycmd/tests/java/subcommands_test.py
@@ -178,7 +178,6 @@ class SubcommandsTest( TestCase ):
                    'GoToReferences',
                    'GoToType',
                    'GoToSymbol',
-                   'OpenProject',
                    'OrganizeImports',
                    'RefactorRename',
                    'RestartServer',

--- a/ycmd/tests/java/testdata/simple_gradle_project/gradle/wrapper/gradle-wrapper.properties
+++ b/ycmd/tests/java/testdata/simple_gradle_project/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip

--- a/ycmd/tests/language_server/generic_completer_test.py
+++ b/ycmd/tests/language_server/generic_completer_test.py
@@ -209,6 +209,10 @@ class GenericCompleterTest( TestCase ):
               'value': PathToTestFile( 'generic_server' ),
             } ),
             has_entries( {
+              'key': 'Open Workspaces',
+              'value': has_items(),
+            } ),
+            has_entries( {
               'key': 'Settings',
               'value': '{}'
             } ),
@@ -255,6 +259,10 @@ class GenericCompleterTest( TestCase ):
             has_entries( {
               'key': 'Project Directory',
               'value': PathToTestFile( 'generic_server' ),
+            } ),
+            has_entries( {
+              'key': 'Open Workspaces',
+              'value': has_items(),
             } ),
             has_entries( {
               'key': 'Settings',
@@ -308,6 +316,10 @@ class GenericCompleterTest( TestCase ):
               has_entries( {
                 'key': 'Project Directory',
                 'value': None,
+              } ),
+              has_entries( {
+                'key': 'Open Workspaces',
+                'value': has_items(),
               } ),
               has_entries( {
                 'key': 'Settings',
@@ -509,6 +521,10 @@ class GenericCompleterTest( TestCase ):
             has_entries( {
               'key': 'Project Directory',
               'value': PathToTestFile( 'generic_server', 'foo' ),
+            } ),
+            has_entries( {
+              'key': 'Open Workspaces',
+              'value': has_items(),
             } ),
             has_entries( {
               'key': 'Settings',

--- a/ycmd/tests/rust/debug_info_test.py
+++ b/ycmd/tests/rust/debug_info_test.py
@@ -15,8 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
-from hamcrest import ( assert_that, contains_exactly, has_entries, has_entry,
-                       instance_of, none )
+from hamcrest import ( assert_that,
+                       contains_exactly,
+                       has_entries,
+                       has_entry,
+                       has_items,
+                       instance_of,
+                       none )
 from unittest.mock import patch
 from unittest import TestCase
 from ycmd.tests.rust import setUpModule, tearDownModule # noqa
@@ -51,6 +56,10 @@ class DebugInfoTest( TestCase ):
             has_entries( {
               'key': 'Project Directory',
               'value': instance_of( str )
+            } ),
+            has_entries( {
+              'key': 'Open Workspaces',
+              'value': has_items()
             } ),
             has_entries( {
               'key': 'Settings',
@@ -102,6 +111,10 @@ class DebugInfoTest( TestCase ):
             has_entries( {
               'key': 'Project Directory',
               'value': instance_of( str )
+            } ),
+            has_entries( {
+              'key': 'Open Workspaces',
+              'value': has_items()
             } ),
             has_entries( {
               'key': 'Settings',

--- a/ycmd/tests/shutdown_test.py
+++ b/ycmd/tests/shutdown_test.py
@@ -56,6 +56,7 @@ class ShutdownTest( ClientTest ):
     filetypes = [ 'cpp',
                   'cs',
                   'go',
+                  'java',
                   'javascript',
                   'typescript',
                   'rust' ]
@@ -105,6 +106,7 @@ class ShutdownTest( ClientTest ):
       filetypes = [ 'cpp',
                     'cs',
                     'go',
+                    'java',
                     'javascript',
                     'typescript',
                     'rust' ]


### PR DESCRIPTION
Perhaps it's finally time to add this capability...

There are a couple missing pieces:

1. So far, this does not take into account the extra confs.
2. Clangd completer does not have GetProjectRootFiles() implemented, but also clangd does not want to listen to this notification. I guess it knows better than us?
3. Java completer also does not have GetProjectRootFiles() implemented, but actually wants this notification.
4. Do we need `_project_directory` *and* `_server_workspace_dirs`?
5. Tests... after we figure out the answers to the above!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1731)
<!-- Reviewable:end -->
