### PR TITLE
[READY] Prefer selectionRange over range in LSP Location-like objects

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -3299,9 +3299,10 @@ def _LspLocationToLocationAndDescription( request_data, location ):
                       'GoTo location' )
     file_contents = []
 
+  range = location.get( 'selectionRange' ) or location[ 'range' ]
   return _BuildLocationAndDescription( filename,
                                        file_contents,
-                                       location[ 'range' ][ 'start' ] )
+                                       range[ 'start' ] )
 
 
 def _LspToYcmdLocation( file_contents, location ):


### PR DESCRIPTION
Currently, the LSP specification uses selectionRange in only three places:

1. In `selectionRange` requests
2. In hierarchy items
3. In DocumentSymbol

Since ycmd does not support the first and the third point, we can ignore them..

As for hierarchy items, `range` property is meant to span the entire symbol definition, while `selectionRange` property is meant to span just the identifier of a symbol. Note that `range` also can include a docstring preceeding a function definition. That means that `symbol[ 'range' ][ 'start' ]` might be pointing at the start of a docstring, instead of pointing at the function name.

Current behaviour of the tested servers:

- `clangd` and `gopls` put what should be in `selectionRange` into both properties.
- `jdt.ls` and `rust-analyzer` properly differentiate these two ranges.

Not handling `selectionRange` properly leads to at least two problems:

1. In hierarchy requests, the description of the root node can be wrong.
2. Requesting outgoing calls of an incoming call picks the wrong location altogether.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1744)
<!-- Reviewable:end -->
