### PR TITLE
[READY]General CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ ubuntu-20.04, macos-12 ]
+        runs-on: [ ubuntu-24.04, macos-14 ]
         compiler: [ 'gcc' ] # Only used on linux
         libclang: [ true ] # Only used on linux
         benchmark: [ true, false ]
         include:
-          - runs-on: ubuntu-20.04
+          - runs-on: ubuntu-24.04
             compiler: 'clang'
             benchmark: false
             libclang: true
             name_suffix: 'with Clang compiler - '
-          - runs-on: ubuntu-20.04
+          - runs-on: ubuntu-24.04
             compiler: 'gcc'
             benchmark: false
             libclang: false
@@ -33,12 +33,12 @@ jobs:
     name: "${{ matrix.runs-on }} - ${{ matrix.name_suffix }}${{ matrix.benchmark && 'C++ Benchmark' || 'test run' }}"
     runs-on: ${{ matrix.runs-on }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 0
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       if: matrix.libclang == true && matrix.benchmark == false
       with:
         key: v3-libclang-${{ runner.os }}-${{ hashFiles( 'cpp/ycm/CMakeLists.txt' ) }}
@@ -51,7 +51,7 @@ jobs:
           clang_archives
       name: Cache libclang
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       if: matrix.benchmark == false
       with:
         key: v2-deps-${{ runner.os }}-${{ hashFiles( 'build.py' ) }}
@@ -65,7 +65,7 @@ jobs:
           third_party/omnisharp-roslyn/v[0-9]*
       name: Cache dependencies
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       if: matrix.benchmark == false
       with:
         key: v2-testdeps-${{ runner.os }}-${{ hashFiles( 'run_tests.py' ) }}
@@ -79,36 +79,41 @@ jobs:
 
     - name: Install Java
       if: matrix.benchmark == false
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: 17
         distribution: 'adopt'
 
     - name: Install Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.9'
 
     - name: Install Go
       if: matrix.benchmark == false
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: stable
         cache: false
+    - name: Install mono
+      if: runner.os == 'Linux' && matrix.benchmark == false
+      run: |
+        sudo apt-get update
+        sudo apt-get install mono-complete
     - name: Install GCC
       if: runner.os == 'Linux' && matrix.compiler != 'clang'
       run: |
         sudo apt-get update
-        sudo apt-get install gcc-8 g++-8
-        sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-8 100
-        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-8 100
+        sudo apt-get install gcc-10 g++-10
+        sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-10 100
+        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 100
     - name: Install Clang
       if: runner.os == 'Linux' && matrix.compiler == 'clang'
       run: |
         sudo apt-get update
-        sudo apt-get install clang-7
-        sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-7 100
-        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-7 100
+        sudo apt-get install clang-14
+        sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-14 100
+        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-14 100
     - name: Run pip and prepare coverage
       if: matrix.benchmark == false
       run: |
@@ -124,7 +129,7 @@ jobs:
       if: matrix.benchmark == false
       run: coverage combine && coverage xml
     - name: Upload coverage data
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       if: matrix.benchmark == false
       with:
         name: "${{ matrix.runs-on }}-${{ matrix.name_suffix }}-tests"
@@ -133,36 +138,33 @@ jobs:
 
   linux_lint:
     name: "C++ Lint"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 0
     - name: Install Python
-      uses: deadsnakes/action@v2.1.1
+      uses: deadsnakes/action@v3.1.0
       with:
-        python-version: '3.8'
+        python-version: '3.13'
         debug: true
     - name: Install GCC
       run: |
         sudo apt-get update
-        sudo apt-get install gcc-8 g++-8
-        sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-8 100
-        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-8 100
+        sudo apt-get install gcc-10 g++-10
+        sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-10 100
+        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 100
     - name: Install clang-tidy
       run: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo apt-get update
         sudo apt-get install -y clang-tidy libc6-dbg build-essential
-        sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-10 100
+        sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-18 100
     - name: Install valgrind
       run: |
-        wget https://sourceware.org/pub/valgrind/valgrind-3.16.1.tar.bz2
-        tar xf valgrind-3.16.1.tar.bz2
-        pushd valgrind-3.16.1
-        ./configure && make -j3 && sudo make install
-        popd
+        sudo apt-get update
+        sudo apt-get install valgrind
     - name: Run pip
       run: python3 -m pip install -r test_requirements.txt
     - name: Lint
@@ -193,12 +195,12 @@ jobs:
       COVERAGE: ${{ !matrix.benchmark }}
     name: "Windows MSVC ${{ matrix.msvc }} ${{ matrix.python-arch }} - ${{ matrix.benchmark && 'C++ Benchmark' || 'test run' }}"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 0
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       if: matrix.libclang == true && matrix.benchmark == false
       with:
         key: v3-libclang-${{ runner.os }}-${{ hashFiles( 'cpp/ycm/CMakeLists.txt' ) }}
@@ -211,7 +213,7 @@ jobs:
           clang_archives
       name: Cache libclang
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       if: matrix.benchmark == false
       with:
         key: v2-deps-${{ runner.os }}-${{ hashFiles( 'build.py' ) }}
@@ -225,7 +227,7 @@ jobs:
           third_party/omnisharp-roslyn/v[0-9]*
       name: Cache dependencies
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       if: matrix.benchmark == false
       with:
         key: v2-testdeps-${{ runner.os }}-${{ hashFiles( 'run_tests.py' ) }}
@@ -239,18 +241,18 @@ jobs:
 
     - name: Install Java
       if: matrix.benchmark == false
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: 17
         distribution: 'temurin'
     - name: Install Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.9'
         architecture: ${{ matrix.python-arch }}
     - name: Install Go
       if: matrix.benchmark == false
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: stable
         cache: false
@@ -270,7 +272,7 @@ jobs:
       if: matrix.benchmark == false
       run: coverage combine && coverage xml
     - name: Upload coverage data
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       if: matrix.benchmark == false
       with:
         name: "${{ matrix.runs-on }}-${{ matrix.name_suffix }}-tests"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,12 +3,12 @@ queue_rules:
   - name: default
     # These define the conditions to get out of the merge queue
     conditions:
-      - status-success=macos-12 - C++ Benchmark
-      - status-success=macos-12 - test run
-      - status-success=ubuntu-20.04 - C++ Benchmark
-      - status-success=ubuntu-20.04 - without libclang completer - test run
-      - status-success=ubuntu-20.04 - with Clang compiler - test run
-      - status-success=ubuntu-20.04 - test run
+      - status-success=macos-14 - C++ Benchmark
+      - status-success=macos-14 - test run
+      - status-success=ubuntu-24.04 - C++ Benchmark
+      - status-success=ubuntu-24.04 - without libclang completer - test run
+      - status-success=ubuntu-24.04 - with Clang compiler - test run
+      - status-success=ubuntu-24.04 - test run
       - status-success=C++ Lint
       - status-success=Windows MSVC 16 x64 - test run
       - status-success=Windows MSVC 17 x64 - test run
@@ -20,12 +20,12 @@ pull_request_rules:
     conditions:
       - base=master
       - "#approved-reviews-by>=2"
-      - status-success=macos-12 - C++ Benchmark
-      - status-success=macos-12 - test run
-      - status-success=ubuntu-20.04 - C++ Benchmark
-      - status-success=ubuntu-20.04 - without libclang completer - test run
-      - status-success=ubuntu-20.04 - with Clang compiler - test run
-      - status-success=ubuntu-20.04 - test run
+      - status-success=macos-14 - C++ Benchmark
+      - status-success=macos-14 - test run
+      - status-success=ubuntu-24.04 - C++ Benchmark
+      - status-success=ubuntu-24.04 - without libclang completer - test run
+      - status-success=ubuntu-24.04 - with Clang compiler - test run
+      - status-success=ubuntu-24.04 - test run
       - status-success=C++ Lint
       - status-success=Windows MSVC 16 x64 - test run
       - status-success=Windows MSVC 17 x64 - test run
@@ -42,12 +42,12 @@ pull_request_rules:
   - name: Manual merge on Azure Pipelines and Maintainer Override
     conditions:
       - base=master
-      - status-success=macos-12 - C++ Benchmark
-      - status-success=macos-12 - test run
-      - status-success=ubuntu-20.04 - C++ Benchmark
-      - status-success=ubuntu-20.04 - without libclang completer - test run
-      - status-success=ubuntu-20.04 - with Clang compiler - test run
-      - status-success=ubuntu-20.04 - test run
+      - status-success=macos-14 - C++ Benchmark
+      - status-success=macos-14 - test run
+      - status-success=ubuntu-24.04 - C++ Benchmark
+      - status-success=ubuntu-24.04 - without libclang completer - test run
+      - status-success=ubuntu-24.04 - with Clang compiler - test run
+      - status-success=ubuntu-24.04 - test run
       - status-success=C++ Lint
       - status-success=Windows MSVC 16 x64 - test run
       - status-success=Windows MSVC 17 x64 - test run
@@ -69,12 +69,12 @@ pull_request_rules:
     conditions:
       - base=master
       - author=puremourning
-      - status-success=macos-12 - C++ Benchmark
-      - status-success=macos-12 - test run
-      - status-success=ubuntu-20.04 - C++ Benchmark
-      - status-success=ubuntu-20.04 - without libclang completer - test run
-      - status-success=ubuntu-20.04 - with Clang compiler - test run
-      - status-success=ubuntu-20.04 - test run
+      - status-success=macos-14 - C++ Benchmark
+      - status-success=macos-14 - test run
+      - status-success=ubuntu-24.04 - C++ Benchmark
+      - status-success=ubuntu-24.04 - without libclang completer - test run
+      - status-success=ubuntu-24.04 - with Clang compiler - test run
+      - status-success=ubuntu-24.04 - test run
       - status-success=C++ Lint
       - status-success=Windows MSVC 16 x64 - test run
       - status-success=Windows MSVC 17 x64 - test run

--- a/run_tests.py
+++ b/run_tests.py
@@ -229,7 +229,6 @@ def UnittestValgrind( parsed_args, extra_unittest_args ):
     # unittest_args += [ '-m', 'not valgrind_skip' ]
 
   new_env = os.environ.copy()
-  new_env[ 'PYTHONMALLOC' ] = 'malloc'
   new_env[ 'LD_LIBRARY_PATH' ] = LIBCLANG_DIR
   new_env[ 'YCM_VALGRIND_RUN' ] = '1'
   cmd = [ 'valgrind',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,3 +6,4 @@ WebTest               >= 2.0.20
 psutil                >= 5.6.6
 coverage              >= 4.2
 requests
+legacy-cgi            ; python_version >= "3.13"

--- a/valgrind.suppressions
+++ b/valgrind.suppressions
@@ -1,16 +1,12 @@
 {
-   Valgrind bug (https://stackoverflow.com/questions/1542457/memory-leak-reported-by-valgrind-in-dlopen)
+   Valgrind has a false positive around dlopen
    Memcheck:Leak
-   fun:malloc
    ...
-   fun:dl_open_worker
-   fun:_dl_catch_exception
    fun:_dl_open
    fun:dlopen_doit
    fun:_dl_catch_exception
    fun:_dl_catch_error
    fun:_dlerror_run
-   fun:dlopen@@GLIBC_2.2.5
-   fun:_PyImport_FindSharedFuncptr
-   fun:_PyImport_LoadDynamicModuleWithSpec
+   fun:dlopen_implementation
+   fun:dlopen@@GLIBC_2.34
 }

--- a/ycmd/tests/bindings/cpp_bindings_raises_exception_test.py
+++ b/ycmd/tests/bindings/cpp_bindings_raises_exception_test.py
@@ -21,7 +21,8 @@ from hamcrest import assert_that, calling, raises
 from unittest import TestCase
 ycm_core = ImportCore()
 
-READONLY_MESSAGE = 'can\'t set attribute'
+READONLY_MESSAGE = ( 'can\'t set attribute'
+                     '|property (\'\' )?of \'\\w+\' object has no setter' )
 
 
 class CppBindingsExceptionTest( TestCase ):


### PR DESCRIPTION
I'm not sure if we want to merge this immediately, or wait for october, so that we can actually drop python 3.8.

Quick summary:

- Switch to ubuntu 24.04
- Switch to macos 14
- Switch to python 3.9
- Install mono-complete
- Redo valgrind
- Update actions
- Use python 3.13 in valgrind run
- Workaround for cgi module being removed
- Fix bindings test in newer python

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1746)
<!-- Reviewable:end -->
