### PR TITLE
[READY] Update Abseil to latest LTS

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -245,7 +245,7 @@ else()
   FetchContent_Declare(
     absl
     GIT_REPOSITORY https://github.com/abseil/abseil-cpp
-    GIT_TAG fb3621f4f897824c0dbe0615fa94543df6192f30
+    GIT_TAG d7aaad83b488fd62bd51c81ecf16cd938532cc0a
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/absl
   )
   FetchContent_MakeAvailable( absl )


### PR DESCRIPTION
Update of abseil allows ycmd to be compiled on FreeBSD.
Reported and tested by @nerozero

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1747)
<!-- Reviewable:end -->
