### PR TITLE
[READY] Add support codeAction/resolve requests

### DIFF
--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -24,7 +24,6 @@ import tempfile
 import threading
 
 from ycmd import responses, utils
-from ycmd.completers.language_server import language_server_protocol as lsp
 from ycmd.completers.language_server import language_server_completer
 from ycmd.utils import LOGGER
 
@@ -624,24 +623,13 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
 
 
   def OrganizeImports( self, request_data ):
-    fixit = {
-      'resolve': True,
-      'command': {
-        'title': 'Organize Imports',
-        'command': 'java.edit.organizeImports',
-        'arguments': [ lsp.FilePathToUri( request_data[ 'filepath' ] ) ]
-      }
-    }
-    return self._ResolveFixit( request_data, fixit )
-
-
-  def CodeActionCommandToFixIt( self, request_data, command ):
-    # JDT wants us to special case `java.apply.workspaceEdit`
-    # https://github.com/eclipse/eclipse.jdt.ls/issues/376
-    if command[ 'command' ][ 'command' ] == 'java.apply.workspaceEdit':
-      command[ 'edit' ] = command.pop( 'command' )[ 'arguments' ][ 0 ]
-      return super().CodeActionLiteralToFixIt( request_data, command )
-    return super().CodeActionCommandToFixIt( request_data, command )
+    fixits = super().GetCodeActions( request_data )[ 'fixits' ]
+    for fixit in fixits:
+      if fixit[ 'command' ][ 'kind' ] == 'source.organizeImports':
+        return self._ResolveFixit( request_data, fixit )
+    # We should never get here. With codeAction/resolve support,
+    # JDT always sends the organizeImports code action.
+    raise RuntimeError( 'OrganizeImports not available.' )
 
 
   def GetServerName( self ):

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -2850,7 +2850,6 @@ class LanguageServerCompleter( Completer ):
                       cursor_range_ls,
                       matched_diagnostics ),
       REQUEST_TIMEOUT_COMMAND )
-
     return self.CodeActionResponseToFixIts( request_data,
                                             code_actions[ 'result' ] )
 
@@ -2861,28 +2860,22 @@ class LanguageServerCompleter( Completer ):
 
     fixits = []
     for code_action in code_actions:
-      if 'edit' in code_action:
-        # TODO: Start supporting a mix of WorkspaceEdits and Commands
-        # once there's a need for such
-        assert 'command' not in code_action
-
-        # This is a WorkspaceEdit literal
-        fixits.append( self.CodeActionLiteralToFixIt( request_data,
-                                                      code_action ) )
+      capabilities = self._server_capabilities[ 'codeActionProvider' ]
+      if ( ( isinstance( capabilities, dict ) and
+             capabilities.get( 'resolveProvider' ) ) or
+           'command' in code_action ):
+        # If server is a code action resolve provider, either we are obligated
+        # to resolve, or we have a command in the code action response.
+        # If server does not want us to resolve, but sends a command anyway,
+        # we still need to lazily execute that command.
+        fixits.append( responses.UnresolvedFixIt( code_action,
+                                                  code_action[ 'title' ],
+                                                  code_action.get( 'kind' ) ) )
         continue
+      # No resoving here - just a simple code action literal.
+      fixits.append( self.CodeActionLiteralToFixIt( request_data,
+                                                    code_action ) )
 
-      # Either a CodeAction or a Command
-      assert 'command' in code_action
-
-      action_command = code_action[ 'command' ]
-      if isinstance( action_command, dict ):
-        # CodeAction with a 'command' rather than 'edit'
-        fixits.append( self.CodeActionCommandToFixIt( request_data,
-                                                      code_action ) )
-        continue
-
-      # It is a Command
-      fixits.append( self.CommandToFixIt( request_data, code_action ) )
 
     # Show a list of actions to the user to select which one to apply.
     # This is (probably) a more common workflow for "code action".
@@ -2986,10 +2979,44 @@ class LanguageServerCompleter( Completer ):
 
 
   def _ResolveFixit( self, request_data, fixit ):
-    if not fixit[ 'resolve' ]:
-      return { 'fixits': [ fixit ] }
+    code_action = fixit[ 'command' ]
+    capabilities = self._server_capabilities[ 'codeActionProvider' ]
+    if ( isinstance( capabilities, dict ) and
+         capabilities.get( 'resolveProvider' ) ):
+      # Resolve through codeAction/resolve request, before resolving commands.
+      # If the server is an asshole, it might be a code action resolve
+      # provider, but send a LSP Command instead. We can not resolve those with
+      # codeAction/resolve!
+      if ( 'command' not in code_action or
+           isinstance( code_action[ 'command' ], str ) ):
+        request_id = self.GetConnection().NextRequestId()
+        msg = lsp.CodeActionResolve( request_id, code_action )
+        code_action = self.GetConnection().GetResponse(
+            request_id,
+            msg,
+            REQUEST_TIMEOUT_COMMAND )[ 'result' ]
 
-    unresolved_fixit = fixit[ 'command' ]
+    result = []
+    if 'edit' in code_action:
+      result.append( self.CodeActionLiteralToFixIt( request_data,
+                                                    code_action ) )
+
+    if 'command' in code_action:
+      assert not result, 'Code actions with edit and command is not supported.'
+      if isinstance( code_action[ 'command' ], str ):
+        unresolved_command_fixit = self.CommandToFixIt( request_data,
+                                                        code_action )
+      else:
+        unresolved_command_fixit = self.CodeActionCommandToFixIt( request_data,
+                                                                  code_action )
+      result.append( self._ResolveFixitCommand( request_data,
+                                                unresolved_command_fixit ) )
+
+    return responses.BuildFixItResponse( result )
+
+
+  def _ResolveFixitCommand( self, request_data, fixit ):
+    unresolved_fixit = fixit.command
     collector = EditCollector()
     with self.GetConnection().CollectApplyEdits( collector ):
       self.GetCommandResponse(
@@ -3001,19 +3028,23 @@ class LanguageServerCompleter( Completer ):
     response = collector.requests
     assert len( response ) < 2
     if not response:
-      return responses.BuildFixItResponse( [ responses.FixIt(
+      return responses.FixIt(
         responses.Location( request_data[ 'line_num' ],
                             request_data[ 'column_num' ],
                             request_data[ 'filepath' ] ),
-        [] ) ] )
+        [] )
     fixit = WorkspaceEditToFixIt(
       request_data,
       response[ 0 ][ 'edit' ],
       unresolved_fixit[ 'title' ] )
-    return responses.BuildFixItResponse( [ fixit ] )
+    return fixit
 
 
   def ResolveFixit( self, request_data ):
+    fixit = request_data[ 'fixit' ]
+    if 'command' not in fixit:
+      # Somebody has sent us an already resolved fixit.
+      return { 'fixits': [ fixit ] }
     return self._ResolveFixit( request_data, request_data[ 'fixit' ] )
 
 

--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -326,8 +326,13 @@ def Initialize( request_id,
                           'refactor.inline',
                           'refactor.rewrite',
                           'source',
-                          'source.organizeImports' ]
+                          'source.organizeImports',
+                          'source.fixAll' ]
           }
+        },
+        'dataSupport': True,
+        'resolveSupport': {
+          'properties': [ 'edit', 'command' ]
         }
       },
       'completion': {
@@ -578,6 +583,10 @@ def CodeAction( request_id, request_data, best_match_range, diagnostics ):
       'diagnostics': diagnostics,
     },
   } )
+
+
+def CodeActionResolve( request_id, code_action ):
+  return BuildRequest( request_id, 'codeAction/resolve', code_action )
 
 
 def Rename( request_id, request_data, new_name ):

--- a/ycmd/tests/clangd/subcommands_test.py
+++ b/ycmd/tests/clangd/subcommands_test.py
@@ -316,7 +316,8 @@ def FixIt_Check_cpp11_DelAdd( results ):
       has_entries( {
         'text': 'Move function body to declaration',
         'resolve': True,
-        'command': has_entries( { 'command': 'clangd.applyTweak' } )
+        'command': has_entries( { 'command': has_entries( {
+          'command': 'clangd.applyTweak' } ) } )
       } ),
     )
   } ) )


### PR DESCRIPTION
So...
We advertise that we can handle CodeActions that are either missing an edit or a command (or both).
The server chooses whether it supports either of the two. If it does, it advertises itself as a "code action resolve provider".

For servers that are code action resolve providers:
- If either edit or command is missing, we need to try resolving the code action via codeAction/resolve.
  - Unless we actually got a LSP Command, in which case codeAction/resove is skipped.
- After resolving it that way we have a CodeAction in one of these forms:
  - A LSP Command
  - A LSP CodeAction with only an edit.
  - A LSP CodeAction with only a command.
  - A LSP CodeAction with both an edit and a command.
- Edits are WorkspaceEdits and can easily be converted into ycmd FixIts.
- Commands are to be executed, yielding ApplyEdits. A single ApplyEdit can be converted into a ycmd FixIt.

For servers that are not code action resolve providers, the steps are the same, but we skip the codeAction/resolve route.

One thing missing is properly defined handling of fixit resolutions that yield multiple fixits. That can happen in a few ways:

- On /resolve_fixit, by a LSP command yielding multiple ApplyEdits.
- When eagerly resolving a fixit, again by a LSP command yielding multiple ApplyEdits.
- Even if all commands always yield a single ApplyEdit, if a CodeAction has both an edit and a command, that's again two fixits.

The first two above don't seem to be used by any server ever. The LSP specs nudges servers away from doing that, but no promises. We are still not supporting any scenario where resolving a single fixit results in more than one fixit.

Another scenario that does not seem to happen:
- The server is a code action resove provider.
- The received CodeAction has neither an edit nor a command.
- After resolving, we get only a command.
- We then need to execute the command and collect ApplyEdits.

In practice, such code actions resolve to a CodeAction containing an edit.

As for the ycmd<->client side of things... it's a bit ugly on the ycmd side, but we're completely preserving the API, so clients do not need to change a thing.

Previously, clients got `{ 'fixits': [ { 'command': LSPCommand ... } ] }` for unresolved fixits.  However, we have not given any guarantees about the value of `'command'`.  We have only said that it should be returned to ycmd for the purposes of `/resolve_fixit`.  With this pull request, we need to pass the entire CodeAction, but we're still putting it in the `command` key.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1754)
<!-- Reviewable:end -->
