### PR TITLE
Pin go version to avoid gopls issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,8 @@ jobs:
       if: matrix.benchmark == false
       uses: actions/setup-go@v5
       with:
-        go-version: stable
+        # HACK : Our gopls is not compatible with Go 1.23+
+        go-version: '<1.23'
         cache: false
     - name: Install mono
       if: runner.os == 'Linux' && matrix.benchmark == false
@@ -254,7 +255,8 @@ jobs:
       if: matrix.benchmark == false
       uses: actions/setup-go@v5
       with:
-        go-version: stable
+        # HACK : Our gopls is not compatible with Go 1.23+
+        go-version: '<1.23'
         cache: false
     - name: Run pip and prepare coverage
       if: matrix.benchmark == false


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1756)
<!-- Reviewable:end -->



* latest stable go 1.23 is incompatible with our gopls version
* we can't just upgrade gopls because the new gopls includes code action command that use showDocument requests which are not supported by YCM, and gopls ignores the client capability

So to make CI green we pin the go version. Unfortunately this is temporary as users will eventually start using new go and having gopls problems.