### PR TITLE
[READY] LSP: Allow globs in GetProjectRootFiles

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -16,6 +16,7 @@
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
 from functools import partial
+from pathlib import Path
 import abc
 import collections
 import contextlib
@@ -2306,8 +2307,8 @@ class LanguageServerCompleter( Completer ):
 
 
   def GetProjectRootFiles( self ):
-    """Returns a list of files that indicate the root of the project.
-    It should be easier to override just this method than the whole
+    """Returns a list of globs matching files that indicate the root of the
+    project.  It should be easier to override just this method than the whole
     GetProjectDirectory."""
     return []
 
@@ -2362,7 +2363,7 @@ class LanguageServerCompleter( Completer ):
     if project_root_files:
       for folder in utils.PathsToAllParentFolders( filepath ):
         for root_file in project_root_files:
-          if os.path.isfile( os.path.join( folder, root_file ) ):
+          if next( Path( folder ).glob( root_file ), [] ):
             return folder
     return None if strict else os.path.dirname( filepath )
 

--- a/ycmd/tests/language_server/generic_completer_test.py
+++ b/ycmd/tests/language_server/generic_completer_test.py
@@ -483,6 +483,62 @@ class GenericCompleterTest( TestCase ):
   @IsolatedYcmd( { 'language_server':
     [ { 'name': 'foo',
         'filetypes': [ 'foo' ],
+        'project_root_files': [ '*root' ],
+        'cmdline': [ 'node', PATH_TO_GENERIC_COMPLETER, '--stdio' ] } ] } )
+  def test_GenericLSPCompleter_DebugInfo_CustomRootGlob( self, app, *args ):
+    test_file = PathToTestFile(
+        'generic_server', 'foo', 'bar', 'baz', 'test_file' )
+    request = BuildRequest( filepath = test_file,
+                            filetype = 'foo',
+                            line_num = 1,
+                            column_num = 1,
+                            contents = '',
+                            event_name = 'FileReadyToParse' )
+
+    app.post_json( '/event_notification', request )
+    WaitUntilCompleterServerReady( app, 'foo' )
+    request.pop( 'event_name' )
+    response = app.post_json( '/debug_info', request ).json
+    assert_that(
+      response,
+      has_entry( 'completer', has_entries( {
+        'name': 'GenericLSP',
+        'servers': contains_exactly( has_entries( {
+          'name': 'fooCompleter',
+          'is_running': instance_of( bool ),
+          'executable': contains_exactly( instance_of( str ),
+                                  instance_of( str ),
+                                  instance_of( str ) ),
+          'address': None,
+          'port': None,
+          'pid': instance_of( int ),
+          'logfiles': contains_exactly( instance_of( str ) ),
+          'extras': contains_exactly(
+            has_entries( {
+              'key': 'Server State',
+              'value': instance_of( str ),
+            } ),
+            has_entries( {
+              'key': 'Project Directory',
+              'value': PathToTestFile( 'generic_server', 'foo' ),
+            } ),
+            has_entries( {
+              'key': 'Open Workspaces',
+              'value': has_items(),
+            } ),
+            has_entries( {
+              'key': 'Settings',
+              'value': '{}'
+            } ),
+          )
+        } ) ),
+      } ) )
+    )
+
+
+  @IsolatedYcmd( { 'language_server':
+    [ { 'name': 'foo',
+        'filetypes': [ 'foo' ],
         'project_root_files': [ 'proj_root' ],
         'cmdline': [ 'node', PATH_TO_GENERIC_COMPLETER, '--stdio' ] } ] } )
   def test_GenericLSPCompleter_DebugInfo_CustomRoot( self, app, *args ):

--- a/ycmd/tests/rust/subcommands_test.py
+++ b/ycmd/tests/rust/subcommands_test.py
@@ -587,6 +587,7 @@ class SubcommandsTest( TestCase ):
     } )
 
 
+  @WithRetry()
   @IsolatedYcmd()
   def test_Subcommands_GoTo_WorksAfterChangingProject( self, app ):
     filepath = PathToTestFile( 'macro', 'src', 'main.rs' )


### PR DESCRIPTION
Some languages name the project description file after the root directory.
I.e. `foo/foo.csproj` and `foo/foo.sln` in case of C#.

This accommodates those language servers.

This is the last part needed for users to be able to use Omnisharp-Roslyn through `GenericLanguageServer`.
We should still get #1752 working, if for no other reason, then not to drag ancient omnisharp version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1759)
<!-- Reviewable:end -->
