### PR TITLE
[WIP/RFC] Allow code actions containing an edit and a command

### DIFF
--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -99,6 +99,14 @@ def ResolveFixit( request, response ):
   return _JsonResponse( completer.ResolveFixit( request_data ), response )
 
 
+@app.post( '/next_fixit' )
+def ResolveFixit( request, response ):
+  request_data = RequestWrap( request.json )
+  completer = _GetCompleterForRequestData( request_data )
+
+  return _JsonResponse( completer.NextFixIt( request_data ), response )
+
+
 @app.post( '/completions' )
 def GetCompletions( request, response ):
   request_data = RequestWrap( request.json )

--- a/ycmd/responses.py
+++ b/ycmd/responses.py
@@ -260,12 +260,13 @@ class FixIt:
     REFACTOR = 'refactor'
 
 
-  def __init__( self, location: Location, chunks, text = '', kind = None ):
+  def __init__( self, location: Location, chunks, text = '', kind = None, keep_going = False ):
     """location of type Location, chunks of type list<FixItChunk>"""
     self.location = location
     self.chunks = chunks
     self.text = text
     self.kind = kind
+    self.keep_going = keep_going
 
 
 class FixItChunk:
@@ -334,7 +335,8 @@ def BuildFixItResponse( fixits ):
         'chunks' : [ BuildFixitChunkData( x ) for x in fixit.chunks ],
         'text': fixit.text,
         'kind': fixit.kind,
-        'resolve': False
+        'resolve': False,
+        'keep_going': fixit.keep_going
       }
 
     if result[ 'kind' ] is None:


### PR DESCRIPTION
Fixes #1692 

WIP, because still no response to https://github.com/microsoft/language-server-protocol/issues/2015
But also tests.
Previously, we could not handle two cases:

- code action containing an edit and a command
- commands producing multiple edits.

This pull request currently aims at the former. Manually tested with the Dart server and everything worked fine.

### Design

#### LSP

Assuming we get a code action with an edit and a command, the client should do the following:

1. Apply the edit.
2. Send `didChange` notification.
3. Execute the command.

Step 3 is still pretty much dark magic.

#### ycmd

Current implementation, when faced with "mixed" code actions does:

1. Convert the edit to a ycmd FixIt, but setting a new property, `keep_going` to `True`.
2. Stores the command for later.
3. Responds to the client with that one FixIt.
4. Once a client decides to apply a FixIt with `keep_going` set, after applying, it should ask ycmd for the next FixIt in the chain.
4.1. I couldn't figure out a better way than to introduce a new route - `/next_fixit`
5. Upon receiving a `/next_fixit` request, ycmd will execute the previously stored command (step 2).

Obviously, `/next_fixit` and `keep_going` are prone to bikeshedding.
I'm more concerned whether the whole idea about storing  the command for later is a good approach.
It works... but only because `:YcmCompleter FixIt` is synchronous. If it weren't, there'd be room for error.