### PR TITLE
fix DocumentURI error for gopls@v0.16.1

### DIFF
--- a/ycmd/completers/language_server/language_server_protocol.py
+++ b/ycmd/completers/language_server/language_server_protocol.py
@@ -753,7 +753,7 @@ def InlayHints( request_id, request_data ):
 
 
 def FilePathToUri( file_name ):
-  return urljoin( 'file:', pathname2url( file_name ) )
+  return urljoin( 'file://', pathname2url( file_name ) )
 
 
 def UriToFilePath( uri ):


### PR DESCRIPTION
When use YCM for golang with gopls@v0.16.1, I meet such response
```json
{"jsonrpc":"2.0","error":{"code":-32700,"message":"JSON RPC parse error: DocumentURI scheme is not \'file\': file:/data/home/winchua/test/g"},"id":1}
```
which disable YCM.

After some debugging, it's cause by [the code from gopls ](https://github.com/golang/tools/blob/master/gopls/internal/protocol/uri.go#L149)  which requires uri of local files should starts with 'file://'

So, I make a pr here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1762)
<!-- Reviewable:end -->
