### PR TITLE
Make building regex module optional

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -7,3 +7,5 @@ psutil                >= 5.6.6
 coverage              >= 4.2
 requests
 legacy-cgi            ; python_version >= "3.13"
+# Needed for building the regex and watchdog modules.
+setuptools


### PR DESCRIPTION
Two things:

1. Make regex optional with `--no-regex`/`--regex`
2. Move `BuildRegexModule()` to the end.

Both done as a way to allow ycmd to work even if regex does not compile on some system.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1764)
<!-- Reviewable:end -->
