### PR TITLE
[READY] Correct where WithRetry decorator is applied

### DIFF
--- a/ycmd/tests/clangd/subcommands_test.py
+++ b/ycmd/tests/clangd/subcommands_test.py
@@ -543,6 +543,7 @@ def FixIt_Check_AutoExpand_Resolved( results ):
   } ) )
 
 
+@WithRetry()
 def RunRangedFixItTest( app, rng, expected, chosen_fixit = 0 ):
   contents = ReadFile( PathToTestFile( 'FixIt_Clang_cpp11.cpp' ) )
   args = {
@@ -616,7 +617,6 @@ class SubcommandsTest( TestCase ):
     } )
 
 
-  @WithRetry()
   @SharedYcmd
   def test_Subcommands_ServerNotInitialized( self, app ):
     for cmd in [
@@ -646,6 +646,7 @@ class SubcommandsTest( TestCase ):
       with self.subTest( cmd = cmd ):
         completer = handlers._server_state.GetFiletypeCompleter( [ 'cpp' ] )
 
+        @WithRetry()
         @patch.object( completer, '_ServerIsInitialized', return_value = False )
         def Test( app, cmd, *args ):
           request = {
@@ -1177,7 +1178,6 @@ class SubcommandsTest( TestCase ):
         RunFixItTest( app, line, column, language, filepath, check )
 
 
-  @WithRetry()
   @SharedYcmd
   def test_Subcommands_FixIt_Ranged( self, app ):
     for test in [
@@ -1237,7 +1237,6 @@ class SubcommandsTest( TestCase ):
     assert_that( actual, equal_to( expected ) )
 
 
-  @WithRetry()
   @IsolatedYcmd( { 'clangd_args': [ '-hidden-features' ] } )
   def test_Subcommands_FixIt_ClangdTweaks( self, app ):
     selection = {

--- a/ycmd/tests/rust/subcommands_test.py
+++ b/ycmd/tests/rust/subcommands_test.py
@@ -138,6 +138,7 @@ def RunHierarchyTest( app, kind, direction, location, expected, code ):
   RunTest( app, test )
 
 
+@WithRetry()
 def RunGoToTest( app, command, test, *, project_root = 'common' ):
   folder = PathToTestFile( project_root, 'src' )
   filepath = os.path.join( folder, test[ 'req' ][ 0 ] )
@@ -423,7 +424,6 @@ class SubcommandsTest( TestCase ):
         RunGoToTest( app, 'GoToType', test )
 
 
-  @WithRetry()
   @SharedYcmd
   def test_Subcommands_GoTo( self, app ):
     for test, command in itertools.product(
@@ -442,7 +442,6 @@ class SubcommandsTest( TestCase ):
         RunGoToTest( app, command, test )
 
 
-  @WithRetry()
   @SharedYcmd
   def test_Subcommands_GoToImplementation( self, app ):
     for test in [
@@ -456,7 +455,6 @@ class SubcommandsTest( TestCase ):
         RunGoToTest( app, 'GoToImplementation', test )
 
 
-  @WithRetry()
   @SharedYcmd
   def test_Subcommands_GoToImplementation_Failure( self, app ):
     RunGoToTest( app,
@@ -587,7 +585,6 @@ class SubcommandsTest( TestCase ):
     } )
 
 
-  @WithRetry()
   @IsolatedYcmd()
   def test_Subcommands_GoTo_WorksAfterChangingProject( self, app ):
     filepath = PathToTestFile( 'macro', 'src', 'main.rs' )


### PR DESCRIPTION
A TestCase.subTest() context manager will swallow exceptions, so applying @WithRetry on the entire test does not work. Instead, it needs to be applied on whatever the subTest is doing.

I have not run the tests manually. I'm hoping CI will be merciful.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1773)
<!-- Reviewable:end -->
