### PR TITLE
Fix GoToDefinition issues in non-compliant repositories lacking go.sum in GOMODCACHE

### DIFF
--- a/ycmd/default_settings.json
+++ b/ycmd/default_settings.json
@@ -38,6 +38,7 @@
   "disable_signature_help": 0,
   "gopls_binary_path": "",
   "gopls_args": [],
+  "gopls_excluded_workspace_paths": [],
   "rust_toolchain_root": "",
   "tsserver_binary_path": "",
   "roslyn_binary_path": "",


### PR DESCRIPTION
This commit addresses the problem where the GoToDefinition feature fails to execute in certain repositories located within the GOMODCACHE path. These specific repositories were not compliant due to the absence of a go.sum file, which is essential for ensuring module integrity and correct dependency resolution.

Add `let g:ycm_gopls_excluded_workspace_paths = null` or `let g:ycm_gopls_excluded_workspace_paths = ['PATH_TO_GOMODCACHE', 'NO_GOSUM_REPO_PATH']` to enable this change.