### PR TITLE
Fix for a race condition when starting language server

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1924,19 +1924,19 @@ class LanguageServerCompleter( Completer ):
     automatically in OnFileReadyToParse, but this may be used in completer
     subcommands that require restarting the underlying server."""
     try:
-        # Only attempt to start the server once - _server_started must be
-        # checked and set in a mutex to prevent race conditions.
-        with self._server_info_mutex:
-            if self._server_started:
-                LOGGER.debug( 'Server %s already started from another thread',
-                            self.GetServerName() )
-                return
-            self._server_started = True
+      # Only attempt to start the server once - _server_started must be
+      # checked and set in a mutex to prevent race conditions.
+      with self._server_info_mutex:
+        if self._server_started:
+          LOGGER.debug( 'Server %s already started from another thread',
+                      self.GetServerName() )
+          return
+        self._server_started = True
 
-        self._extra_conf_dir = self._GetSettingsFromExtraConf( request_data )
+      self._extra_conf_dir = self._GetSettingsFromExtraConf( request_data )
 
-        if self.StartServer( request_data, *args, **kwargs ):
-          self._SendInitialize( request_data )
+      if self.StartServer( request_data, *args, **kwargs ):
+        self._SendInitialize( request_data )
 
     except Exception:
       LOGGER.exception( 'Error while starting %s', self.GetServerName() )

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -41,7 +41,7 @@ from ycmd.completers.language_server import language_server_protocol as lsp
 NO_HOVER_INFORMATION = 'No hover information.'
 
 # All timeout values are in seconds
-REQUEST_TIMEOUT_COMPLETION = 5
+REQUEST_TIMEOUT_COMPLETION = 10
 REQUEST_TIMEOUT_INITIALISE = 30
 REQUEST_TIMEOUT_COMMAND    = 30
 CONNECTION_TIMEOUT         = 5

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1928,16 +1928,12 @@ class LanguageServerCompleter( Completer ):
         # checked and set in a mutex to prevent race conditions.
         with self._server_info_mutex:
             if self._server_started:
-                LOGGER.info( 'Server %s already started from another thread',
+                LOGGER.debug( 'Server %s already started from another thread',
                             self.GetServerName() )
                 return
             self._server_started = True
 
         self._extra_conf_dir = self._GetSettingsFromExtraConf( request_data )
-
-        LOGGER.info('KS DEBUG: begin sleep in _StartAndInitializeServer')
-        time.sleep(2)
-        LOGGER.info('KS DEBUG: end sleep in _StartAndInitializeServer')
 
         if self.StartServer( request_data, *args, **kwargs ):
           self._SendInitialize( request_data )

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1926,6 +1926,9 @@ class LanguageServerCompleter( Completer ):
     self._server_started = False
     self._extra_conf_dir = self._GetSettingsFromExtraConf( request_data )
 
+    LOGGER.info('KS DEBUG: begin sleep in _StartAndInitializeServer')
+    time.sleep(2)
+    LOGGER.info('KS DEBUG: end sleep in _StartAndInitializeServer')
     # Only attempt to start the server once. Set this after above call as it may
     # throw an exception
     self._server_started = True

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -1027,7 +1027,6 @@ class LanguageServerCompleter( Completer ):
     self._server_keep_logfiles = user_options[ 'server_keep_logfiles' ]
     self._stdout_file = None
     self._stderr_file = None
-    self._server_started = False
 
     self._Reset()
 
@@ -1064,6 +1063,7 @@ class LanguageServerCompleter( Completer ):
     self._extra_conf_dir = None
     self._semantic_token_atlas = None
     self._server_workspace_dirs = set()
+    self._server_started = False
 
 
   def GetCompleterName( self ):
@@ -1923,24 +1923,33 @@ class LanguageServerCompleter( Completer ):
     StartServer. In general, completers don't need to call this as it is called
     automatically in OnFileReadyToParse, but this may be used in completer
     subcommands that require restarting the underlying server."""
-    self._server_started = False
-    self._extra_conf_dir = self._GetSettingsFromExtraConf( request_data )
+    try:
+        # Only attempt to start the server once - _server_started must be
+        # checked and set in a mutex to prevent race conditions.
+        with self._server_info_mutex:
+            if self._server_started:
+                LOGGER.info( 'Server %s already started from another thread',
+                            self.GetServerName() )
+                return
+            self._server_started = True
 
-    LOGGER.info('KS DEBUG: begin sleep in _StartAndInitializeServer')
-    time.sleep(2)
-    LOGGER.info('KS DEBUG: end sleep in _StartAndInitializeServer')
-    # Only attempt to start the server once. Set this after above call as it may
-    # throw an exception
-    self._server_started = True
+        self._extra_conf_dir = self._GetSettingsFromExtraConf( request_data )
 
-    if self.StartServer( request_data, *args, **kwargs ):
-      self._SendInitialize( request_data )
+        LOGGER.info('KS DEBUG: begin sleep in _StartAndInitializeServer')
+        time.sleep(2)
+        LOGGER.info('KS DEBUG: end sleep in _StartAndInitializeServer')
+
+        if self.StartServer( request_data, *args, **kwargs ):
+          self._SendInitialize( request_data )
+
+    except Exception:
+      LOGGER.exception( 'Error while starting %s', self.GetServerName() )
+      # reset _server_started
+      self.Shutdown()
 
 
   def OnFileReadyToParse( self, request_data ):
-    if not self.ServerIsHealthy() and not self._server_started:
-      # We have to get the settings before starting the server, as this call
-      # might throw UnknownExtraConf.
+    if not self.ServerIsHealthy():
       self._StartAndInitializeServer( request_data )
 
     if not self.ServerIsHealthy():
@@ -2047,10 +2056,9 @@ class LanguageServerCompleter( Completer ):
           # restarted while this loop is running.
           self._initialize_event.wait( timeout=timeout )
 
-          # If the timeout is hit waiting for the server to be ready, after we
-          # tried to start the server, we return False and kill the message
-          # poll.
-          return not self._server_started or self._initialize_event.is_set()
+          # If the timeout is hit waiting for the server to be ready and
+          # initialized, we return False and kill the message poll.
+          return self._initialize_event.is_set()
 
         if not self.GetConnection():
           # The server isn't running or something. Don't re-poll, as this will

--- a/ycmd/tests/language_server/language_server_completer_test.py
+++ b/ycmd/tests/language_server/language_server_completer_test.py
@@ -1482,11 +1482,11 @@ class LanguageServerCompleterTest( TestCase ):
 
   @IsolatedYcmd()
   @patch.object( completer, 'MESSAGE_POLL_TIMEOUT', 0.01 )
-  def test_LanguageServerCompleter_PollForMessages_ServerNotStarted(
+  def test_LanguageServerCompleter_PollForMessages_ServerStartTooLong(
       self, app ):
     server = MockCompleter()
     request_data = RequestWrap( BuildRequest() )
-    assert_that( server.PollForMessages( request_data ), equal_to( True ) )
+    assert_that( server.PollForMessages( request_data ), equal_to( False ) )
 
 
   @IsolatedYcmd()


### PR DESCRIPTION
In the following scenario:

1. Run vim with https://github.com/vim-ctrlspace/vim-ctrlspace plugin
2. open a workspace which contains a few buffers, for example C++ source/header files (can be in a single tab)

What happens from time to time is that LSP server (in my case clangd) started more than once. With more than one running clangd process, YouCompleteMe does not work at all, because it tries to use a server that is not initialized - initialize request was sent to another one. Workaround: quit vim, kill ycmd and clangd processes, start vim again.

The way I fixed it is that `_server_started` is only accessed within `_server_info_mutex` and only the first thread calls `StartServer()`. Note that it required to partially revert #1434. Given that `_server_started` is now accessed only within the mutex, it does not make any sense for `_AwaitServerMessages` to access it. For additional rationale about it, see 6b6084afc55439167da378c243b4019e22c746b4 commit message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/ycmd/1780)
<!-- Reviewable:end -->
