### PR TITLE
Bump gopls to v0.19.1

### DIFF
--- a/build.py
+++ b/build.py
@@ -964,7 +964,7 @@ def EnableGoCompleter( args ):
   new_env.pop( 'GOROOT', None )
   new_env[ 'GOBIN' ] = p.join( new_env[ 'GOPATH' ], 'bin' )
 
-  gopls = 'golang.org/x/tools/gopls@v0.16.2'
+  gopls = 'golang.org/x/tools/gopls@v0.19.1'
   CheckCall( [ go, 'install', gopls ],
              env = new_env,
              quiet = args.quiet,


### PR DESCRIPTION
Go 1.24 introduces the `tool` directive which this version of `gopls` is not currently equipped to handle, throwing errors.